### PR TITLE
UI Store Tests, pt. 2

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/accounts/__tests__/AccountsStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/accounts/__tests__/AccountsStore.test.js
@@ -1,0 +1,82 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { getAccounts, removeAccountInfo } from '../../../helpers/api';
+import { registerContextItems as registerAccountsStore } from '../AccountsStore';
+
+jest.mock('../../../helpers/api');
+
+describe('AccountsStore', () => {
+  let store = null;
+  const appContext = {};
+  const newAccount = {
+    id: 'mscott',
+    accountName: 'It all starts with an idea.',
+    accountArn: 'But you can never tell where an idea will end up.',
+    email: 'because-ideas-spread-they-change-they-grow@example.com',
+    name: 'They connect us with the world.',
+    createdAt: 'Limitless paper',
+    updatedAt: 'in a paperless world',
+    rev: 100,
+    status: 'COMPLETED',
+  };
+
+  beforeEach(async () => {
+    await registerAccountsStore(appContext);
+    store = appContext.accountsStore;
+  });
+
+  describe('addAccount', () => {
+    it('should add a account', async () => {
+      // BUILD
+      getAccounts.mockResolvedValueOnce([]);
+      await store.load();
+
+      // OPERATE
+      await store.addAccount(newAccount);
+
+      // CHECK
+      expect(store.list[0]).toMatchObject(newAccount);
+    });
+
+    it('should not add the project because it already exists', async () => {
+      // BUILD
+      getAccounts.mockResolvedValueOnce([newAccount]);
+      await store.load();
+
+      // OPERATE
+      await store.addAccount(newAccount);
+
+      // CHECK
+      expect(store.list.length).toBe(1);
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove the account', async () => {
+      // BUILD
+      getAccounts.mockResolvedValueOnce([newAccount]);
+      await store.load();
+
+      // OPERATE
+      await store.removeItem(newAccount.id);
+      // I'm not sure why the function is 'removeItem' and not 'deleteAccount'
+      // breaks the convention set by some of the others
+
+      // CHECK
+      expect(removeAccountInfo).toHaveBeenCalledWith(newAccount.id);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/aws-accounts/__tests__/AwsAccountsStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/aws-accounts/__tests__/AwsAccountsStore.test.js
@@ -1,0 +1,73 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { getAwsAccounts, addAwsAccount } from '../../../helpers/api';
+import { registerContextItems as registerAwsAccountsStore } from '../AwsAccountsStore';
+
+jest.mock('../../../helpers/api');
+
+describe('AwsAccountsStore', () => {
+  let store = null;
+  const appContext = {};
+  const newAwsAccount = {
+    id: 'mouserat',
+    rev: 5000,
+    name: 'candles-in-the-wind',
+    description: 'up in horsey heaven, heres the thing',
+    accountId: 'you_trade_your_legs_for_angels_wings',
+    externalId: 'and-once-weve-all-said-goodbye',
+    roleArn: 'YouTakeARunningLeapAndYouLearnToFly',
+    vpcId: 'and_although_we_all_miss_you_every_day',
+    subnetId: 'we-know-youre-up-there-eating-heavens-hay',
+    encryptionKeyArn: 'AndHeresThePartThatHurtsTheMost',
+    createdAt: 'humans cannot ride a ghost :(',
+    updatedAt: 'Bye bye, Lil Sebastian',
+  };
+
+  beforeEach(async () => {
+    await registerAwsAccountsStore(appContext);
+    store = appContext.awsAccountsStore;
+  });
+
+  describe('addAwsAccount', () => {
+    it('should add a new Aws Account successfully', async () => {
+      // BUILD
+      getAwsAccounts.mockResolvedValue([]);
+      addAwsAccount.mockResolvedValue(newAwsAccount);
+      await store.load();
+
+      // OPERATE
+      await store.addAwsAccount(newAwsAccount);
+
+      // CHECK
+      expect(newAwsAccount).toMatchObject(store.list[0]);
+      // some properties are dropped when added, so this makes sure store.list[0]
+      //      is a subset of newAwsAccount
+    });
+
+    it('should not add an Aws Account', async () => {
+      // BUILD
+      getAwsAccounts.mockResolvedValue([newAwsAccount]);
+      addAwsAccount.mockResolvedValue(newAwsAccount);
+      await store.load();
+
+      // OPERATE
+      await store.addAwsAccount(newAwsAccount);
+
+      // CHECK
+      expect(store.list.length).toBe(1);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/__tests__/EnvironmentsStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments/__tests__/EnvironmentsStore.test.js
@@ -1,0 +1,124 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { registerContextItems as registerEnvironmentsStore } from '../EnvironmentsStore';
+import { getEnvironments, deleteEnvironment, createEnvironment, getEnvironmentCost } from '../../../helpers/api';
+
+jest.mock('../../../helpers/api');
+
+describe('EnvironmentsStore', () => {
+  let internalStore = null;
+  const internalAppContext = {
+    userStore: {
+      user: {
+        username: 'd.grayson',
+        isExternalResearcher: false,
+      },
+    },
+    uiEventBus: {
+      fireEvent: jest.fn(),
+    },
+  };
+
+  const exampleCost = {
+    startDate: '01-01-1900',
+    cost: {
+      exampleCost: {
+        amount: 10,
+        unit: '$200',
+      },
+    },
+  };
+
+  let newEnv = null;
+
+  beforeEach(async () => {
+    registerEnvironmentsStore(internalAppContext);
+    internalStore = internalAppContext.environmentsStore;
+    newEnv = {
+      id: 'gotham_city',
+      rev: 1,
+      description: 'city of the (in)famous hero',
+      name: '',
+      status: 'COMPLETED',
+      indexId: 'env-id',
+      projectId: 'civic_city',
+      createdAt: '1941',
+      updatedAt: '2019',
+      costs: [exampleCost],
+      sharedWithUsers: [],
+      isExternal: false,
+    };
+  });
+
+  describe('createEnvironment', () => {
+    it('should successfully add the internal environment', async () => {
+      // BUILD
+
+      getEnvironments.mockResolvedValueOnce([]);
+      createEnvironment.mockResolvedValueOnce(newEnv);
+      await internalStore.load();
+
+      // OPERATE
+      const retVal = await internalStore.createEnvironment({ pin: '1581963' });
+
+      // CHECK
+      expect(retVal).toMatchObject(
+        expect.objectContaining({
+          id: newEnv.id,
+          description: newEnv.description,
+          projectId: newEnv.projectId,
+        }),
+      );
+
+      expect(internalStore.list.length).toEqual(1);
+    });
+    it('should not create a new internal environment since it already exists', async () => {
+      // BUILD
+      getEnvironments.mockResolvedValueOnce([newEnv]);
+      createEnvironment.mockResolvedValueOnce(newEnv);
+      getEnvironmentCost.mockResolvedValueOnce([exampleCost]);
+      await internalStore.load();
+
+      // OPERATE
+      const retVal = await internalStore.createEnvironment({ pin: '1581963' });
+
+      // CHECK
+      expect(retVal).toMatchObject(
+        expect.objectContaining({
+          id: newEnv.id,
+          description: newEnv.description,
+          projectId: newEnv.projectId,
+        }),
+      );
+      expect(internalStore.list.length).toBe(1);
+    });
+  });
+
+  describe('deleteEnvironment', () => {
+    it('should try to delete the environment', async () => {
+      // BUILD
+      getEnvironments.mockResolvedValueOnce([newEnv]);
+      getEnvironmentCost.mockResolvedValueOnce([exampleCost]);
+      await internalStore.load();
+
+      // OPERATE
+      internalStore.deleteEnvironment(newEnv, internalAppContext.userStore.user, '123456');
+
+      // CHECK
+      expect(deleteEnvironment).toHaveBeenCalledWith(internalStore.list[0].id);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/indexes/__tests__/IndexesStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/indexes/__tests__/IndexesStore.test.js
@@ -13,13 +13,14 @@
  *  permissions and limitations under the License.
  */
 
-import { IndexesStore } from '../IndexesStore';
+import { registerContextItems as registerIndexesStore } from '../IndexesStore';
 import { getIndexes, addIndex } from '../../../helpers/api';
 
 jest.mock('../../../helpers/api');
 
 describe('IndexesStore', () => {
   let store = null;
+  const appContext = {};
   const newIndex = {
     id: 'gon_freecss',
     rev: 2,
@@ -28,12 +29,17 @@ describe('IndexesStore', () => {
     createdAt: '1999',
     updatedAt: '2011',
   };
+
+  beforeEach(async () => {
+    await registerIndexesStore(appContext);
+    store = appContext.indexesStore;
+  });
+
   describe('add index', () => {
     it('should successfully add an index', async () => {
       // BUILD
       getIndexes.mockResolvedValue([]);
       addIndex.mockResolvedValue(newIndex);
-      store = IndexesStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -48,7 +54,6 @@ describe('IndexesStore', () => {
     it('should get and return the specified index', async () => {
       // BUILD
       getIndexes.mockResolvedValue([newIndex]);
-      store = IndexesStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -61,7 +66,6 @@ describe('IndexesStore', () => {
     it('should return an empty object', async () => {
       // BUILD
       getIndexes.mockResolvedValue([newIndex]);
-      store = IndexesStore.create({}, {});
       await store.load();
 
       // OPERATE

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/__tests__/ProjectsStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/__tests__/ProjectsStore.test.js
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-import { ProjectsStore } from '../ProjectsStore';
+import { registerContextItems as registerProjectsStore } from '../ProjectsStore';
 
 import { getProjects, addProject, updateProject } from '../../../helpers/api';
 
@@ -21,6 +21,7 @@ jest.mock('../../../helpers/api');
 
 describe('ProjectsStore', () => {
   let store = null;
+  const appContext = {};
   const newProject = {
     id: 'aCreativeName!',
     rev: 1,
@@ -39,11 +40,14 @@ describe('ProjectsStore', () => {
     updatedAt: 'after',
   };
 
+  beforeEach(async () => {
+    await registerProjectsStore(appContext);
+    store = appContext.projectsStore;
+  });
   describe('add project', () => {
     it('should add a project', async () => {
       // BUILD
       getProjects.mockResolvedValueOnce([]);
-      store = ProjectsStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -56,7 +60,6 @@ describe('ProjectsStore', () => {
     it('should not add the project because it already exists', async () => {
       // BUILD
       getProjects.mockResolvedValueOnce([diffProject]);
-      store = ProjectsStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -71,7 +74,6 @@ describe('ProjectsStore', () => {
     it('should try to add the updated function', async () => {
       // BUILD
       getProjects.mockResolvedValueOnce([newProject]);
-      store = ProjectsStore.create({}, {});
       await store.load();
 
       updateProject.mockResolvedValueOnce(diffProject);

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/__tests__/StudiesStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/__tests__/StudiesStore.test.js
@@ -1,0 +1,93 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { categories } from '../categories';
+import { registerContextItems as registerStudiesStore } from '../StudiesStore';
+import { getStudies, createStudy } from '../../../helpers/api';
+
+jest.mock('../../../helpers/api');
+
+describe('StudiesStore', () => {
+  let store = null;
+  const appContext = {};
+  const newStudy = {
+    id: 'studying_anew',
+    rev: 1,
+    name: 'new_beginnings',
+  };
+
+  beforeEach(async () => {
+    registerStudiesStore(appContext);
+    store = appContext.studiesStoresMap[categories.organization.id];
+  });
+
+  describe('addStudy', () => {
+    it('should add a study', async () => {
+      // BUILD
+      getStudies.mockResolvedValueOnce([]);
+
+      await store.load();
+
+      // OPERATE
+      await store.addStudy(newStudy);
+
+      // CHECk
+      expect(store.list[0]).toMatchObject(newStudy);
+    });
+
+    it('should not add the study because it already exists', async () => {
+      // BUILD
+      getStudies.mockResolvedValueOnce([newStudy]);
+
+      await store.load();
+
+      // OPERATE
+      await store.addStudy(newStudy);
+
+      // CHECk
+      expect(store.list.length).toBe(1);
+    });
+  });
+
+  describe('getStudyStore', () => {
+    it('should create a study store if it does not exist', async () => {
+      // BUILD
+      getStudies.mockResolvedValueOnce([]);
+
+      await store.load();
+
+      // OPERATE
+      const retVal = await store.getStudyStore('newStudyStoreID');
+
+      // CHECK
+      expect(retVal.studyId).toBe('newStudyStoreID');
+    });
+  });
+
+  describe('createStudy', () => {
+    it('should create a new study and return it', async () => {
+      // BUILD
+      getStudies.mockResolvedValueOnce([]);
+      createStudy.mockResolvedValueOnce(newStudy);
+      await store.load();
+
+      // OPERATE
+      const retVal = await store.createStudy(newStudy);
+
+      // CHECK
+      expect(retVal).toMatchObject(newStudy);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/UsersStore.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/UsersStore.test.js
@@ -16,13 +16,14 @@
 import { addUser, updateUser, getUsers } from '@aws-ee/base-ui/dist/helpers/api';
 import { addUsers } from '../../../helpers/api';
 
-import { UsersStore } from '../UsersStore';
+import { registerContextItems as registerUsersStore } from '../UsersStore';
 
 jest.mock('@aws-ee/base-ui/dist/helpers/api');
 jest.mock('../../../helpers/api');
 
 describe('UsersStore', () => {
   let store = null;
+  const appContext = {};
   const exampleUser = {
     firstName: 'Ash',
     lastName: 'Ketchum',
@@ -30,12 +31,18 @@ describe('UsersStore', () => {
     ns: 'satoshi.025',
   };
 
+  beforeEach(async () => {
+    await registerUsersStore(appContext);
+    store = appContext.usersStore;
+  });
+
   describe('adding users', () => {
     it('should add a user', async () => {
       // BUILD
       getUsers.mockResolvedValueOnce([]);
       addUser.mockResolvedValueOnce(exampleUser);
-      store = UsersStore.create({}, {});
+
+      // store = UsersStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -63,7 +70,7 @@ describe('UsersStore', () => {
         await store.addUser(otherUser);
       });
 
-      store = UsersStore.create({}, {});
+      // store = UsersStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -89,7 +96,7 @@ describe('UsersStore', () => {
       getUsers.mockResolvedValueOnce([exampleUser]);
       updateUser.mockResolvedValueOnce(updatedExampleUser);
 
-      store = UsersStore.create({}, {});
+      // store = UsersStore.create({}, {});
       await store.load();
 
       // OPERATE
@@ -104,8 +111,7 @@ describe('UsersStore', () => {
   describe('deleting users', () => {
     it('should delete the user', async () => {
       // BUILD
-      getUsers.mockResolvedValueOnce([exampleUser]);
-      store = UsersStore.create({}, {});
+      getUsers.mockResolvedValue([exampleUser]);
       await store.load();
 
       // OPERATE

--- a/addons/addon-base-ui/packages/base-ui/src/models/users/__tests__/UsersStore.test.js
+++ b/addons/addon-base-ui/packages/base-ui/src/models/users/__tests__/UsersStore.test.js
@@ -1,0 +1,96 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { registerContextItems as registerUsersStore } from '../UsersStore';
+import { addUser, getUsers, updateUser } from '../../../helpers/api';
+
+jest.mock('../../../helpers/api');
+
+describe('UsersStore', () => {
+  let store = null;
+  const appContext = {};
+  const newUser = {
+    firstName: 'gordon',
+    lastName: 'freeman',
+    username: 'gf_lambda',
+    ns: 'gf_lambda.xen',
+    email: 'gfreeman@example.com',
+    userType: 'Researcher',
+    isAdmin: true,
+    authenticationProviderId: 'black_mesa', // Id of the authentication provider this user is authenticated against (such as internal, cognito auth provider id etc)
+    identityProviderName: 'lambda_sector', // Name of the identity provider this user belongs to (such as Identity Provider Id in cognito user pool in case of Federation etc)
+    status: 'active',
+    projectId: ['grav-gun'],
+    rev: 0,
+  };
+
+  const updatedUser = {
+    firstName: 'G-man',
+    lastName: 'unknown',
+    username: 'gf_lambda',
+    ns: 'gf_lambda.xen',
+    email: 'redacted@example.com',
+    userType: 'Administrator',
+    isAdmin: true,
+  };
+
+  beforeEach(async () => {
+    await registerUsersStore(appContext);
+    store = appContext.usersStore;
+  });
+
+  describe('addUser', () => {
+    it('should add a new user', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([]);
+      addUser.mockResolvedValueOnce(newUser);
+      await store.load();
+
+      // OPERATE
+      await store.addUser(newUser);
+
+      // CHECK
+      expect(newUser).toMatchObject(store.list[0]);
+    });
+
+    it('should not add user because it already exists', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([newUser]);
+      addUser.mockResolvedValueOnce(newUser);
+      await store.load();
+
+      // OPERATE
+      await store.addUser(newUser);
+
+      // CHECK
+      expect(store.list.length).toBe(1);
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should update the user info', async () => {
+      // BUILD
+      getUsers.mockResolvedValueOnce([newUser]);
+      updateUser.mockResolvedValueOnce(updatedUser);
+      await store.load();
+
+      // OPERATE
+      await store.updateUser(updatedUser);
+
+      // CHECK
+      expect(store.list[0]).toMatchObject(updatedUser);
+    });
+  });
+});


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Added UI Store Tests:
- UsersStore (addon-base-ui)
- AccountsStore
- AwsAccountsStore
- ServicesStore
- EnvironmentsStore

---------
Also modified stores to be initialized correctly using `registerContextItems` instead of calling them directly.
--------
EnvironmentsStore will likely need more tests implemented down the road, but for now this is a good start.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
