### PR TITLE
Add Github support to CI/CD.

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -1,9 +1,20 @@
+Parameters:
+
+  GitHubOAuthToken:
+    Description: OAuth token used by AWS CodePipeline to connect to GitHub
+    Type: String
+    Default: 'to-be-specified'
+    NoEcho: true
+
+
 Conditions:
+  UseCodeCommit: !Equals ['${self:custom.settings.githubOwner}', '']
   CreateStagingEnv: !Equals ['${self:custom.settings.createStagingEnv}', true]
   RunTestsAgainstTargetEnv: !Equals ['${self:custom.settings.runTestsAgainstTargetEnv}', true]
   AddManualApproval: !Equals ['${self:custom.settings.requireManualApproval}', true]
   SubscribeNotificationEmail: !Not
     - !Equals ['${self:custom.settings.emailForNotifications}', '']
+
 
 Resources:
   # SNS Topic to receive various notifications from the pipeline
@@ -69,8 +80,12 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - ${self:custom.settings.codeCommitSourceRoleArn} # Allows CodePipeline's source stage to encrypt while uploading to artifact bucket
-                - !GetAtt AppDeployerRole.Arn # Allows CodeBuild (the deploy stage in pipeline) to decrypt code when downloading
+                - !If
+                  - UseCodeCommit
+                  - ${self:custom.settings.sourceRoleArn} # Allows CodePipeline's source stage to encrypt while uploading to artifact bucket
+                  - !Ref AWS::NoValue
+                - !GetAtt AppDeployerRole.Arn  # Allows CodeBuild (the deploy stage in pipeline) to decrypt code when downloading
+                - !GetAtt AppPipelineRole.Arn  # Allows CodePipeline to encrypt code when uploading
             Action:
               - kms:Encrypt
               - kms:Decrypt
@@ -114,7 +129,10 @@ Resources:
             Principal:
               AWS:
                 - !Ref AWS::AccountId
-                - ${self:custom.settings.codeCommitSourceRoleArn}
+                - !If
+                  - UseCodeCommit
+                  - ${self:custom.settings.sourceRoleArn}
+                  - !Ref AWS::NoValue
 
   # The AWS IAM role to be assumed by the AWS CodePipeline.
   # The role specified in each stage is assumed for that specific stage in the pipeline.
@@ -139,13 +157,25 @@ Resources:
                   - codecommit:GetBranch
                   - codecommit:GetCommit
                 Effect: Allow
-                Resource: ${self:custom.settings.codeCommitRepoArn}
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:codecommit:${AWS::Region}:${self:custom.settings.sourceAccountId}:${self:custom.settings.repoName}'
               - Action:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Effect: Allow
                 Resource: '*'
+              - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                  - s3:GetObjectVersion
+                  - s3:ListBucket
+                  - s3:GetBucketPolicy
+                Effect: Allow
+                Resource:
+                  - !Sub arn:aws:s3:::${AppArtifactBucket}
+                  - !Sub arn:aws:s3:::${AppArtifactBucket}/*
               - Action:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
@@ -158,10 +188,13 @@ Resources:
                   - !GetAtt TestStgEnvProject.Arn
                   - !GetAtt TargetEnvDeployProject.Arn
                   - !GetAtt TestTargetEnvProject.Arn
-              - Action:
-                  - sts:AssumeRole
-                Effect: Allow
-                Resource: ${self:custom.settings.codeCommitSourceRoleArn}
+              - !If
+                - UseCodeCommit
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Resource: ${self:custom.settings.sourceRoleArn}
+                - !Ref AWS::NoValue
               - Action:
                   - sns:Publish
                 Effect: Allow
@@ -206,6 +239,7 @@ Resources:
   # where the source code is located (i.e., the account containing the AWS CodeCommit repo with the source code)
   # If you are not using AWS CodeCommit then this role needs to be removed or updated accordingly
   PipelineTriggerRole:
+    Condition: UseCodeCommit
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -240,23 +274,41 @@ Resources:
         # Assume CodeCommitSourceRole for this operation that grants the permissions to download code from CodeCommit
         # repo from source account and allows uploading it to the artifacts S3 bucket and encrypt the artifact using
         # KMS key
-        - Name: Source
-          Actions:
-            - Name: SourceAction
-              RunOrder: 1
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Provider: CodeCommit
-                Version: '1'
-              Configuration:
-                RepositoryName: ${self:custom.settings.codeCommitRepoName}
-                BranchName: ${self:custom.settings.codeCommitRepoBranchName}
-                PollForSourceChanges: 'false'
-              OutputArtifacts:
-                - Name: SourceArtifact
-              Region: ${self:custom.settings.codeCommitRepoAwsRegion}
-              RoleArn: ${self:custom.settings.codeCommitSourceRoleArn}
+        - !If
+          - UseCodeCommit
+          - Name: Source
+            Actions:
+              - Name: SourceAction
+                RunOrder: 1
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: '1'
+                Configuration:
+                  RepositoryName: ${self:custom.settings.repoName}
+                  BranchName: ${self:custom.settings.repoBranch}
+                  PollForSourceChanges: 'false'
+                OutputArtifacts:
+                  - Name: SourceArtifact
+                Region: ${self:custom.settings.sourceAwsRegion}
+                RoleArn: ${self:custom.settings.sourceRoleArn}
+          - Name: Source
+            Actions:
+              - Name: GitHubSource
+                ActionTypeId:
+                  Category: Source
+                  Owner: ThirdParty
+                  Provider: GitHub
+                  Version: '1'
+                Configuration:
+                  OAuthToken: !Ref GitHubOAuthToken
+                  Owner: ${self:custom.settings.githubOwner}
+                  Repo:  ${self:custom.settings.repoName}
+                  Branch: ${self:custom.settings.repoBranch}
+                  PollForSourceChanges: true
+                OutputArtifacts:
+                  - Name: SourceArtifact
 
         # Add stage to deploy to staging env if CreateStagingEnv condition is true
         - !If
@@ -444,6 +496,7 @@ Resources:
 
   # IAM role to be assumed by CloudWatch events service to trigger the CodePipeline
   CodeCommitSourceEventRole:
+    Condition: UseCodeCommit
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -464,6 +517,7 @@ Resources:
 
   # CloudWatch event rule to trigger the CodePipeline
   PipelineTriggerRule:
+    Condition: UseCodeCommit
     Type: AWS::Events::Rule
     Properties:
       Description: CloudWatch event rule to trigger the CodePipeline for [${self:custom.settings.solutionName}] and env [${self:custom.settings.envName}]
@@ -471,12 +525,12 @@ Resources:
         source: [aws.codecommit]
         detail-type: [CodeCommit Repository State Change]
         resources:
-          - ${self:custom.settings.codeCommitRepoArn}
+          - !Sub 'arn:${AWS::Partition}:codecommit:${AWS::Region}:${self:custom.settings.sourceAccountId}:${self:custom.settings.repoName}'
         detail:
           event: [referenceCreated, referenceUpdated]
           referenceType: [branch]
           referenceName:
-            - ${self:custom.settings.codeCommitRepoBranchName}
+            - ${self:custom.settings.repoBranch}
       State: ENABLED
       Targets:
         - Id: !Ref AppPipeline
@@ -510,11 +564,12 @@ Resources:
   # A resource level policy for the default event bus in the target account (target account = the AWS account where code need to be deployed)
   # to allow CodeCommit events to be published from the source account (source account = the AWS account containing the AWS CodeCommit repo with the source code)
   EventBusPolicy:
+    Condition: UseCodeCommit
     Type: AWS::Events::EventBusPolicy
     Properties:
       StatementId: ${self:custom.settings.namespace}-ebp
       Action: events:PutEvents
-      Principal: !Select [4, !Split [':', '${self:custom.settings.codeCommitRepoArn}']]
+      Principal: ${self:custom.settings.sourceAccountId}
 
 Outputs:
   AppArtifactBucketName: { Value: !Ref AppArtifactBucket }
@@ -522,5 +577,4 @@ Outputs:
   ArtifactBucketKeyArn: { Value: !GetAtt ArtifactBucketKey.Arn }
   AppPipelineName: { Value: !Ref AppPipeline }
   AppPipelineArn: { Value: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${AppPipeline}' }
-  PipelineTriggerRoleArn: { Value: !GetAtt PipelineTriggerRole.Arn }
   PipelineNotificationsTopic: { Value: !Ref PipelineNotificationsTopic }

--- a/main/cicd/cicd-pipeline/config/settings/.defaults.yml
+++ b/main/cicd/cicd-pipeline/config/settings/.defaults.yml
@@ -1,16 +1,22 @@
+# AWS Region of the source repository, only used for CodeCommit; defaults to same region as pipeline
+sourceAwsRegion: ${self:custom.settings.awsRegion}
 
-# The stack name of the 'infrastructure' serverless service
-cicdSourceStackName: ${self:custom.settings.namespace}-cicd-src
-
-# AWS Region of the source repository
-# Currently, the source code repo and the solution target aws region are same so use "awsRegion" variable
-codeCommitRepoAwsRegion: ${self:custom.settings.awsRegion}
+# Name of the repository in either CodeCommit or Github
+repoName: aws-galileo-gateway
 
 # The git branch name of the source code repository the code pipeline should build and deploy
-codeCommitRepoBranchName: master
+repoBranch: master
+
+# Path to repo token (e.g. Github access token) in parameter store
+tokenName: /${self:custom.settings.envName}/${self:custom.settings.solutionName}/github/token
 
 # Name of the AWS CodePipeline instance
-pipelineName: ${self:custom.settings.namespace}-${self:custom.settings.codeCommitRepoBranchName}
+pipelineName: ${self:custom.settings.namespace}-${self:custom.settings.repoBranch}
+
+# Either specify a Github owner (and an OAuth Token in CloudFormation) or source account and role (for CodeCommit)
+githubOwner: ''
+sourceAccountId: ''
+sourceRoleArn: ''
 
 # Flag indicating whether to create a staging environment.
 # If this flag is set to true the pipeline will first deploy the solution to a staging environment before deploying the

--- a/main/cicd/cicd-pipeline/package.json
+++ b/main/cicd/cicd-pipeline/package.json
@@ -8,7 +8,8 @@
   "devDependencies": {
     "@aws-ee/base-serverless-settings-helper": "workspace:*",
     "serverless": "^1.63.0",
-    "serverless-deployment-bucket": "^1.1.0"
+    "serverless-deployment-bucket": "^1.1.0",
+    "serverless-plugin-scripts": "^1.0.2"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/main/cicd/cicd-pipeline/scripts/deploy-github-token.bash
+++ b/main/cicd/cicd-pipeline/scripts/deploy-github-token.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+
+stack_name="$1"
+token_name="$2"
+
+
+token=$(aws ssm get-parameter --name ${token_name} --with-decryption --output text --query Parameter.Value 2> /dev/null || echo 'not-found')
+
+if [[ $token != 'not-found' ]]; then
+  aws cloudformation update-stack \
+    --stack-name ${stack_name} \
+    --capabilities CAPABILITY_IAM \
+    --use-previous-template \
+    --parameters ParameterKey=GitHubOAuthToken,ParameterValue=${token}
+fi

--- a/main/cicd/cicd-pipeline/serverless.yml
+++ b/main/cicd/cicd-pipeline/serverless.yml
@@ -21,6 +21,9 @@ custom:
   settings: ${file(./config/settings/.settings.js):merged}
   tags:
     Name: ${self:custom.settings.envName}-${self:service}
+  scripts:
+    hooks:
+      'aws:deploy:finalize:cleanup': scripts/deploy-github-token.bash ${self:provider.stackName} ${self:custom.settings.tokenName}
 
 resources:
   - Description: Galileo-Gateway ${self:custom.settings.version} ${self:custom.settings.solutionName} ${self:custom.settings.envName} CICD-Pipeline
@@ -28,3 +31,4 @@ resources:
 
 plugins:
   - serverless-deployment-bucket
+  - serverless-plugin-scripts

--- a/main/cicd/cicd-source/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-source/config/infra/cloudformation.yml
@@ -31,7 +31,7 @@ Resources:
                   - codecommit:GetCommit
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
-                Resource: !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${self:custom.settings.codeCommitRepoName}"
+                Resource: !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${self:custom.settings.repoName}"
               - Sid: CopySourceCodeToArtifactBucketPermission
                 Effect: Allow
                 Action:
@@ -91,12 +91,12 @@ Resources:
         source: [aws.codecommit]
         detail-type: [CodeCommit Repository State Change]
         resources:
-          - !Sub 'arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${self:custom.settings.codeCommitRepoName}'
+          - !Sub 'arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${self:custom.settings.repoName}'
         detail:
           event: [referenceCreated, referenceUpdated]
           referenceType: [branch]
           referenceName:
-            - ${self:custom.settings.codeCommitRepoBranchName}
+            - ${self:custom.settings.repoBranch}
       State: ENABLED
       Targets:
         - Id: !Sub "CodeCommitCrossAccount${AWS::AccountId}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1275,6 +1275,7 @@ importers:
       '@aws-ee/base-serverless-settings-helper': 'link:../../../addons/addon-base/packages/serverless-settings-helper'
       serverless: 1.67.3
       serverless-deployment-bucket: 1.1.1
+      serverless-plugin-scripts: 1.0.2
     optionalDependencies:
       fsevents: 2.1.2
     specifiers:
@@ -1282,6 +1283,7 @@ importers:
       fsevents: '*'
       serverless: ^1.63.0
       serverless-deployment-bucket: ^1.1.0
+      serverless-plugin-scripts: ^1.0.2
   main/cicd/cicd-source:
     devDependencies:
       '@aws-ee/base-serverless-settings-helper': 'link:../../../addons/addon-base/packages/serverless-settings-helper'
@@ -16401,6 +16403,10 @@ packages:
       serverless: '>= 1.48.1'
     resolution:
       integrity: sha512-OXgfXWZM8RxXie1NXNvjQk7TpM3KI/lyJd4pmakcL7XNZADCd1ph5yOvVdDlJAZgmrkaq2tzSG8ZaKDE66JTmg==
+  /serverless-plugin-scripts/1.0.2:
+    dev: true
+    resolution:
+      integrity: sha1-IYCMPP0KGoTkjAZgsPbzcLVmVIY=
   /serverless-s3-sync/1.12.0:
     dependencies:
       '@auth0/s3': 1.0.0


### PR DESCRIPTION
*Description of changes:*

NOTE: I will write up better documentation in the README to capture the below instructions, but I first want to vet that my approach here is sound.

Added support for CI/CD to use Github instead of CodeCommit. Note that a couple of setting values (e.g. repoName, repoBranch) have been renamed so they can be common across both configs.

If `githubOwner` is specified as a setting, that will activate github mode, otherwise CodeCommit mode will be used. It'll be good to get an example yaml made to illustrate this. Also, when using Github, the `cicd-source` component should not be deployed.

Also required to make this work is a Github personal access token, which once created, should be stored as a secure string in Parameter Store at `/$envName/$solutionName/github/token`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
