### PR TITLE
Incomplete Studies populated for OpenDataScraper fix

### DIFF
--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
@@ -190,12 +190,12 @@ module.exports = function newHandler({ studyService, log = consoleLogger } = {})
         // studyService.find returns the entire db row for that study id
         const existingStudy = await studyService.find(userContext, study.id);
         if (!existingStudy) {
-          studyService.create(userContext, study);
+          await studyService.create(userContext, study);
         } else {
           // remove additional properties before update call to match jsonSchemaValidation
           const studyToUpdate = _.omit(existingStudy, ['updatedAt', 'updatedBy', 'createdAt', 'createdBy', 'category']);
 
-          studyService.update(userContext, studyToUpdate);
+          await studyService.update(userContext, studyToUpdate);
         }
       }),
     );


### PR DESCRIPTION
Issue #, if available:
Found during bug bash. #1002

Description of changes:
There was a delay seen on the total required (~40) studies being populated in the database. The first attempt that lambda makes to save rows is incomplete and requires a rerun of the lambda to populate studies fully.

Awaiting create and update method calls inside Promise.all solves this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
