### PR TITLE
Remove trailing newlines from grep outputs.

### DIFF
--- a/scripts/get-cicd-pipeline-artifacts-bucket-info.sh
+++ b/scripts/get-cicd-pipeline-artifacts-bucket-info.sh
@@ -13,14 +13,14 @@ install_dependencies "$@"
 
 function get_cicd_pipeline_artifacts_bucket_info() {
   pushd $SOLUTION_ROOT_DIR/cicd/cicd-pipeline
-  local pipeline_stack_name=$($EXEC sls info -s $STAGE | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2)
+  local pipeline_stack_name=$($EXEC sls info -s $STAGE | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')
   popd
 
   echo "pipeline_stack_name=${pipeline_stack_name}"
 
-  local solution_name="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'solutionName:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
-  local aws_region="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsRegion:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
-  local aws_profile="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsProfile:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
+  local solution_name="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'solutionName:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
+  local aws_region="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsRegion:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
+  local aws_profile="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsProfile:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
 
   if [ $aws_profile ]; then
       artifacts_s3_bucket_arn="$(aws cloudformation describe-stacks --stack-name $pipeline_stack_name --output text --region $aws_region --profile $aws_profile --query 'Stacks[0].Outputs[?OutputKey==`AppArtifactBucketArn`].OutputValue')"

--- a/scripts/get-info.sh
+++ b/scripts/get-info.sh
@@ -29,23 +29,22 @@ init_package_manager
 function get_info() {
   pushd "$SOLUTION_DIR/infrastructure" > /dev/null
   local stack_name_infrastructure
-  stack_name_infrastructure=$($EXEC sls info -s "$STAGE" | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2)
+  stack_name_infrastructure=$($EXEC sls info -s "$STAGE" | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')
   popd > /dev/null
 
   pushd "$SOLUTION_DIR/backend" > /dev/null
   local stack_name_backend
-  stack_name_backend=$($EXEC sls info -s "$STAGE" | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2)
+  stack_name_backend=$($EXEC sls info -s "$STAGE" | grep 'stack:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')
   popd > /dev/null
 
   local solution_name aws_region aws_profile
-
   # Note that we disable exit on non-zero for this section as the awsProfile
   # will not be present in the CI/CD pipeline YAML and that fact, combined
   # with set -o pipefail, will cause this script to exit with a non-zero rc.
   set +e
-  solution_name="$(grep '^solutionName:' --ignore-case < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2)"
-  aws_region="$(grep '^awsRegion:' --ignore-case < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2)"
-  aws_profile="$(grep '^awsProfile:' < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2)"
+  solution_name="$(grep '^solutionName:' --ignore-case < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
+  aws_region="$(grep '^awsRegion:' --ignore-case < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
+  aws_profile="$(grep '^awsProfile:' < "$CONFIG_DIR/settings/$STAGE.yml" | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
   set -e
 
   local root_psswd_cmd=''

--- a/scripts/get-relying-party-info.sh
+++ b/scripts/get-relying-party-info.sh
@@ -16,10 +16,10 @@ init_package_manager
 #  Displays human friendly summary message containing information required to configure Relying Party Trust in ADFS
 ##
 function get_rp_info() {
-  local solution_name="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'solutionName:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
-  local aws_region="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsRegion:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
+  local solution_name="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'solutionName:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
+  local aws_region="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep 'awsRegion:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
   local userpool_name="${STAGE}-${solution_name}-userPool"
-  local aws_profile="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep -w 'awsProfile:' --ignore-case | sed 's/ //g' | cut -d':' -f2)"
+  local aws_profile="$(cat $CONFIG_DIR/settings/$STAGE.yml | grep -w 'awsProfile:' --ignore-case | sed 's/ //g' | cut -d':' -f2 | tr -d '\012\015')"
   local aws_profile_cli_param=""
   if [ $aws_profile ]; then
     aws_profile_cli_param="--profile $aws_profile"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
I directly applied the fix to a bug I encountered while deploying the latest version of the application.
This fixes an issue on the bash scripts using grep to retrieve parameters from the configuration files.

It merely includes a simple operation removing trainling newlines at the end of the pipe applied to all grep outputs in several bash scripts.

The bug happens during the environment-deploy script when calling get-info.sh : if the config file has blank lines between 2 successive parameters retrieved with grep, the grep output includes a newline character which is not supported when using it to call aws cli [apis.](url)

![Screenshot from 2020-06-10 18-10-17](https://user-images.githubusercontent.com/33128425/84292258-7065c680-ab46-11ea-8f64-2e721ea7e97c.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
