### PR TITLE
UI store tests, pt. 1

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/indexes/__tests__/IndexesStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/indexes/__tests__/IndexesStore.test.js
@@ -1,0 +1,74 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { IndexesStore } from '../IndexesStore';
+import { getIndexes, addIndex } from '../../../helpers/api';
+
+jest.mock('../../../helpers/api');
+
+describe('IndexesStore', () => {
+  let store = null;
+  const newIndex = {
+    id: 'gon_freecss',
+    rev: 2,
+    awsAccountId: 'aws-account-info',
+    description: 'whale island',
+    createdAt: '1999',
+    updatedAt: '2011',
+  };
+  describe('add index', () => {
+    it('should successfully add an index', async () => {
+      // BUILD
+      getIndexes.mockResolvedValue([]);
+      addIndex.mockResolvedValue(newIndex);
+      store = IndexesStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.addIndex(newIndex);
+
+      // CHECK
+      expect(store.list[0].id).toEqual(newIndex.id);
+    });
+  });
+
+  describe('get index', () => {
+    it('should get and return the specified index', async () => {
+      // BUILD
+      getIndexes.mockResolvedValue([newIndex]);
+      store = IndexesStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      const retVal = await store.getIndex(newIndex.id);
+
+      // CHECK
+      expect(retVal).toMatchObject(newIndex);
+    });
+
+    it('should return an empty object', async () => {
+      // BUILD
+      getIndexes.mockResolvedValue([newIndex]);
+      store = IndexesStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      const retVal = await store.getIndex('index_that_doesnt_exist');
+
+      // CHECK
+      expect(retVal).toMatchObject({});
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/__tests__/ProjectsStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/__tests__/ProjectsStore.test.js
@@ -1,0 +1,87 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { ProjectsStore } from '../ProjectsStore';
+
+import { getProjects, addProject, updateProject } from '../../../helpers/api';
+
+jest.mock('../../../helpers/api');
+
+describe('ProjectsStore', () => {
+  let store = null;
+  const newProject = {
+    id: 'aCreativeName!',
+    rev: 1,
+    description: 'simple description',
+    indexId: '10',
+    createdAt: 'now',
+    updatedAt: 'later',
+  };
+
+  const diffProject = {
+    id: 'anotherCreativeName',
+    rev: 1,
+    description: 'simple description',
+    indexId: '11',
+    createdAt: 'before',
+    updatedAt: 'after',
+  };
+
+  describe('add project', () => {
+    it('should add a project', async () => {
+      // BUILD
+      getProjects.mockResolvedValueOnce([]);
+      store = ProjectsStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.addProject(newProject);
+
+      // CHECK
+      expect(addProject).toHaveBeenCalledWith(newProject);
+    });
+
+    it('should not add the project because it already exists', async () => {
+      // BUILD
+      getProjects.mockResolvedValueOnce([diffProject]);
+      store = ProjectsStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.addProject(diffProject);
+
+      // CHECK
+      expect(addProject).not.toHaveBeenCalledWith(diffProject);
+    });
+  });
+
+  describe('update project', () => {
+    it('should try to add the updated function', async () => {
+      // BUILD
+      getProjects.mockResolvedValueOnce([newProject]);
+      store = ProjectsStore.create({}, {});
+      await store.load();
+
+      updateProject.mockResolvedValueOnce(diffProject);
+      store.addProject = jest.fn();
+
+      // OPERATE
+      await store.updateProject(diffProject);
+
+      // CHECK
+      expect(store.addProject).toHaveBeenCalledWith(diffProject);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/UsersStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/UsersStore.test.js
@@ -1,0 +1,118 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { addUser, updateUser, getUsers } from '@aws-ee/base-ui/dist/helpers/api';
+import { addUsers } from '../../../helpers/api';
+
+import { UsersStore } from '../UsersStore';
+
+jest.mock('@aws-ee/base-ui/dist/helpers/api');
+jest.mock('../../../helpers/api');
+
+describe('UsersStore', () => {
+  let store = null;
+  const exampleUser = {
+    firstName: 'Ash',
+    lastName: 'Ketchum',
+    username: 'satoshi',
+    ns: 'satoshi.025',
+  };
+
+  describe('adding users', () => {
+    it('should add a user', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([]);
+      addUser.mockResolvedValueOnce(exampleUser);
+      store = UsersStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.addUser(exampleUser);
+
+      // CHECK
+      // note we can't match the object because store.list[0] is just get/set methods
+      expect(store.list[0].firstName).toEqual(exampleUser.firstName);
+      expect(store.list[0].lastName).toEqual(exampleUser.lastName);
+    });
+
+    it('should add two users', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([]);
+      const otherUser = {
+        firstName: 'Gary',
+        lastName: 'Oak',
+        username: 'shigeru',
+        ns: 'shigeru.009',
+      };
+
+      addUser.mockResolvedValueOnce(exampleUser).mockResolvedValueOnce(otherUser);
+      addUsers.mockImplementation(async () => {
+        await store.addUser(exampleUser);
+        await store.addUser(otherUser);
+      });
+
+      store = UsersStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.addUsers([exampleUser, otherUser]);
+
+      // CHECK
+      expect(store.list[0].firstName).toEqual(exampleUser.firstName);
+      expect(store.list[0].lastName).toEqual(exampleUser.lastName);
+      expect(store.list[1].firstName).toEqual(otherUser.firstName);
+      expect(store.list[1].lastName).toEqual(otherUser.lastName);
+    });
+  });
+
+  describe('updating users', () => {
+    it('should update the user', async () => {
+      // BUILD
+      const updatedExampleUser = {
+        firstName: 'brock',
+        lastName: 'takeshi',
+        username: 'satoshi',
+        ns: 'satoshi.025',
+      };
+      getUsers.mockResolvedValueOnce([exampleUser]);
+      updateUser.mockResolvedValueOnce(updatedExampleUser);
+
+      store = UsersStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.updateUser(exampleUser);
+
+      // CHECK
+      expect(store.list[0].firstName).toEqual(updatedExampleUser.firstName);
+      expect(store.list[0].lastName).toEqual(updatedExampleUser.lastName);
+    });
+  });
+
+  describe('deleting users', () => {
+    it('should delete the user', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([exampleUser]);
+      store = UsersStore.create({}, {});
+      await store.load();
+
+      // OPERATE
+      await store.deleteUser(exampleUser);
+
+      // CHECK
+      expect(store.list.length).toEqual(0);
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/account/__tests__/account-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/account/__tests__/account-service.test.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-permission-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-permission-service.test.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 const AwsService = require('@aws-ee/base-services/lib/aws/aws-service');

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user-roles/__tests__/user-roles-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user-roles/__tests__/user-roles-service.test.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-authz-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-authz-service.test.js
@@ -1,3 +1,17 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const UserAuthzService = require('../user-authz-service');
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 const Logger = require('@aws-ee/base-services/lib/logger/logger-service');


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Added the following UI store tests:
     - UsersStore
     - ProjectsStore
     - IndexesStore

- Added License to old unit tests

Note that UI stores lack input validation, so sad-path testing is unfeasible. As a result, the majority of testing is happy-path verification. Sad-path testing will likely be added in integration test sets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
