### PR TITLE
Properly filter the list envrionment API call by a user's permissions.

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-service.js
@@ -102,13 +102,13 @@ class EnvironmentService extends Service {
     const envPromiseResolutions = await Promise.all(envPromises);
 
     const envAccessible = envPromiseResolutions
-      .map((isAccessible, index) => {
+      .map((permission, index) => {
         return {
-          isAccessible,
+          permission,
           environmentsIndex: envMap[index].environmentsIndex,
         };
       })
-      .filter(item => item.isAccessible);
+      .filter(item => item.permission.effect === 'allow');
 
     return [...envAccessible].map(item => environments[item.environmentsIndex]);
   }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

The implementation had a bug that was returning all workspaces when user queried, not just those with permission to access. That caused a subsequent API call failure when trying to fetch details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
