### PR TITLE
addon-base-raas/.../user-service.js unit test set

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
@@ -47,6 +47,29 @@ describe('UserService', () => {
     service = await container.find('userService');
   });
 
+  describe('create a non-existing user', () => {
+    it('should call createUser', async () => {
+      const user = {
+        email: 'example@amazon.com',
+      };
+
+      // Skip authorization
+      service.assertAuthorized = jest.fn();
+
+      // mocked functions
+      service.toUserType = jest.fn(() => {
+        return { userType: 'root' };
+      });
+      service.findUser = jest.fn(() => {
+        return null;
+      });
+      service.createUser = jest.fn();
+
+      await service.createUsers({}, [user], 'internal');
+      expect(service.createUser).toHaveBeenCalled();
+    });
+  });
+
   describe('create an existing user', () => {
     it('should fail due because the user already exists', async () => {
       const user = {
@@ -73,29 +96,6 @@ describe('UserService', () => {
         const error = err.payload[0];
         expect(error).toEqual('Error creating user example@amazon.com. Cannot add user. The user already exists.');
       }
-    });
-  });
-
-  describe('create a non-existing user', () => {
-    it('should call createUser', async () => {
-      const user = {
-        email: 'example@amazon.com',
-      };
-
-      // Skip authorization
-      service.assertAuthorized = jest.fn();
-
-      // mocked functions
-      service.toUserType = jest.fn(() => {
-        return { userType: 'root' };
-      });
-      service.findUser = jest.fn(() => {
-        return null;
-      });
-      service.createUser = jest.fn();
-
-      await service.createUsers({}, [user], 'internal');
-      expect(service.createUser).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Added unit test set for `addon-base-raas/packages/base-raas-services/lib/user/user-service.js`. 
Unit tests:
- create a user (should succeed)
- try to create a user that already exists (should fail)
- try to create a user with the same email as existing user, but different credentials (should fail)
- try to create a user with inadequate permissions (should fail)
- try to create multiple users with one call (should succeed)

If there are any other unit tests that should be added, please let me know. I did not include tests for `listUsers`, since this method essentially just wraps the inherited method from `addon-base/.../user-service.js`. Unit tests for this service will be added soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
