### PR TITLE
Make use of types.optional correct and consistent in Environment model.

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/Environment.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/Environment.js
@@ -51,12 +51,12 @@ const Environment = types
     createdBy: types.optional(UserIdentifier, {}),
     updatedAt: '',
     updatedBy: types.optional(UserIdentifier, {}),
-    costs: types.optional(types.array(environmentCost), []),
+    costs: types.array(environmentCost, []),
     fetchingUrl: types.optional(types.boolean, false),
     error: types.maybeNull(types.string),
     isExternal: types.optional(types.boolean, false),
     stackId: types.maybeNull(types.string),
-    sharedWithUsers: types.optional(types.array(UserIdentifier, [])),
+    sharedWithUsers: types.array(UserIdentifier, []),
   })
   .actions(self => ({
     setEnvironment(rawEnvironment) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Fix a bug I created because I didn't understand how `types.optional` worked. I corrected two uses to be consistent with one another.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
