### PR TITLE
Allow VPC and subnet IDs to be parameterized for packer AMI builds.

### DIFF
--- a/main/solution/machine-images/README.md
+++ b/main/solution/machine-images/README.md
@@ -13,3 +13,7 @@ To build Amazon Machine Images:
 ```bash
 $ pnpx sls build-image -s $STAGE
 ```
+
+Note that if no configuration is provided the default VPC will be used to create AMIs, and if
+no default VPC exists AMI creation will fail. To instead provide a VPC and subnet to use,
+create a `config/settings/$STAGE.yml` file with ID values (see `example.yml` for an example).

--- a/main/solution/machine-images/config/infra/packer-ec2-linux-workspace.json
+++ b/main/solution/machine-images/config/infra/packer-ec2-linux-workspace.json
@@ -2,7 +2,8 @@
   "variables": {
     "aws_access_key": "",
     "aws_secret_key": "",
-    "vpc-id": "",
+    "vpcId": "",
+    "subnetId": "",
     "awsProfile": "",
     "awsRegion": "",
     "amiName": ""
@@ -14,6 +15,8 @@
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "region": "{{user `awsRegion`}}",
+      "vpc_id": "{{user `vpcId`}}",
+      "subnet_id": "{{user `subnetId`}}",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",

--- a/main/solution/machine-images/config/infra/packer-ec2-windows-workspace.json
+++ b/main/solution/machine-images/config/infra/packer-ec2-windows-workspace.json
@@ -2,7 +2,8 @@
   "variables": {
     "aws_access_key": "",
     "aws_secret_key": "",
-    "vpc-id": "",
+    "vpcId": "",
+    "subnetId": "",
     "awsProfile": "",
     "awsRegion": "",
     "amiName": ""
@@ -14,6 +15,8 @@
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "region": "{{user `awsRegion`}}",
+      "vpc_id": "{{user `vpcId`}}",
+      "subnet_id": "{{user `subnetId`}}",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",

--- a/main/solution/machine-images/config/infra/packer-emr-workspace.json
+++ b/main/solution/machine-images/config/infra/packer-emr-workspace.json
@@ -2,7 +2,8 @@
   "variables": {
     "aws_access_key": "",
     "aws_secret_key": "",
-    "vpc-id": "",
+    "vpcId": "",
+    "subnetId": "",
     "awsProfile": "",
     "awsRegion": "",
     "amiName": ""
@@ -14,6 +15,8 @@
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "region": "{{user `awsRegion`}}",
+      "vpc_id": "{{user `vpcId`}}",
+      "subnet_id": "{{user `subnetId`}}",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",

--- a/main/solution/machine-images/config/settings/example.yml
+++ b/main/solution/machine-images/config/settings/example.yml
@@ -1,0 +1,4 @@
+# VPC ID and Subnet ID where EC2 instances will be launched to
+# create AMIs from. If left blank, the default VPC will be used.
+# vpcId: vpc-0123456789abcdef0
+# subnetId: subnet-0123456789abcdef0


### PR DESCRIPTION
Issue #, if available:

Description of changes:

If an account has no default VPC (common with security hardened accounts), you need to be able to provide VPC and subnet IDs when building AMIs using package. This PR makes that possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
