### PR TITLE
Environment Delete failure fix

### DIFF
--- a/scripts/environment-delete.sh
+++ b/scripts/environment-delete.sh
@@ -250,6 +250,8 @@ removeStack "Infrastructure" "$SOLUTION_DIR/infrastructure" "DONT_ASK_CONFIRMATI
 
 removeStack "Prep-Master-Account" "$SOLUTION_DIR/prepare-master-acc" "DONT_ASK_CONFIRMATION"
 
+removeStack "Machine-Images" "$SOLUTION_DIR/machine-images" "DONT_ASK_CONFIRMATION"
+
 removeCfLambdaAssociations
 
 removeCICDStacks "ASK_CONFIRMATION"


### PR DESCRIPTION
Issue #, if available:
https://sim.amazon.com/issues/GALI-366

Description of changes:
Noticed this error while running the environment-delete.sh script
<img width="713" alt="Screen Shot 2020-07-21 at 2 08 04 PM" src="https://user-images.githubusercontent.com/20480854/88090453-9f1a8800-cb5b-11ea-9935-c03212335e2a.png">

Moving the removeCfLambdaAssociations after Cloudformation stacks results in a successful environment delete process.
Also added a missing stack to be deleted for "Prep-Master-Account".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
