### PR TITLE
Modified Cognito provider to parse Auth0 users properly

### DIFF
--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/__tests__/user-attributes-mapper-service.test.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/__tests__/user-attributes-mapper-service.test.js
@@ -1,0 +1,50 @@
+const UserAttributesMapperService = require('../user-attributes-mapper-service');
+
+describe('UserAttributeMapperService', () => {
+  let service = null;
+  beforeEach(() => {
+    service = new UserAttributesMapperService();
+  });
+
+  describe('getUsername', () => {
+    it('should map a Cognito username', () => {
+      const decodedToken = {
+        'cognito:username': 'johndoe@example.com',
+      };
+
+      const result = service.getUsername(decodedToken);
+      expect(result.username).toEqual('johndoe@example.com');
+      expect(result.usernameInIdp).toEqual('johndoe@example.com');
+    });
+
+    it('should map an ADFS username', () => {
+      const decodedToken = {
+        'cognito:username': 'ADFS\\123abc',
+      };
+
+      const result = service.getUsername(decodedToken);
+      expect(result.username).toEqual('ADFS_123abc');
+      expect(result.usernameInIdp).toEqual('123abc');
+    });
+
+    it('should map an Auth0 username', () => {
+      const decodedToken = {
+        'cognito:username': 'Auth0_auth0|5ef37c962da',
+      };
+
+      const result = service.getUsername(decodedToken);
+      expect(result.username).toEqual('Auth0_auth0_5ef37c962da');
+      expect(result.usernameInIdp).toEqual('5ef37c962da');
+    });
+
+    it('should map an Auth0+Google username', () => {
+      const decodedToken = {
+        'cognito:username': 'Auth0_google-oauth2|10285875304827',
+      };
+
+      const result = service.getUsername(decodedToken);
+      expect(result.username).toEqual('Auth0_google-oauth2_10285875304827');
+      expect(result.usernameInIdp).toEqual('10285875304827');
+    });
+  });
+});


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This PR adds support to federate users to Auth0 using the Cognito auth provider. During this process, we realized that Auth0 users get created with a different format than ADFS users. 

Auth0 users format example:
```
Auth0_auth0|5ef37c962da
```

ADFS users format example:
```
ADFS\\123abc
```

This commit modifies the function that parses the cognito:username to handle both formats properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
