### PR TITLE
Tests for update aws account

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-aws-accounts.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-aws-accounts.json
@@ -40,7 +40,11 @@
     "subnetId": {
       "type": "string",
       "pattern": "^subnet-[a-f0-9]{8,17}$"
+    },
+    "encryptionKeyArn": {
+      "type": "string",
+      "pattern": "^arn:aws:kms:.*$"
     }
   },
-  "required": ["id", "rev", "identityPoolId", "userRoleAccess", "roleArn", "externalId"]
+  "required": ["id", "rev", "roleArn", "externalId"]
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
I was missing tests for the update function in the aws-accounts service. I found that the json schema `update-aws-account.json` was incorrect. It was specifying `identityPoolId` and `userRoleAccess` as required attributes, but those attributes were not specified in the list of valid properties. It also specified `additionalProperties: false` which means that you cannot specify additional properties that are not listed in the valid properties. 

Long story short, it was impossible to provide a valid input because of the way the schema was written. I realized that this code has never been exercised probably because there is no way to Update an AWS Account from the Galileo UI. So, my guess is that this code never worked but nobody noticed because there was no UI to exercise it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
