### PR TITLE
GALI-288: Bug Fix. Added validation for awsAccountId on index creation

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddIndexForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddIndexForm.js
@@ -23,6 +23,7 @@ const addIndexFormFields = {
   },
   awsAccountId: {
     label: 'AWS Account ID',
+    rules: 'required|string',
   },
   description: {
     label: 'Description',

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AddIndex.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AddIndex.js
@@ -26,7 +26,7 @@ import validate from '@aws-ee/base-ui/dist/models/forms/Validate';
 
 import { getAddIndexForm, getAddIndexFormFields } from '../../models/forms/AddIndexForm';
 
-class AddIndex extends React.Component {
+export class AddIndex extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -175,6 +175,7 @@ class AddIndex extends React.Component {
     this.formProcessing = true;
     try {
       // Perform client side validations first
+      this.index.awsAccountId = this.state.awsAccountId;
       const validationResult = await validate(this.index, this.addIndexFormFields);
       // if there are any client side validation errors then do not attempt to make API call
       if (validationResult.fails()) {
@@ -184,7 +185,6 @@ class AddIndex extends React.Component {
         });
       } else {
         // There are no client side validation errors so ask the store to add user (which will make API call to server to add the user)
-        this.index.awsAccountId = this.state.awsAccountId;
         await this.props.indexesStore.addIndex(this.index);
         runInAction(() => {
           this.formProcessing = false;

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddIndex.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddIndex.test.js
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { AddIndex } from '../AddIndex';
+
+const usersStore = {
+  asDropDownOptions: () => [
+    {
+      key: 'userABC',
+      value: 'userABC',
+      text: 'Dr. John Doe',
+    },
+  ],
+};
+
+const awsAccountsStore = {
+  dropdownOptions: [
+    {
+      key: '1',
+      value: '123',
+      text: 'Index 123',
+    },
+  ],
+};
+
+const indexesStore = {
+  addIndex: jest.fn(),
+};
+
+describe('AddIndex', () => {
+  let component = null;
+  let wrapper = null;
+  beforeEach(() => {
+    // Render AddIndex component
+    wrapper = shallow(
+      <AddIndex indexesStore={indexesStore} usersStore={usersStore} awsAccountsStore={awsAccountsStore} />,
+    );
+
+    // Get instance of the component
+    component = wrapper.instance();
+
+    // Mock goto function
+    component.goto = jest.fn();
+  });
+
+  it('should give an error if accountId is not present', async () => {
+    // Set index attributes, except awsAccountId
+    component.index.id = 'index-123';
+    component.index.description = 'Some relevant description';
+
+    // Submit form
+    await component.handleSubmit();
+
+    // Verify an error is displayed
+    const errors = component.validationErrors.errors;
+    expect(errors.awsAccountId).toBeDefined();
+    expect(errors.awsAccountId).toContain('The awsAccountId field is required.');
+  });
+
+  it('should not give an error if accountId is provided', async () => {
+    // Set index attributes
+    component.index.id = 'index-123';
+    component.index.description = 'Some relevant description';
+
+    // Also set indexId, which is in the component state for some reason
+    wrapper.setState({ awsAccountId: 'abc' });
+
+    // Submit form
+    await component.handleSubmit();
+
+    // Verify addIndex gets invoked
+    expect(component.validationErrors.errors).not.toBeDefined();
+    expect(indexesStore.addIndex).toHaveBeenCalled();
+    expect(component.goto).toHaveBeenCalledWith('/accounts');
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/indexes/__tests__/indexes-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/indexes/__tests__/indexes-service.test.js
@@ -1,0 +1,75 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+
+jest.mock('@aws-ee/base-services/lib/authorization/authorization-service');
+const AuthServiceMock = require('@aws-ee/base-services/lib/authorization/authorization-service');
+
+jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
+const AuditServiceMock = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+const IndexesService = require('../indexes-service');
+
+describe('IndexesService', () => {
+  let service = null;
+  beforeEach(async () => {
+    // Initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('indexesService', new IndexesService());
+    container.register('authorizationService', new AuthServiceMock());
+    container.register('dbService', new DbServiceMock());
+    container.register('auditWriterService', new AuditServiceMock());
+    container.register('settings', new SettingsServiceMock());
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('indexesService');
+  });
+
+  describe('create', () => {
+    it('should fail if awsAccountId is empty', async () => {
+      const index = {
+        id: 'index-123',
+        description: 'Some relevant description',
+        awsAccountId: '', // empty awsAccountId should cause error
+      };
+
+      // Skip authorization
+      service.assertAuthorized = jest.fn();
+
+      try {
+        await service.create({}, index);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.payload).toBeDefined();
+        const error = err.payload.validationErrors[0];
+        expect(error).toMatchObject({
+          keyword: 'minLength',
+          dataPath: '.awsAccountId',
+          message: 'should NOT be shorter than 1 characters',
+        });
+      }
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-indexes.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-indexes.json
@@ -10,7 +10,8 @@
       "pattern": "^[A-Za-z0-9-_]+$"
     },
     "awsAccountId": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "description": {
       "type": "string"


### PR DESCRIPTION
Issue #, if available: GALI-288

Description of changes:
Page crash when adding index without associated AWS account. This PR adds validation on the frontend React form and the backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
