### PR TITLE
removing params restriction for env search

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-service.js
@@ -609,6 +609,7 @@ class EnvironmentService extends Service {
     // the specified environment
     const { status, indexId } = await this.mustFind(requestContext, {
       id,
+      fields: ['status', 'indexId', 'createdBy', 'projectId', 'sharedWithUsers'],
     });
 
     if (status !== 'COMPLETED') {


### PR DESCRIPTION
Issue #, if available:
https://sim.amazon.com/issues/GALI-307

Description of changes:
Environment authorization was being carried out with incomplete parameters, thereby denying environment access to project admins and shared users. This fix does not restrict environment fields during authorization evaluation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
