### PR TITLE
Stared work on aws-accounts-service unit tests and refactored DbService mock.

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
@@ -1,0 +1,117 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+
+jest.mock('@aws-ee/base-services/lib/authorization/authorization-service');
+const AuthServiceMock = require('@aws-ee/base-services/lib/authorization/authorization-service');
+
+jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
+const AuditServiceMock = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+jest.mock('@aws-ee/base-services/lib/lock/lock-service');
+const LockServiceMock = require('@aws-ee/base-services/lib/lock/lock-service');
+
+jest.mock('@aws-ee/base-services/lib/s3-service');
+const S3ServiceMock = require('@aws-ee/base-services/lib/s3-service');
+
+const AwsAccountService = require('../aws-accounts-service');
+
+describe('AwsAccountService', () => {
+  let service = null;
+  let dbService = null;
+  beforeAll(async () => {
+    // Initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('authorizationService', new AuthServiceMock());
+    container.register('dbService', new DbServiceMock());
+    container.register('auditWriterService', new AuditServiceMock());
+    container.register('settings', new SettingsServiceMock());
+    container.register('lockService', new LockServiceMock());
+    container.register('s3Service', new S3ServiceMock());
+    container.register('awsAccountService', new AwsAccountService());
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('awsAccountService');
+    dbService = await container.find('dbService');
+  });
+
+  describe('find', () => {
+    it('should return undefined for external guests', async () => {
+      // BUILD
+      const requestContext = { principal: { userRole: 'guest' } };
+      const params = { id: '123', fields: [] };
+      // OPERATE
+      const response = await service.find(requestContext, params);
+      // CHECK
+      expect(response).toBe(undefined);
+    });
+
+    it('should return undefined for external researchers', async () => {
+      // BUILD
+      const requestContext = { principal: { userRole: 'external-researcher' } };
+      const params = { id: '123', fields: [] };
+      // OPERATE
+      const response = await service.find(requestContext, params);
+      // CHECK
+      expect(response).toBe(undefined);
+    });
+
+    it('should return undefined for internal guests', async () => {
+      // BUILD
+      const requestContext = { principal: { userRole: 'internal-guest' } };
+      const params = { id: '123', fields: [] };
+      // OPERATE
+      const response = await service.find(requestContext, params);
+      // CHECK
+      expect(response).toBe(undefined);
+    });
+
+    it('should return an aws account record successfully', async () => {
+      // BUILD
+      const requestContext = { principal: { userRole: 'admin' } };
+      const params = { id: '123', fields: ['accountId', 'description'] };
+
+      // Mock response from a get() to dynamodb
+      dbService.table.get.mockReturnValue({
+        id: '123',
+        accountId: '01234567890',
+        description: 'Research account',
+      });
+
+      // OPERATE
+      const response = await service.find(requestContext, params);
+
+      // CHECK
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: '123' });
+      expect(dbService.table.projection).toHaveBeenCalledWith(['accountId', 'description']);
+      expect(response).toMatchObject({
+        id: '123',
+        accountId: '01234567890',
+        description: 'Research account',
+      });
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
@@ -32,6 +32,7 @@ const ProjectService = require('../project-service');
 
 describe('ProjectService', () => {
   let service = null;
+  let dbService = null;
   beforeAll(async () => {
     // Initialize services container and register dependencies
     const container = new ServicesContainer();
@@ -45,6 +46,7 @@ describe('ProjectService', () => {
 
     // Get instance of the service we are testing
     service = await container.find('projectService');
+    dbService = await container.find('dbService');
 
     // Skip authorization
     service.assertAuthorized = jest.fn();
@@ -178,16 +180,13 @@ describe('ProjectService', () => {
 
   describe('delete', () => {
     it('should NOT fail if an environment is not linked to project', async () => {
-      // 'Test_ID' id is present on the db-service manual mock file.
-      // Using that as a project ID reference for delete
-      // Happy-path: Make sure no exceptions are thrown
+      dbService.table.scan.mockReturnValueOnce([{ id: 'Test_ID' }]);
       await expect(() => service.delete({}, { id: 'Not_Test_ID' })).not.toThrow(); // Different that 'Test_ID'
     });
 
     it('should fail if an environment is linked to project', async () => {
       try {
-        // 'Test_ID' id is present on the db-service manual mock file.
-        // Using that as a project ID reference for delete
+        dbService.table.scan.mockReturnValueOnce([{ id: 'Test_ID' }]);
         await service.delete({}, { id: 'Test_ID' });
         expect.hasAssertions();
       } catch (err) {

--- a/addons/addon-base/packages/services/lib/__mocks__/db-service.js
+++ b/addons/addon-base/packages/services/lib/__mocks__/db-service.js
@@ -18,45 +18,52 @@ const Service = require('@aws-ee/base-services-container/lib/service');
 class DbService extends Service {
   async init() {
     this.client = {};
-    const scan = jest.fn(() => [
-      {
-        id: 'Test_ID',
-      },
-    ]);
-    const table = jest.fn(() => ({
-      scan,
-    }));
 
-    // pass an object with id: testFAIL to make this method fail
-    // otherwise it mocks a completed function
-    const keyFn = ipt => {
-      const error = { code: 'ConditionalCheckFailedException' };
-      if (ipt.id === 'testFAIL') {
-        throw error;
-      } else {
-        return {
-          rev: jest.fn().mockReturnThis(),
-          delete: jest.fn().mockReturnThis(),
-          item: jest.fn(() => ({
-            update: jest.fn(),
-          })),
-        };
-      }
+    // DynamoDB table mock. It matches the functions that
+    // a dynamodb table client offers (scan, get, key, etc).
+
+    /**
+     * Examples of how to use dbService in unit tests. To mock
+     * the response of the typical calls to update, get, scan, etc:
+     *
+     * dbService.table.scan.mockReturnValueOnce([{ id: 'Test_ID' }]);
+     *
+     * or mock that an exception is thrown
+     *
+     * dbService.table.delete.mockImplementationOnce(() => {
+     *  throw error
+     * });
+     *
+     * or assert that an update is invoked with the correct key/id
+     *
+     * expect(dbService.table.key).toHaveBeenCalledWith({ id: '123'; });
+     *
+     * Notice the use of mockImplementationOnce() and mockReturnValueOnce(),
+     * it's very important to mock it `Once` so that subsequent tests do
+     * not adopt the mock behavior of the last test that used the dbService.
+     */
+    this.table = {
+      // Following functions use builder pattern to enhance request
+      key: jest.fn().mockReturnThis(),
+      projection: jest.fn().mockReturnThis(),
+      rev: jest.fn().mockReturnThis(),
+      item: jest.fn().mockReturnThis(),
+      condition: jest.fn().mockReturnThis(),
+      // Following functions are actual calls to dynamo
+      scan: jest.fn(),
+      get: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
     };
 
-    const testRetVal = jest.fn(() => ({
-      condition: jest.fn(() => ({
-        key: jest.fn(keyFn),
-      })),
-    }));
-
+    const tableFn = jest.fn().mockReturnValue(this.table);
     this.helper = {
       unmarshal: {},
-      scanner: jest.fn(() => ({ table })),
-      updater: jest.fn(() => ({ table: testRetVal })),
-      getter: jest.fn(() => ({ table })),
-      query: jest.fn(() => ({ table })),
-      deleter: jest.fn(() => ({ table: testRetVal })),
+      scanner: jest.fn().mockReturnValue({ table: tableFn }),
+      updater: jest.fn().mockReturnValue({ table: tableFn }),
+      getter: jest.fn().mockReturnValue({ table: tableFn }),
+      query: jest.fn().mockReturnValue({ table: tableFn }),
+      deleter: jest.fn().mockReturnValue({ table: tableFn }),
     };
   }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
I wanted to submit this pull request sooner rather than later to share the new DbService mock. I feel that is much easier and natural to mock now. You can now mock on your unit tests the responses of the typical calls to `scan`, `update`, `delete`, etc, like so: 

```js
dbService.table.scan.mockReturnValueOnce([{ id: 'Test_ID' }]);
```

or mock delete throwing an exception:

```js
dbService.table.delete.mockImplementationOnce(() => {
   throw error;
});
```

or assert that `update` is invoked with the correct id:

```js
expect(dbService.table.key).toHaveBeenCalledWith({ id: '123'; });
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
