### PR TITLE
Testing react components without export

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AddIndex.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AddIndex.js
@@ -26,7 +26,7 @@ import validate from '@aws-ee/base-ui/dist/models/forms/Validate';
 
 import { getAddIndexForm, getAddIndexFormFields } from '../../models/forms/AddIndexForm';
 
-export class AddIndex extends React.Component {
+class AddIndex extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddIndex.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddIndex.test.js
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { AddIndex } from '../AddIndex';
+import AddIndex from '../AddIndex';
 
 const usersStore = {
   asDropDownOptions: () => [
@@ -47,7 +47,11 @@ describe('AddIndex', () => {
   beforeEach(() => {
     // Render AddIndex component
     wrapper = shallow(
-      <AddIndex indexesStore={indexesStore} usersStore={usersStore} awsAccountsStore={awsAccountsStore} />,
+      <AddIndex.WrappedComponent
+        indexesStore={indexesStore}
+        usersStore={usersStore}
+        awsAccountsStore={awsAccountsStore}
+      />,
     );
 
     // Get instance of the component

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/projects/AddProject.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/projects/AddProject.js
@@ -26,7 +26,7 @@ import validate from '@aws-ee/base-ui/dist/models/forms/Validate';
 
 import { getAddProjectForm, getAddProjectFormFields } from '../../models/forms/AddProjectForm';
 
-export class AddProject extends React.Component {
+class AddProject extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/projects/__tests__/AddProject.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/projects/__tests__/AddProject.test.js
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { AddProject } from '../AddProject';
+import AddProject from '../AddProject';
 
 const usersStore = {
   asDropDownOptions: () => [
@@ -46,7 +46,9 @@ describe('AddProject', () => {
   let wrapper = null;
   beforeEach(() => {
     // Render AddProject component
-    wrapper = shallow(<AddProject indexesStore={indexesStore} usersStore={usersStore} projectsStore={projectsStore} />);
+    wrapper = shallow(
+      <AddProject.WrappedComponent indexesStore={indexesStore} projectsStore={projectsStore} usersStore={usersStore} />,
+    );
 
     // Get instance of the component
     component = wrapper.instance();


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Removing the need to `export` the raw Component before the mobx wrappers. I figured out how to test it with enzyme without needing to do that. This removes the risk of someone importing the raw component.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
