### PR TITLE
Adding regenerator-runtime to fix unit tests

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/package.json
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/package.json
@@ -74,7 +74,8 @@
     "typescript": "^3.7.5",
     "webpack": "4.41.2",
     "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2"
+    "enzyme-adapter-react-16": "^1.15.2",
+    "regenerator-runtime": "^0.13.5"
   },
   "scripts": {
     "test": "NODE_ENV=test jest --config jest.config.js --passWithNoTests",

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/setup-tests.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/setup-tests.js
@@ -13,7 +13,6 @@
  *  permissions and limitations under the License.
  */
 
-/* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { configure } from 'enzyme';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,7 @@ importers:
       jest-junit: 10.0.0
       prettier: 1.19.1
       pretty-quick: 1.11.1_prettier@1.19.1
+      regenerator-runtime: 0.13.5
       serverless: 1.67.3
       serverless-deployment-bucket: 1.1.1
       typescript: 3.8.3
@@ -166,6 +167,7 @@ importers:
       react-syntax-highlighter: ^11.0.2
       react-table: ^6.11.5
       react-timeago: ^4.4.0
+      regenerator-runtime: ^0.13.5
       request: ^2.34
       semantic-ui-react: ^0.88.2
       serverless: ^1.63.0


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Sanket reported that the CI/CD pipeline was failing to run the unit tests. Looks like I was missing to add regenerator-runtime as a dev dependency on the base-raas-ui package. With this change, the ./scripts/run-unit-tests.sh script does not fail anymore. I have tested with a clean clone of the repository to verify it works. 

For reference, regenerator-runtime is needed to test React components with Jest and Babel: https://jestjs.io/docs/en/22.x/getting-started.html. I verified that regenerator-runtime has an MIT license and is safe to include. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
