### PR TITLE
Default brand name updated

### DIFF
--- a/main/solution/ui/config/settings/.defaults.yml
+++ b/main/solution/ui/config/settings/.defaults.yml
@@ -17,10 +17,10 @@ websiteCloudFrontId: ${cf:${self:custom.settings.infrastructureStackName}.CloudF
 websiteUrl: ${cf:${self:custom.settings.infrastructureStackName}.WebsiteUrl}
 
 # Branding
-brandPageTitle: 'Research as a Service'
-brandMainTitle: 'Research as a Service (${self:custom.settings.envName}/${self:custom.settings.awsRegion})'
-brandLoginTitle: 'RaaS'
-brandLoginSubtitle: 'Research as a Service Portal (${self:custom.settings.envName}/${self:custom.settings.awsRegion})'
+brandPageTitle: 'Galileo'
+brandMainTitle: 'Galileo - Gateway (${self:custom.settings.envName}/${self:custom.settings.awsRegion})'
+brandLoginTitle: 'Galileo'
+brandLoginSubtitle: 'Galileo Gateway (${self:custom.settings.envName}/${self:custom.settings.awsRegion})'
 
 # After how many minutes should the auto logout dialog be displayed? once displayed the user has 1 minute to dismiss
 # the dialog, otherwise they will be automatically logged out


### PR DESCRIPTION
Issue #, if available:
https://sim.amazon.com/issues/GALI-352

Description of changes:
Default branding was still referring to "Research as a Service". Changed to "Galileo Gateway".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
