### PR TITLE
Hosted zone ID fix

### DIFF
--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -180,7 +180,7 @@ Resources:
         - Name: ${self:custom.settings.domainName}
           Type: A
           AliasTarget:
-            HostedZoneId: Z2FDTNDATAQYW2 # This is a requried hard-coded string that is to be used for AWS
+            HostedZoneId: Z2FDTNDATAQYW2 # This is a required hard-coded string that is to be used for AWS
             DNSName: !GetAtt WebsiteCloudFront.DomainName
 
 Outputs:
@@ -205,5 +205,7 @@ Outputs:
 
   HostedZoneId:
     Description: Id of the hosted zone created when a custom domain is used
-    Condition: UseCustomDomain
-    Value: WebsiteCloudFront.DistributionId
+    Value: !If
+      - UseCustomDomain
+      - !Ref HostedZone
+      - 'NotSetAsCustomDomainDisabled'


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
The hard-coded string is required for special hosted zone used by CloudFront. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html

Also, HostedZoneID is only to be evaluated if a custom domain is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
