### PR TITLE
Workspace Start/Stop functionality

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/api.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/api.js
@@ -136,6 +136,14 @@ function updateEnvironment(body) {
   return httpApiPut('api/workspaces', { data: body });
 }
 
+function stopEnvironment(id) {
+  return httpApiPut(`api/workspaces/${id}/stop`);
+}
+
+function startEnvironment(id) {
+  return httpApiPut(`api/workspaces/${id}/start`);
+}
+
 function getEnvironmentKeypair(id) {
   return httpApiGet(`api/workspaces/${id}/keypair`);
 }
@@ -232,6 +240,8 @@ export {
   deleteEnvironment,
   createEnvironment,
   updateEnvironment,
+  stopEnvironment,
+  startEnvironment,
   getEnvironmentKeypair,
   getEnvironmentPasswordData,
   getEnvironmentNotebookUrl,

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/Environment.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/Environment.js
@@ -111,6 +111,10 @@ const Environment = types
       return _.includes(['COMPLETED'], this.status);
     },
 
+    get isStopped() {
+      return _.includes(['STOPPED'], this.status);
+    },
+
     get isPending() {
       return _.includes(['PENDING'], this.status);
     },

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/EnvironmentsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/EnvironmentsStore.js
@@ -25,6 +25,8 @@ import {
   getEnvironments,
   deleteEnvironment,
   createEnvironment,
+  startEnvironment,
+  stopEnvironment,
   getEnvironmentCost,
   getExternalTemplate,
   updateEnvironment,
@@ -98,6 +100,18 @@ const EnvironmentsStore = BaseStore.named('EnvironmentsStore')
         }
 
         return entry;
+      },
+
+      async stopEnvironment(environment) {
+        const uiEventBus = getEnv(self).uiEventBus;
+        await uiEventBus.fireEvent('environmentStopping', environment);
+        await stopEnvironment(environment.id);
+      },
+
+      async startEnvironment(environment) {
+        const uiEventBus = getEnv(self).uiEventBus;
+        await uiEventBus.fireEvent('environmentStarting', environment);
+        await startEnvironment(environment.id);
       },
 
       markAsTerminating: id => {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentCard.js
@@ -16,10 +16,10 @@
 import React from 'react';
 import _ from 'lodash';
 import { observer, inject } from 'mobx-react';
-import { decorate, runInAction } from 'mobx';
+import { decorate, action, observable, runInAction } from 'mobx';
 import { withRouter } from 'react-router-dom';
 import TimeAgo from 'react-timeago';
-import { Header, Icon, Label, Image } from 'semantic-ui-react';
+import { Header, Icon, Label, Image, Modal, Button } from 'semantic-ui-react';
 import Dotdotdot from 'react-dotdotdot';
 
 import { displayError } from '@aws-ee/base-ui/dist/helpers/notification';
@@ -43,7 +43,9 @@ class EnvironmentCard extends React.Component {
   constructor(props) {
     super(props);
     runInAction(() => {
-      // add any state changing initialization logic if needed
+      this.shouldShowTerminateDialog = false;
+      this.terminationInProgress = false;
+      this.stateChange = false;
     });
   }
 
@@ -78,12 +80,112 @@ class EnvironmentCard extends React.Component {
     event.preventDefault();
     event.stopPropagation();
 
+    const cleanTerminationState = () => {
+      runInAction(() => {
+        this.shouldShowTerminateDialog = false;
+        this.terminationInProgress = false;
+      });
+    };
+
     try {
+      runInAction(() => {
+        this.terminationInProgress = true;
+      });
       const store = this.getStore();
       await store.deleteEnvironment(this.getEnvironment(), this.props.user, storage.getItem(localStorageKeys.pinToken));
+      cleanTerminationState();
     } catch (error) {
+      cleanTerminationState();
       displayError(error);
     }
+  };
+
+  renderTerminateDialog(environment) {
+    const shouldShowTerminateDialog = this.shouldShowTerminateDialog;
+    const { name } = environment;
+    const progress = this.terminationInProgress;
+
+    return (
+      <Modal
+        open={shouldShowTerminateDialog}
+        size="tiny"
+        onClose={this.hideTerminateDialog}
+        closeOnDimmerClick={!progress}
+      >
+        <Header content="Terminate Environment" />
+        <Modal.Content>
+          <p>Are you sure you want to terminate environment &quot;{name}&quot; ?</p>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button disabled={progress} onClick={this.hideTerminateDialog}>
+            Cancel
+          </Button>
+          <Button loading={progress} disabled={progress} color="red" onClick={this.handleTerminateEnvironment}>
+            <Icon name="remove" /> Terminate
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+
+  handleStopEnvironment = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const cleanStateChange = () => {
+      runInAction(() => {
+        this.stateChange = false;
+      });
+    };
+
+    try {
+      runInAction(() => {
+        this.stateChange = true;
+      });
+      const store = this.getStore();
+      await store.stopEnvironment(this.getEnvironment());
+      cleanStateChange();
+    } catch (error) {
+      displayError(error);
+      cleanStateChange();
+    }
+  };
+
+  handleStartEnvironment = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const cleanStateChange = () => {
+      runInAction(() => {
+        this.stateChange = false;
+      });
+    };
+
+    try {
+      runInAction(() => {
+        this.stateChange = true;
+      });
+      const store = this.getStore();
+      await store.startEnvironment(this.getEnvironment());
+      cleanStateChange();
+    } catch (error) {
+      displayError(error);
+      cleanStateChange();
+    }
+  };
+
+  showTerminateDialog = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+    this.shouldShowTerminateDialog = true;
+    this.terminationInProgress = false;
+  };
+
+  hideTerminateDialog = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.terminationInProgress) return;
+    this.shouldShowTerminateDialog = false;
   };
 
   getEnvironment() {
@@ -118,6 +220,7 @@ class EnvironmentCard extends React.Component {
       <div className="flex">
         {this.renderLeftCard(item)}
         {this.renderRightCard(item)}
+        {this.renderTerminateDialog(item)}
       </div>
     );
   }
@@ -211,22 +314,21 @@ class EnvironmentCard extends React.Component {
         <div className="fs-9 mb2">
           <Dotdotdot clamp={1}>{environment.projectId}</Dotdotdot>
         </div>
-        <div className="mb1 mt5 breakout">{this.renderTerminateButton(environment)}</div>
+        <div className="mb1 mt5 breakout flex-auto">
+          {this.renderStopButton(environment)}
+          {this.renderStartButton(environment)}
+          {this.renderTerminateButton(environment)}
+        </div>
       </div>
     );
   }
 
   renderTerminateButton(environment) {
     let terminateButton;
-    if (environment.isCompleted) {
+    if (environment.isCompleted || environment.isStopped) {
       terminateButton = (
-        <Label
-          color="red"
-          className="cursor-pointer"
-          data-id={environment.id}
-          onClick={this.handleTerminateEnvironment}
-        >
-          <Icon name="power off" />
+        <Label color="red" className="cursor-pointer" data-id={environment.id} onClick={this.showTerminateDialog}>
+          <Icon name="minus circle" />
           Terminate
         </Label>
       );
@@ -234,9 +336,53 @@ class EnvironmentCard extends React.Component {
 
     return <>{terminateButton}</>;
   }
+
+  renderStopButton(environment) {
+    let stopButton;
+    // Only the environment types listed here currently have the start/stop functionality
+    const validEnvTypes = ['ec2-windows', 'ec2-linux', 'sagemaker'];
+    // Render button if Environment can be stopped AND prevent admins from attempting to terminate external envs
+    if (
+      environment.isCompleted &&
+      !(this.props.user.isAdmin && environment.isExternal) &&
+      _.includes(validEnvTypes, environment.instanceInfo.type)
+    ) {
+      stopButton = (
+        <Label color="orange" className="cursor-pointer" data-id={environment.id} onClick={this.handleStopEnvironment}>
+          <Icon name="power" />
+          Stop
+        </Label>
+      );
+    }
+
+    return <>{stopButton}</>;
+  }
+
+  renderStartButton(environment) {
+    let startButton;
+    // Render button if Environment can be stpped AND prevent admins from attempting to terminate external envs
+    if (environment.isStopped && !(this.props.user.isAdmin && environment.isExternal)) {
+      startButton = (
+        <Label color="green" className="cursor-pointer" data-id={environment.id} onClick={this.handleStartEnvironment}>
+          <Icon name="power" />
+          Start
+        </Label>
+      );
+    }
+
+    return <>{startButton}</>;
+  }
 }
 
-// see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
-decorate(EnvironmentCard, {});
+// Using MobX-4 to decorate here
+decorate(EnvironmentCard, {
+  showTerminateDialog: action,
+  hideTerminateDialog: action,
+  handleStartEnvironment: action,
+  handleStopEnvironment: action,
+  shouldShowTerminateDialog: observable,
+  terminationInProgress: observable,
+  stateChange: observable,
+});
 
 export default inject('userDisplayName')(withRouter(observer(EnvironmentCard)));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentDetailPage.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentDetailPage.js
@@ -207,6 +207,17 @@ class EnvironmentDetailPage extends React.Component {
     return this.renderPendingInfo();
   }
 
+  renderCostDetailsTabPane() {
+    return {
+      menuItem: 'Research Workspace Details',
+      render: () => (
+        <Tab.Pane attached={false}>
+          <Observer>{() => this.renderInstanceDetails()}</Observer>
+        </Tab.Pane>
+      ),
+    };
+  }
+
   renderCompletedTabs() {
     const environment = this.getEnvironment();
 
@@ -241,14 +252,7 @@ class EnvironmentDetailPage extends React.Component {
           </Tab.Pane>
         ),
       },
-      {
-        menuItem: 'Research Workspace Details',
-        render: () => (
-          <Tab.Pane attached={false}>
-            <Observer>{() => this.renderInstanceDetails()}</Observer>
-          </Tab.Pane>
-        ),
-      },
+      this.renderCostDetailsTabPane(),
       this.renderUserShareTabPane(),
     ];
 

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentStatusIcon.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentStatusIcon.js
@@ -38,7 +38,7 @@ class EnvironmentStatusIcon extends React.Component {
         </Label>
       );
     }
-    if (status === 'FAILED') {
+    if (status === 'FAILED' || status.endsWith('FAILED')) {
       return (
         <Label basic size="mini" color="red">
           Error
@@ -62,10 +62,37 @@ class EnvironmentStatusIcon extends React.Component {
         </div>
       );
     }
+    if (status === 'STOPPING') {
+      return (
+        <div>
+          <Label basic size="mini">
+            Stopping
+            <Icon loading name="spinner" size="large" color="red" className="ml1 mr1" />
+          </Label>
+        </div>
+      );
+    }
+    if (status === 'STOPPED') {
+      return (
+        <Label basic size="mini" color="orange">
+          Stopped
+        </Label>
+      );
+    }
+    if (status === 'STARTING') {
+      return (
+        <Label basic size="mini">
+          Starting
+          <Icon loading name="spinner" size="large" color="yellow" className="ml1 mr1" />
+        </Label>
+      );
+    }
+
+    // unknown state - should have returned
     return (
       <Label basic size="mini">
-        Starting
-        <Icon loading name="spinner" size="large" color="yellow" className="ml1 mr1" />
+        Unknown State
+        <Icon loading name="spinner" size="large" color="red" className="ml1 mr1" />
       </Label>
     );
   }

--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/environment-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/environment-controller.js
@@ -90,6 +90,36 @@ async function configure(context) {
   );
 
   // ===============================================================
+  //  PUT / (mounted to /api/workspaces)
+  // ===============================================================
+  router.put(
+    '/:id/start',
+    wrap(async (req, res) => {
+      const requestContext = res.locals.requestContext;
+      const id = req.params.id;
+      const operation = 'start';
+      const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
+
+      res.status(200).json(result);
+    }),
+  );
+
+  // ===============================================================
+  //  PUT / (mounted to /api/workspaces)
+  // ===============================================================
+  router.put(
+    '/:id/stop',
+    wrap(async (req, res) => {
+      const requestContext = res.locals.requestContext;
+      const id = req.params.id;
+      const operation = 'stop';
+      const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
+
+      res.status(200).json(result);
+    }),
+  );
+
+  // ===============================================================
   //  DELETE /:id (mounted to /api/workspaces)
   // ===============================================================
   router.delete(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-service.test.js
@@ -1,0 +1,122 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+
+jest.mock('@aws-ee/base-services/lib/aws/aws-service');
+const AwsServiceMock = require('@aws-ee/base-services/lib/aws/aws-service');
+
+jest.mock('@aws-ee/base-services/lib/authorization/authorization-service');
+const AuthServiceMock = require('@aws-ee/base-services/lib/authorization/authorization-service');
+
+jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
+const AuditServiceMock = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+jest.mock('../../project/project-service');
+const ProjectServiceMock = require('../../project/project-service');
+
+jest.mock('../../../../../../addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-trigger-service');
+const WorkflowTriggerServiceMock = require('../../../../../../addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-trigger-service');
+
+jest.mock('../../aws-accounts/aws-accounts-service');
+const AwsAccountsServiceMock = require('../../aws-accounts/aws-accounts-service');
+
+jest.mock('../../indexes/indexes-service');
+const IndexesServiceMock = require('../../indexes/indexes-service');
+
+jest.mock('../../user/user-service');
+const UserServiceMock = require('../../user/user-service');
+
+jest.mock('../../compute/compute-platform-service');
+const ComputePlatformServiceMock = require('../../compute/compute-platform-service');
+
+jest.mock('../../compute/compute-price-service');
+const ComputePriceServiceMock = require('../../compute/compute-price-service');
+
+jest.mock('../../study/study-permission-service');
+const StudyPermissionServiceMock = require('../../study/study-permission-service');
+
+jest.mock('../environment-ami-service.js');
+const EnvironmentAmiServiceMock = require('../environment-ami-service.js');
+
+jest.mock('../environment-authz-service.js');
+const EnvironmentAuthZServiceMock = require('../environment-authz-service.js');
+
+jest.mock('../environment-mount-service.js');
+const EnvironmentMountServiceMock = require('../environment-mount-service.js');
+
+const EnvironmentService = require('../environment-service');
+
+describe('EnvironmentService', () => {
+  let service = null;
+  beforeEach(async () => {
+    // Initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('environmentService', new EnvironmentService());
+    container.register('projectService', new ProjectServiceMock());
+    container.register('userService', new UserServiceMock());
+    container.register('studyPermissionService', new StudyPermissionServiceMock());
+    container.register('authorizationService', new AuthServiceMock());
+    container.register('environmentAmiService', new EnvironmentAmiServiceMock());
+    container.register('environmentAuthzService', new EnvironmentAuthZServiceMock());
+    container.register('environmentMountService', new EnvironmentMountServiceMock());
+    container.register('dbService', new DbServiceMock());
+    container.register('aws', new AwsServiceMock());
+    container.register('indexesService', new IndexesServiceMock());
+    container.register('computePlatformService', new ComputePlatformServiceMock());
+    container.register('computePriceService', new ComputePriceServiceMock());
+    container.register('awsAccountsService', new AwsAccountsServiceMock());
+    container.register('auditWriterService', new AuditServiceMock());
+    container.register('workflowTriggerService', new WorkflowTriggerServiceMock());
+    container.register('settings', new SettingsServiceMock());
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('environmentService');
+  });
+
+  describe('startingCompletedEnv', () => {
+    it('should fail to start if status is already "COMPLETED"', async () => {
+      const params = {
+        id: 'my-environment',
+        operation: 'start',
+      };
+
+      // Skip authorization
+      service.assertAuthorized = jest.fn();
+      service.mustFind = jest.fn(() => {
+        return { status: 'COMPLETED', projectId: 'project-id', instanceInfo: { type: 'sagemaker' } };
+      });
+
+      try {
+        await service.changeWorkspaceRunState({}, params);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual(
+          'unable to start environment with id "my-environment" - current status "COMPLETED"',
+        );
+      }
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/plugins/workflow-steps-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/plugins/workflow-steps-plugin.js
@@ -20,6 +20,14 @@ const provisionAccount = require('../steps/provision-account/provision-account')
 const provisionAccountYaml = require('../steps/provision-account/provision-account.yml');
 const provisionEnvironment = require('../steps/provision-environment/provision-environment');
 const provisionEnvironmentYaml = require('../steps/provision-environment/provision-environment.yml');
+const startSageMakerEnvironment = require('../steps/start-sagemaker-environment/start-sagemaker-environment');
+const startSageMakerEnvironmentYaml = require('../steps/start-sagemaker-environment/start-sagemaker-environment.yml');
+const stopSageMakerEnvironment = require('../steps/stop-sagemaker-environment/stop-sagemaker-environment');
+const stopSageMakerEnvironmentYaml = require('../steps/stop-sagemaker-environment/stop-sagemaker-environment.yml');
+const startEC2Environment = require('../steps/start-ec2-environment/start-ec2-environment');
+const startEC2EnvironmentYaml = require('../steps/start-ec2-environment/start-ec2-environment.yml');
+const stopEC2Environment = require('../steps/stop-ec2-environment/stop-ec2-environment');
+const stopEC2EnvironmentYaml = require('../steps/stop-ec2-environment/stop-ec2-environment.yml');
 
 const add = (implClass, yaml) => ({ implClass, yaml });
 
@@ -28,6 +36,10 @@ const steps = [
   add(deleteEnvironment, deleteEnvironmentYaml),
   add(provisionAccount, provisionAccountYaml),
   add(provisionEnvironment, provisionEnvironmentYaml),
+  add(startSageMakerEnvironment, startSageMakerEnvironmentYaml),
+  add(stopSageMakerEnvironment, stopSageMakerEnvironmentYaml),
+  add(startEC2Environment, startEC2EnvironmentYaml),
+  add(stopEC2Environment, stopEC2EnvironmentYaml),
 ];
 
 async function registerWorkflowSteps(registry) {

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-ec2-environment/start-ec2-environment.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-ec2-environment/start-ec2-environment.js
@@ -1,0 +1,142 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+class StartEC2Environment extends StepBase {
+  async start() {
+    const environmentId = await this.payload.string('environmentId');
+    this.state.setKey('STATE_ENVIRONMENT_ID', environmentId);
+
+    const requestContext = await this.payload.object('requestContext');
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+
+    const [environmentService] = await this.mustFindServices(['environmentService']);
+    const environment = await environmentService.mustFind(requestContext, { id: environmentId });
+
+    const ec2 = await this.getEc2Service();
+    const { Ec2WorkspaceInstanceId } = environment.instanceInfo;
+
+    const params = {
+      InstanceIds: [Ec2WorkspaceInstanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const paramsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(paramsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+
+    if (status !== 'STOPPED') {
+      throw new Error(`EC2 instance [${Ec2WorkspaceInstanceId}] is not stopped`);
+    }
+
+    try {
+      await ec2.startInstances(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('start ec2 instance error: ', error);
+      throw error;
+    }
+
+    await this.updateEnvironmentStatus('STARTING');
+    this.state.setKey('STATE_INSTANCE_ID', Ec2WorkspaceInstanceId);
+
+    return this.wait(5)
+      .maxAttempts(120)
+      .until('checkInstanceStarted')
+      .thenCall('updateEnvironmentStatusToCompleted');
+  }
+
+  async checkInstanceStarted() {
+    const instanceId = await this.state.string('STATE_INSTANCE_ID');
+    this.print(`instanceId: [${instanceId}]`);
+
+    const ec2 = await this.getEc2Service();
+    const params = {
+      InstanceIds: [instanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const parmsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(parmsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+
+    if (['SHUTTING-DOWN', 'TERMINATED', 'STOPPING'].includes(status)) {
+      throw new Error(`EC2 instance [${instanceId}] is in [${status}] state and can not be started`);
+    }
+
+    return status === 'RUNNING';
+  }
+
+  async getEc2Service() {
+    const [aws] = await this.mustFindServices(['aws']);
+    const [requestContext, RoleArn, ExternalId] = await Promise.all([
+      this.payload.object('requestContext'),
+      this.payload.string('cfnExecutionRole'),
+      this.payload.string('roleExternalId'),
+    ]);
+
+    const sts = new aws.sdk.STS();
+    const {
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
+    } = await sts
+      .assumeRole({
+        RoleArn,
+        RoleSessionName: `RaaS-${requestContext.principalIdentifier.username}`,
+        ExternalId,
+      })
+      .promise();
+
+    return new aws.sdk.EC2({ accessKeyId, secretAccessKey, sessionToken });
+  }
+
+  async updateEnvironmentStatusToCompleted() {
+    return this.updateEnvironmentStatus('COMPLETED');
+  }
+
+  async updateEnvironmentStatus(status) {
+    const environmentService = await this.mustFindServices('environmentService');
+    const id = await this.state.string('STATE_ENVIRONMENT_ID');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+
+    // SECURITY NOTE
+    // add field to authorize update on behalf of user
+    // this is needed to allow shared envirnments to start/stop by other users
+    requestContext.fromWorkflow = true;
+
+    await environmentService.update(requestContext, { id, status });
+  }
+
+  async onFail() {
+    return this.updateEnvironmentStatus('STARTING_FAILED');
+  }
+}
+
+module.exports = StartEC2Environment;

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-ec2-environment/start-ec2-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-ec2-environment/start-ec2-environment.yml
@@ -1,0 +1,8 @@
+id: st-start-ec2-environment
+v: 1
+title: Start EC2 Environment
+desc: |
+  Start an EC2 Instance.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-sagemaker-environment/start-sagemaker-environment.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-sagemaker-environment/start-sagemaker-environment.js
@@ -1,0 +1,155 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+class StartSagemakerEnvironment extends StepBase {
+  async start() {
+    const environmentId = await this.payload.string('environmentId');
+    this.state.setKey('STATE_ENVIRONMENT_ID', environmentId);
+
+    const requestContext = await this.payload.object('requestContext');
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+
+    const [environmentService] = await this.mustFindServices(['environmentService']);
+    const environment = await environmentService.mustFind(requestContext, { id: environmentId });
+
+    const sm = await this.getSageMakerService();
+    const { NotebookInstanceName } = environment.instanceInfo;
+    const params = {
+      NotebookInstanceName,
+    };
+
+    let notebookInstanceInfo;
+    try {
+      notebookInstanceInfo = await sm.describeNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe notebook instance error: ', error);
+      throw error;
+    }
+
+    const { NotebookInstanceStatus: notebookInstanceStatus } = notebookInstanceInfo;
+    const status = notebookInstanceStatus.toUpperCase();
+
+    if (status !== 'STOPPED') {
+      throw new Error(`Notebook instance [${NotebookInstanceName}] is not stopped`);
+    }
+
+    try {
+      await sm.startNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('start notebook instance error: ', error);
+      throw error;
+    }
+
+    await this.updateEnvironmentStatus('STARTING');
+    this.state.setKey('STATE_NOTEBOOK_INSTANCE_NAME', NotebookInstanceName);
+
+    return this.wait(5)
+      .maxAttempts(120)
+      .until('checkNotebookStarted')
+      .thenCall('updateEnvironmentStatusToCompleted');
+  }
+
+  async checkNotebookStarted() {
+    const NotebookInstanceName = await this.state.string('STATE_NOTEBOOK_INSTANCE_NAME');
+    this.print(`Notebook instance name: [${NotebookInstanceName}]`);
+
+    const sm = await this.getSageMakerService();
+    const params = {
+      NotebookInstanceName,
+    };
+
+    let notebookInstanceInfo;
+    try {
+      notebookInstanceInfo = await sm.describeNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe notebook instance error: ', error);
+      // may be a transient error - return false
+      return false;
+    }
+
+    const { NotebookInstanceStatus: notebookInstanceStatus } = notebookInstanceInfo;
+    const status = notebookInstanceStatus.toUpperCase();
+
+    if (status === 'FAILED') {
+      throw new Error(
+        `Notebook instance [${NotebookInstanceName}] is in failed state with reason: ${notebookInstanceStatus.FailureReason}`,
+      );
+    }
+    if (status === 'DELETING') {
+      throw new Error(`Notebook instance [${NotebookInstanceName}] is being deleted`);
+    }
+
+    return status === 'INSERVICE';
+  }
+
+  async getSageMakerService() {
+    const [aws] = await this.mustFindServices(['aws']);
+    // increase retry defaults to reduce the risk of failures caused
+    // by throttles
+    aws.sdk.config.update({
+      maxRetries: 6, // default 3
+      retryDelayOptions: {
+        base: 300, // default 100
+      },
+    });
+
+    const [requestContext, RoleArn, ExternalId] = await Promise.all([
+      this.payload.object('requestContext'),
+      this.payload.string('cfnExecutionRole'),
+      this.payload.string('roleExternalId'),
+    ]);
+
+    const sts = new aws.sdk.STS();
+    const {
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
+    } = await sts
+      .assumeRole({
+        RoleArn,
+        RoleSessionName: `RaaS-${requestContext.principalIdentifier.username}`,
+        ExternalId,
+      })
+      .promise();
+
+    return new aws.sdk.SageMaker({ accessKeyId, secretAccessKey, sessionToken });
+  }
+
+  async updateEnvironmentStatusToCompleted() {
+    return this.updateEnvironmentStatus('COMPLETED');
+  }
+
+  async updateEnvironmentStatus(status) {
+    const environmentService = await this.mustFindServices('environmentService');
+    const id = await this.state.string('STATE_ENVIRONMENT_ID');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+
+    // SECURITY NOTE
+    // add field to authorize update on behalf of user
+    // this is needed to allow shared envirnments to start/stop by other users
+    requestContext.fromWorkflow = true;
+
+    await environmentService.update(requestContext, { id, status });
+  }
+
+  async onFail() {
+    return this.updateEnvironmentStatus('STARTING_FAILED');
+  }
+}
+
+module.exports = StartSagemakerEnvironment;

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-sagemaker-environment/start-sagemaker-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/start-sagemaker-environment/start-sagemaker-environment.yml
@@ -1,0 +1,8 @@
+id: st-start-sagemaker-environment
+v: 1
+title: Start SageMaker Environment
+desc: |
+  Start a SageMaker Jupyter Notebook.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-ec2-environment/stop-ec2-environment.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-ec2-environment/stop-ec2-environment.js
@@ -1,0 +1,144 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+class StopEC2Environment extends StepBase {
+  async start() {
+    const environmentId = await this.payload.string('environmentId');
+    this.state.setKey('STATE_ENVIRONMENT_ID', environmentId);
+
+    const requestContext = await this.payload.object('requestContext');
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+
+    const [environmentService] = await this.mustFindServices(['environmentService']);
+    const environment = await environmentService.mustFind(requestContext, { id: environmentId });
+
+    const ec2 = await this.getEc2Service();
+    const { Ec2WorkspaceInstanceId } = environment.instanceInfo;
+
+    const params = {
+      InstanceIds: [Ec2WorkspaceInstanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const paramsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(paramsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+
+    if (!['STOPPING', 'STOPPED'].includes(status)) {
+      if (status !== 'RUNNING') {
+        throw new Error(`EC2 instance [${Ec2WorkspaceInstanceId}] is not running`);
+      }
+
+      try {
+        await ec2.stopInstances(params).promise();
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('stop ec2 instance error: ', error);
+        throw error;
+      }
+    }
+    await this.updateEnvironmentStatus('STOPPING');
+
+    this.state.setKey('STATE_INSTANCE_ID', Ec2WorkspaceInstanceId);
+
+    return this.wait(5)
+      .maxAttempts(120)
+      .until('checkInstanceStopped')
+      .thenCall('updateEnvironmentStatusToStopped');
+  }
+
+  async checkInstanceStopped() {
+    const instanceId = await this.state.string('STATE_INSTANCE_ID');
+    this.print(`instanceId: [${instanceId}]`);
+
+    const ec2 = await this.getEc2Service();
+    const params = {
+      InstanceIds: [instanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const parmsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(parmsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+
+    if (['SHUTTING-DOWN', 'TERMINATED'].includes(status)) {
+      throw new Error(`EC2 instance [${instanceId}] is in ${status} state and can not be stopped`);
+    }
+
+    return status === 'STOPPED';
+  }
+
+  async getEc2Service() {
+    const [aws] = await this.mustFindServices(['aws']);
+    const [requestContext, RoleArn, ExternalId] = await Promise.all([
+      this.payload.object('requestContext'),
+      this.payload.string('cfnExecutionRole'),
+      this.payload.string('roleExternalId'),
+    ]);
+
+    const sts = new aws.sdk.STS();
+    const {
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
+    } = await sts
+      .assumeRole({
+        RoleArn,
+        RoleSessionName: `RaaS-${requestContext.principalIdentifier.username}`,
+        ExternalId,
+      })
+      .promise();
+
+    return new aws.sdk.EC2({ accessKeyId, secretAccessKey, sessionToken });
+  }
+
+  async updateEnvironmentStatusToStopped() {
+    return this.updateEnvironmentStatus('STOPPED');
+  }
+
+  async updateEnvironmentStatus(status) {
+    const environmentService = await this.mustFindServices('environmentService');
+    const id = await this.state.string('STATE_ENVIRONMENT_ID');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+
+    // SECURITY NOTE
+    // add field to authorize update on behalf of user
+    // this is needed to allow shared envirnments to start/stop by other users
+    requestContext.fromWorkflow = true;
+
+    await environmentService.update(requestContext, { id, status });
+  }
+
+  async onFail() {
+    return this.updateEnvironmentStatus('STOPPING_FAILED');
+  }
+}
+
+module.exports = StopEC2Environment;

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-ec2-environment/stop-ec2-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-ec2-environment/stop-ec2-environment.yml
@@ -1,0 +1,8 @@
+id: st-stop-ec2-environment
+v: 1
+title: Stop EC2 Environment
+desc: |
+  Stop an EC2 Instance.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-sagemaker-environment/stop-sagemaker-environment.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-sagemaker-environment/stop-sagemaker-environment.js
@@ -1,0 +1,148 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+class StopSagemakerEnvironment extends StepBase {
+  async start() {
+    const environmentId = await this.payload.string('environmentId');
+    this.state.setKey('STATE_ENVIRONMENT_ID', environmentId);
+
+    const requestContext = await this.payload.object('requestContext');
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+
+    const [environmentService] = await this.mustFindServices(['environmentService']);
+    const environment = await environmentService.mustFind(requestContext, { id: environmentId });
+
+    const sm = await this.getSageMakerService();
+    const { NotebookInstanceName } = environment.instanceInfo;
+
+    const params = {
+      NotebookInstanceName,
+    };
+
+    let notebookInstanceInfo;
+    try {
+      notebookInstanceInfo = await sm.describeNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe notebook instance error: ', error);
+      throw error;
+    }
+
+    const { NotebookInstanceStatus: notebookInstanceStatus } = notebookInstanceInfo;
+    const status = notebookInstanceStatus.toUpperCase();
+
+    if (status !== 'INSERVICE') {
+      throw new Error(`Notebook instance [${NotebookInstanceName}] is not running`);
+    }
+
+    try {
+      await sm.stopNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('stop notebook instance error: ', error);
+      throw error;
+    }
+
+    await this.updateEnvironmentStatus('STOPPING');
+
+    this.state.setKey('STATE_NOTEBOOK_INSTANCE_NAME', NotebookInstanceName);
+
+    return this.wait(5)
+      .maxAttempts(120)
+      .until('checkNotebookStopped')
+      .thenCall('updateEnvironmentStatusToStopped');
+  }
+
+  async checkNotebookStopped() {
+    const notebookInstanceName = await this.state.string('STATE_NOTEBOOK_INSTANCE_NAME');
+    this.print(`Notebook instance name: [${notebookInstanceName}]`);
+
+    const sm = await this.getSageMakerService();
+    const params = {
+      NotebookInstanceName: notebookInstanceName,
+    };
+
+    let notebookInstanceInfo;
+    try {
+      notebookInstanceInfo = await sm.describeNotebookInstance(params).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe notebook instance error: ', error);
+      // may be a transient error - return false
+      return false;
+    }
+
+    const { NotebookInstanceStatus: notebookInstanceStatus } = notebookInstanceInfo;
+    const status = notebookInstanceStatus.toUpperCase();
+
+    if (status === 'FAILED') {
+      throw new Error(
+        `Notebook instance [${notebookInstanceName}] is in failed state with reason: ${notebookInstanceStatus.FailureReason}`,
+      );
+    }
+    if (status === 'DELETING') {
+      throw new Error(`Notebook instance [${notebookInstanceName}] is being deleted`);
+    }
+
+    return status === 'STOPPED';
+  }
+
+  async getSageMakerService() {
+    const [aws] = await this.mustFindServices(['aws']);
+    const [requestContext, RoleArn, ExternalId] = await Promise.all([
+      this.payload.object('requestContext'),
+      this.payload.string('cfnExecutionRole'),
+      this.payload.string('roleExternalId'),
+    ]);
+
+    const sts = new aws.sdk.STS();
+    const {
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
+    } = await sts
+      .assumeRole({
+        RoleArn,
+        RoleSessionName: `RaaS-${requestContext.principalIdentifier.username}`,
+        ExternalId,
+      })
+      .promise();
+
+    return new aws.sdk.SageMaker({ accessKeyId, secretAccessKey, sessionToken });
+  }
+
+  async updateEnvironmentStatusToStopped() {
+    return this.updateEnvironmentStatus('STOPPED');
+  }
+
+  async updateEnvironmentStatus(status) {
+    const environmentService = await this.mustFindServices('environmentService');
+    const id = await this.state.string('STATE_ENVIRONMENT_ID');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+
+    // SECURITY NOTE
+    // add field to authorize update on behalf of user
+    // this is needed to allow shared envirnments to start/stop by other users
+    requestContext.fromWorkflow = true;
+
+    await environmentService.update(requestContext, { id, status });
+  }
+
+  async onFail() {
+    return this.updateEnvironmentStatus('STOPPING_FAILED');
+  }
+}
+
+module.exports = StopSagemakerEnvironment;

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-sagemaker-environment/stop-sagemaker-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/stop-sagemaker-environment/stop-sagemaker-environment.yml
@@ -1,0 +1,8 @@
+id: st-stop-sagemaker-environment
+v: 1
+title: Stop SageMaker Environment
+desc: |
+  Stop a SageMaker Jupyter Notebook.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/plugins/workflows-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/plugins/workflows-plugin.js
@@ -16,11 +16,23 @@
 const createEnvironmentYaml = require('../workflows/create-environment.yml');
 const deleteEnvironmentYaml = require('../workflows/delete-environment.yml');
 const provisionAccountYaml = require('../workflows/provision-account.yml');
+const startSageMakerYaml = require('../workflows/start-sagemaker-environment.yml');
+const stopSageMakerYaml = require('../workflows/stop-sagemaker-environment.yml');
+const startEC2Yaml = require('../workflows/start-ec2-environment.yml');
+const stopEC2Yaml = require('../workflows/stop-ec2-environment.yml');
 
 const add = yaml => ({ yaml });
 
 // The order is important, add your templates here
-const workflows = [add(createEnvironmentYaml), add(deleteEnvironmentYaml), add(provisionAccountYaml)];
+const workflows = [
+  add(createEnvironmentYaml),
+  add(deleteEnvironmentYaml),
+  add(provisionAccountYaml),
+  add(startSageMakerYaml),
+  add(stopSageMakerYaml),
+  add(startEC2Yaml),
+  add(stopEC2Yaml),
+];
 
 async function registerWorkflows(registry) {
   // eslint-disable-next-line no-restricted-syntax

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/start-ec2-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/start-ec2-environment.yml
@@ -1,0 +1,14 @@
+id: wf-start-ec2-environment
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Start an EC2 instance
+desc: |
+  Start an EC2 instance.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-start-ec2-environment
+    stepTemplateVer: 1
+    id: wf-step_1_1591284567331_05 # Randomly generated id, no need to change it

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/start-sagemaker-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/start-sagemaker-environment.yml
@@ -1,0 +1,14 @@
+id: wf-start-sagemaker-environment
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Start a SageMaker Notebook
+desc: |
+  Start a SageMaker Jupyter Notebook.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-start-sagemaker-environment
+    stepTemplateVer: 1
+    id: wf-step_1_1580582317343_28 # Randomly generated id, no need to change it

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/stop-ec2-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/stop-ec2-environment.yml
@@ -1,0 +1,14 @@
+id: wf-stop-ec2-environment
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Stop an EC2 instance
+desc: |
+  Stop an EC2 instance.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-stop-ec2-environment
+    stepTemplateVer: 1
+    id: wf-step_1_1591644531449_03 # Randomly generated id, no need to change it

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/stop-sagemaker-environment.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/stop-sagemaker-environment.yml
@@ -1,0 +1,14 @@
+id: wf-stop-sagemaker-environment
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Stop a SageMaker Notebook
+desc: |
+  Stop a SageMaker Jupyter Notebook.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-stop-sagemaker-environment
+    stepTemplateVer: 1
+    id: wf-step_1_1580582317303_28 # Randomly generated id, no need to change it


### PR DESCRIPTION
Issue #, if available:
Galileo Backlog Item CHAM-7

Description of changes:
This feature allows switching the Start/Stop state of successfully provisioned workspaces (currently only for SageMaker, EC2 Linux and EC2 Windows). 

<img width="1052" alt="Screen Shot 2020-06-22 at 10 08 29 PM" src="https://user-images.githubusercontent.com/20480854/85352857-e9fd9d00-b4d4-11ea-84b2-1b9f15b1a6a4.png">

I'll be adding unit tests for this next.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
