### PR TITLE
Adding example.yml files to guide user env config

### DIFF
--- a/main/cicd/cicd-pipeline/config/settings/example.yml
+++ b/main/cicd/cicd-pipeline/config/settings/example.yml
@@ -5,17 +5,17 @@ sourceAccountId: 123456789012
 awsProfile: galimain
 
 # The source code repository name
-codeCommitRepoName: raas
+codeCommitRepoName: aws-galileo-gateway
 
 # Arn of the AWS Code Commit source code repository
 codeCommitRepoArn: arn:aws:codecommit:us-east-1:123456789012:raas
 
 # ARN of the code commit source role. Please provide the value of the CloudFormation output variable
 # "CodeCommitSourceRoleArn" from the "cicd-source" stack.
-codeCommitSourceRoleArn: arn:aws:iam::123456789012:role/demo-va-raas-cicd-src-CodeCommitSourceRole-FONXYL4UWDGZ
+codeCommitSourceRoleArn: arn:aws:iam::123456789012:role/example-va-raas-cicd-src-CodeCommitSourceRole-XXXXXXXXXXXX
 
 # Email address to receive CodePipeline failure notifications and notifications for manual approval
-emailForNotifications: johndoe@company.com
+emailForNotifications: johndoe@example.com
 
 # Flag indicating whether to run integration tests against the target environment
 # Set this to false if you do not want to run automated tests against target env (such as production)

--- a/main/cicd/cicd-source/config/settings/example.yml
+++ b/main/cicd/cicd-source/config/settings/example.yml
@@ -8,7 +8,7 @@ targetAccountId: 123456789012
 
 # name of the AWS CodeCommit repository containing the source code of the solution
 # for which you want to deploy the CI/CD pipeline
-codeCommitRepoName: raas
+codeCommitRepoName: aws-galileo-gateway
 
 # The name of the git branch of the source code repository the code pipeline needs to build and deploy
 codeCommitRepoBranchName: master
@@ -60,7 +60,7 @@ codeCommitRepoBranchName: master
 #
 # The arn of the artifacts bucket
 #artifactsS3BucketArn: "*"
-artifactsS3BucketArn: 'arn:aws:s3:::demo-va-raas-cicd-pipeline-appartifactbucket-1p9uwo3lfecrl'
+artifactsS3BucketArn: 'arn:aws:s3:::example-va-raas-cicd-pipeline-appartifactbucket-XXXXXXXXXXXXX'
 
 #artifactsKmsKeyArn: "*"
-artifactsKmsKeyArn: 'arn:aws:kms:us-east-1:123456789012:key/cc2539c0-9563-4ac5-be71-624ad1567968'
+artifactsKmsKeyArn: 'arn:aws:kms:us-east-1:123456789012:key/cc2539c0-9563-4ac5-be71-XXXXXXXXXXXX'

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -20,4 +20,4 @@ envName: ${opt:stage}
 envType: demo
 
 # Root user's email address
-rootUserEmail: johndoe@company.com
+rootUserEmail: johndoe@example.com

--- a/main/config/settings/examplestg.yml
+++ b/main/config/settings/examplestg.yml
@@ -20,4 +20,4 @@ envName: ${opt:stage}
 envType: demo
 
 # Root user's email address
-rootUserEmail: johndoe@company.com
+rootUserEmail: johndoe@example.com

--- a/main/solution/post-deployment/config/settings/example.yml
+++ b/main/solution/post-deployment/config/settings/example.yml
@@ -46,5 +46,5 @@ fedIdpDisplayNames: '["Login using Active Directory"]'
 # If you do not want to connect to Active Directory then leave this setting as empty array as follows.
 #
 # fedIdpMetadatas: '[]'
-# TODO: Remove saml-metadata/datalake-demo-idp-metadata.xml file and replace this setting to use sample file
-fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-demo-idp-metadata.xml"]'
+# TODO: Remove saml-metadata/datalake-example-idp-metadata.xml file and replace this setting to use sample file
+fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-example-idp-metadata.xml"]'

--- a/main/solution/post-deployment/config/settings/examplestg.yml
+++ b/main/solution/post-deployment/config/settings/examplestg.yml
@@ -46,5 +46,5 @@ fedIdpDisplayNames: '["Login using Active Directory"]'
 # If you do not want to connect to Active Directory then leave this setting as empty array as follows.
 #
 # fedIdpMetadatas: '[]'
-# TODO: Remove saml-metadata/datalake-demo-idp-metadata.xml file and replace this setting to use sample file
-fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-demo-idp-metadata.xml"]'
+# TODO: Remove saml-metadata/datalake-example-idp-metadata.xml file and replace this setting to use sample file
+fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-example-idp-metadata.xml"]'

--- a/main/solution/prepare-master-acc/config/settings/example.yml
+++ b/main/solution/prepare-master-acc/config/settings/example.yml
@@ -12,4 +12,4 @@ mainAccountId: 123456789012
 # This id will be required by the solution to assume the role in master account.
 # The external id specified here MUST match the value you specify in the "Create AWS Account" screen
 # when creating a member account via the RaaS solution UI
-externalId: spyglass-master
+externalId: galileo-master


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
These example.yml files are to guide users to create and add their own namespace for their Galileo Gateway instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
