### PR TITLE
bugfix - internal non-production user password

### DIFF
--- a/addons/addon-base/packages/services/lib/user/user-service.js
+++ b/addons/addon-base/packages/services/lib/user/user-service.js
@@ -56,6 +56,7 @@ class UserService extends Service {
     await this.validateCreateUser(requestContext, user);
 
     const { username, password } = user;
+    delete user.password;
     const authenticationProviderId = user.authenticationProviderId || 'internal';
     if (password) {
       // If password is specified then make sure this is for adding user to internal authentication provider only
@@ -93,12 +94,17 @@ class UserService extends Service {
         .updater()
         .table(table)
         .key({ username, ns })
-        .item({
-          ...user,
-          authenticationProviderId,
-          rev: 0,
-          createdBy: by,
-        })
+        .item(
+          _.omit(
+            {
+              ...user,
+              authenticationProviderId,
+              rev: 0,
+              createdBy: by,
+            },
+            ['password'],
+          ),
+        )
         .update();
     }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Fix bug in user service where we store the “internal - non-production” users and their passwords in same table

Verified with creating new internal users 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
