### PR TITLE
Fix missing import encapsulation of PR Scalability improve

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/package.json
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/package.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-ee/base-workflow-core": "workspace:*",
+    "@aws-ee/base-services": "workspace:*",
     "lodash": "^4.17.15",
     "shortid": "^2.2.15",
     "slugify": "^1.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,7 @@ importers:
       xml: ^1.0.1
   addons/addon-base-raas/packages/base-raas-workflow-steps:
     dependencies:
+      '@aws-ee/base-services': 'link:../../../addon-base/packages/services'
       '@aws-ee/base-workflow-core': 'link:../../../addon-base-workflow/packages/base-workflow-core'
       lodash: 4.17.15
       shortid: 2.2.15
@@ -358,6 +359,7 @@ importers:
       pretty-quick: 1.11.1_prettier@1.19.1
       source-map-support: 0.5.16
     specifiers:
+      '@aws-ee/base-services': 'workspace:*'
       '@aws-ee/base-workflow-core': 'workspace:*'
       eslint: ^6.8.0
       eslint-config-airbnb: ^18.1.0
@@ -9577,7 +9579,6 @@ packages:
     resolution:
       integrity: sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==
   /fsevents/2.1.2:
-    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true


### PR DESCRIPTION
Issue #, if available:

I missed a building error that did not pop up locally after merging PR #64.

Description of changes:

I forgot to add the `base-services` addon import encapsulation in the `base-raas-workflow-steps/package.json` file... It's used to import the utility functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
