### PR TITLE
[Unit Tests] account-service, indexes-service, refactors

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/account/__tests__/account-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/account/__tests__/account-service.test.js
@@ -1,0 +1,226 @@
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+
+jest.mock('@aws-ee/base-services/lib/authorization/authorization-service');
+const AuthServiceMock = require('@aws-ee/base-services/lib/authorization/authorization-service');
+
+jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
+const AuditServiceMock = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+
+jest.mock('@aws-ee/base-services/lib/aws/aws-service');
+const AWSMock = require('@aws-ee/base-services/lib/aws/aws-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+jest.mock('../../../../../../addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-trigger-service');
+const WorkflowTriggerServiceMock = require('../../../../../../addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-trigger-service');
+
+const AccountService = require('../account-service');
+
+// Tested Methods: provisionAccount, update, delete
+describe('accountService', () => {
+  let service = null;
+  let dbService = null;
+  let wfService = null;
+  const error = { code: 'ConditionalCheckFailedException' };
+  beforeAll(async () => {
+    const container = new ServicesContainer();
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('dbService', new DbServiceMock());
+    container.register('authorizationService', new AuthServiceMock());
+    container.register('auditWriterService', new AuditServiceMock());
+    container.register('aws', new AWSMock());
+    container.register('workflowTriggerService', new WorkflowTriggerServiceMock());
+    container.register('settings', new SettingsServiceMock());
+    container.register('accountService', new AccountService());
+    await container.initServices();
+
+    service = await container.find('accountService');
+    dbService = await container.find('dbService');
+    wfService = await container.find('workflowTriggerService');
+    service.assertAuthorized = jest.fn();
+  });
+
+  describe('provisionAccount tests', () => {
+    it('should fail to create account with no credentials', async () => {
+      // BUILD
+      // OPERATE
+      try {
+        await service.provisionAccount({}, {});
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail to create account with partial credentials', async () => {
+      // BUILD
+      const dataMissing = {
+        accountName: 'Winston Bishop',
+        accountEmail: 'beanbagchair@example.com',
+        masterRoleArn: '',
+        externalId: '',
+        description: '',
+      };
+
+      // OPERATE
+      try {
+        await service.provisionAccount({}, dataMissing);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual(
+          'Creating AWS account process has not been correctly configured: missing AWS account ID, VPC ID and VPC Subnet ID.',
+        );
+      }
+    });
+
+    it('should successfully try to provision an account with full credentials', async () => {
+      // BUILD
+      const iptData = {
+        accountName: "Who's that girl?",
+        accountEmail: 'itsjest@example.com',
+        masterRoleArn: 'reagan :/',
+        externalId: '837 Traction Ave',
+        description: 'A classic nodejs-lodash mess-around',
+      };
+      service.audit = jest.fn();
+      wfService.triggerWorkflow = jest.fn();
+
+      // OPERATE
+      await service.provisionAccount({}, iptData);
+
+      // CHECK
+      expect(wfService.triggerWorkflow).toHaveBeenCalledWith(
+        {},
+        {
+          workflowId: 'wf-provision-account',
+        },
+        expect.objectContaining(iptData),
+      );
+      expect(service.audit).toHaveBeenCalledWith(
+        {},
+        {
+          action: 'provision-account',
+          body: {
+            accountName: "Who's that girl?",
+            accountEmail: 'itsjest@example.com',
+            description: 'A classic nodejs-lodash mess-around',
+          },
+        },
+      );
+    });
+  });
+
+  describe('update tests', () => {
+    it('should fail if no id is provided', async () => {
+      // BUILD
+      const acct = {
+        stackId: 'example-stack-id',
+      };
+      // OPERATE
+      try {
+        await service.update({}, acct);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail because the account does not exist', async () => {
+      // BUILD
+      service.find = jest.fn().mockResolvedValue(undefined);
+      try {
+        // OPERATE
+        await service.update({}, { id: 'Spencer' });
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'notFound')).toBe(true);
+      }
+    });
+
+    it('should should fail to find the environment id', async () => {
+      // BUILD
+      const existingAcct = {
+        id: 'testFAIL',
+      };
+      const iptData = {
+        id: 'testFAIL',
+      };
+
+      dbService.table.update.mockImplementationOnce(() => {
+        throw error;
+      });
+      service.mustFind = jest.fn().mockResolvedValue(existingAcct);
+
+      try {
+        await service.update({}, iptData);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('environment with id "testFAIL" does not exist');
+      }
+    });
+
+    it('should successfully try to update the account', async () => {
+      // BUILD
+      const existingAcct = {
+        id: 'schmidt',
+      };
+      const iptData = {
+        id: 'bishop',
+      };
+      service.mustFind = jest.fn().mockResolvedValue(existingAcct);
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.update({}, iptData);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        {},
+        {
+          action: 'update-account',
+          body: iptData,
+        },
+      );
+    });
+  });
+
+  describe('delete tests', () => {
+    it('should fail because the id does not exist', async () => {
+      // BUILD
+      dbService.table.delete.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // OPERATE
+      try {
+        await service.delete({}, { id: 'testFAIL' });
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'notFound')).toBe(true);
+      }
+    });
+
+    it('should succeed to delete the account', async () => {
+      // BUILD
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.delete({}, { id: 'testSUCCEED' });
+
+      // CHECK
+      expect(dbService.table.delete).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'delete-account', body: { id: 'testSUCCEED' } });
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/indexes/__tests__/indexes-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/indexes/__tests__/indexes-service.test.js
@@ -30,8 +30,11 @@ jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
 const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
 const IndexesService = require('../indexes-service');
 
+// Tested Functions: create, update, delete
 describe('IndexesService', () => {
   let service = null;
+  let dbService = null;
+  const error = { code: 'ConditionalCheckFailedException' };
   beforeEach(async () => {
     // Initialize services container and register dependencies
     const container = new ServicesContainer();
@@ -45,31 +48,218 @@ describe('IndexesService', () => {
 
     // Get instance of the service we are testing
     service = await container.find('indexesService');
+    dbService = await container.find('dbService');
+
+    // Skip authorization
+    service.assertAuthorized = jest.fn();
   });
 
   describe('create', () => {
     it('should fail if awsAccountId is empty', async () => {
+      // BUILD
+
       const index = {
         id: 'index-123',
         description: 'Some relevant description',
         awsAccountId: '', // empty awsAccountId should cause error
       };
 
-      // Skip authorization
-      service.assertAuthorized = jest.fn();
-
+      // OPERATE
       try {
         await service.create({}, index);
         expect.hasAssertions();
       } catch (err) {
         expect(err.payload).toBeDefined();
-        const error = err.payload.validationErrors[0];
-        expect(error).toMatchObject({
+        const thrownError = err.payload.validationErrors[0];
+        // CHECK
+        expect(thrownError).toMatchObject({
           keyword: 'minLength',
           dataPath: '.awsAccountId',
           message: 'should NOT be shorter than 1 characters',
         });
       }
+    });
+
+    it('should fail if the id already exists', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-8675309',
+        description: 'is Jenny there?',
+        awsAccountId: 'example-ttutone-81',
+      };
+
+      dbService.table.update.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // OPERATE
+      try {
+        await service.create({}, index);
+        expect.toHaveAssertions();
+      } catch (err) {
+        // VERIFY
+        expect(err.message).toEqual('indexes with id "id-8675309" already exists');
+      }
+    });
+
+    it('should succeed if the input is valid and the id does not exist', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-1985',
+        description: 'U2 and Blondie',
+        awsAccountId: 'example-BFS-04',
+      };
+
+      dbService.table.update.mockReturnValueOnce({ id: 'id-1985' });
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.create({}, index);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'create-index', body: { id: 'id-1985' } });
+    });
+  });
+
+  describe('update', () => {
+    it('should fail if id does not exist', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-slipp-when-wet',
+        description: 'halfway there',
+        awsAccountId: 'example-JBJ-86',
+        rev: 1,
+      };
+
+      dbService.table.update.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      service.find = jest.fn().mockResolvedValue(null);
+
+      // OPERATE
+      try {
+        await service.update({}, index);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('indexes with id "id-slipp-when-wet" does not exist');
+      }
+    });
+
+    it('should fail if id has already been updated', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-slipp-when-wet',
+        description: 'd or a',
+        awsAccountId: 'example-JBJ-87',
+        rev: 1,
+      };
+
+      dbService.table.update.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      service.find = jest.fn().mockResolvedValue({ updatedBy: { username: 'alreadyChanged' } });
+
+      // OPERATE
+      try {
+        await service.update({}, index);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual(
+          'indexes information changed by "alreadyChanged" just before your request is processed, please try again',
+        );
+      }
+    });
+
+    it('should succeed if the input is valid and the id does not exist', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-DSB',
+        description: 'a smokey room',
+        awsAccountId: 'example-JOUR-81',
+        rev: 1,
+      };
+
+      dbService.table.update.mockReturnValueOnce({ id: 'id-DSB' });
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.update({}, index);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'update-index', body: { id: 'id-DSB' } });
+    });
+
+    it('should fail if no value for rev is provided', async () => {
+      // BUILD
+      const index = {
+        id: 'id-BYM',
+        description: 'those eyes!',
+        awsAccountId: 'example-VM-67',
+      };
+      // OPERATE
+      try {
+        await service.update({}, index);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+  });
+
+  describe('delete', () => {
+    it('should fail if id does not exist', async () => {
+      // BUILD
+
+      const index = {
+        id: 'id-ROCK-3',
+        description: 'the last known survivor',
+        awsAccountId: 'example-SURV-82',
+      };
+
+      dbService.table.delete.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      // OPERATE
+      try {
+        await service.delete({}, index);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('indexes with id "id-ROCK-3" does not exist');
+      }
+    });
+
+    it('should succeed if the input is valid and the id does not exist', async () => {
+      // BUILD
+
+      const index = {
+        id: 'index-BAD',
+        description: 'smooth',
+        awsAccountId: 'example-MJ-88',
+      };
+
+      dbService.table.update.mockReturnValueOnce({ id: 'index-BAD' });
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.delete({}, index);
+
+      // CHECK
+      expect(dbService.table.delete).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'delete-index', body: { id: 'index-BAD' } });
     });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user-roles/__tests__/user-roles-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user-roles/__tests__/user-roles-service.test.js
@@ -1,7 +1,5 @@
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
-
-jest.mock('@aws-ee/base-services/lib/json-schema-validation-service');
-const JsonSchemaValidationServiceMock = require('@aws-ee/base-services/lib/json-schema-validation-service');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 
 // Mocked dependencies
 jest.mock('@aws-ee/base-services/lib/db-service');
@@ -24,7 +22,7 @@ describe('UserRolesService', () => {
   let dbService = null;
   beforeAll(async () => {
     const container = new ServicesContainer();
-    container.register('jsonSchemaValidationService', new JsonSchemaValidationServiceMock());
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
     container.register('dbService', new DbServiceMock());
     container.register('authorizationService', new AuthServiceMock());
     container.register('auditWriterService', new AuditServiceMock());
@@ -42,14 +40,26 @@ describe('UserRolesService', () => {
   // create() currently assumes 'updatedBy' is always a user (see line 74 / 114)
   // if/when that is changed, we will need another unit test
   describe('create test', () => {
-    it('should successfully log an audit event saying a user role was created', async () => {
+    it('should fail if no id is provided', async () => {
+      const roleToCreate = {
+        description: 'this is gonna be great!',
+        userType: 'EXTERNAL',
+      };
+
+      try {
+        await service.create({}, roleToCreate);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should successfully try to create a user role', async () => {
       // BUILD
       const roleToCreate = {
-        properties: {
-          id: 'Murasaki Shikibu',
-          description: 'Hikaru Genji no inochi monogatari desu',
-          userType: 'internal',
-        },
+        id: 'Murasaki Shikibu',
+        description: 'Hikaru Genji no inochi monogatari desu',
+        userType: 'INTERNAL',
       };
 
       service.audit = jest.fn();
@@ -58,12 +68,14 @@ describe('UserRolesService', () => {
       await service.create({}, roleToCreate);
 
       // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
       expect(service.audit).toHaveBeenCalledWith({}, { action: 'create-user-role', body: undefined });
     });
 
     it('should fail because the id already exists', async () => {
       const roleToCreate = {
         id: 'testFAIL',
+        userType: 'INTERNAL',
       };
 
       // Mock dynamodb throwing an error because item.id already exists
@@ -95,7 +107,8 @@ describe('UserRolesService', () => {
 
       const datum = {
         id: 'yasakani no magatama',
-        rev: 'yata no kagami',
+        rev: 1,
+        userType: 'INTERNAL',
       };
 
       service.audit = jest.fn();
@@ -104,6 +117,7 @@ describe('UserRolesService', () => {
       await service.update(context, datum);
 
       // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
       expect(service.audit).toHaveBeenCalledWith(context, { action: 'update-user-role', body: undefined });
     });
 
@@ -111,7 +125,8 @@ describe('UserRolesService', () => {
       // BUILD
       const datum = {
         id: 'testFAIL',
-        rev: 'kusanagi no tsurugi',
+        rev: 1,
+        userType: 'EXTERNAL',
       };
       service.find = jest.fn().mockResolvedValue(undefined);
 
@@ -135,7 +150,8 @@ describe('UserRolesService', () => {
       // BUILD
       const datum = {
         id: 'testFAIL',
-        rev: 'v1',
+        rev: 1,
+        userType: 'INTERNAL',
       };
 
       // Mock dynamodb throwing an error because revision has already been updated
@@ -152,10 +168,26 @@ describe('UserRolesService', () => {
         expect.hasAssertions();
       } catch (err) {
         // CHECK
-        expect(dbService.table.rev).toHaveBeenCalledWith('v1');
+        expect(dbService.table.rev).toHaveBeenCalledWith(1);
         expect(err.message).toEqual(
           'userRoles information changed by "tsukuyomi" just before your request is processed, please try again',
         );
+      }
+    });
+
+    it('should fail because no value for rev was provided', async () => {
+      // BUILD
+      const ipt = {
+        id: 'testFAIL',
+        userType: 'INTERNAL',
+      };
+
+      // OPERATE
+      try {
+        await service.update({}, ipt);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('Input has validation errors');
       }
     });
   });


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- added unit tests for indexes-service
- added unit tests for account-service
- refactored old unit tests
- added json schema validation tests to applicable test sets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
