### PR TITLE
Add some RStudio detail in the machine-images readme.

### DIFF
--- a/main/solution/machine-images/README.md
+++ b/main/solution/machine-images/README.md
@@ -1,10 +1,32 @@
 # Building Machine Images
 
+
 ## Packer
 
 This solution uses [Packer](https://www.packer.io/) to create an Amazon Machine Image (AMI). This AMI forms the basis for EC2/EMR environments that investigators use for their research.
 
 To install Packer, please see their installation [instructions](https://www.packer.io/intro/getting-started/install.html).
+
+
+## Preparation
+
+For the RStudio image to function, a few files not in the repository need to be included in the build by placing them
+in the `config/infra/files/rstudio` folder (note this folder is ignored by `git` to minimize the risk of files being
+committed to source control).
+
+*  `secret.txt`: A single-line text file that contains the JWT secret from the Galileo deployment, which can
+   be found in Parameter Store at `/$stage/$solution/jwt/secret`, where `$stage` is the stage name for the
+   environment and `$solution` is the solution name.
+
+*  `cert.key`: The TLS private key in PEM format for the RStudio domain.
+
+*  `cert.pem`: TLS certificate chain for the above in PEM format, with the intermediate certs first and the root last.
+
+The current implementation assigns hostnames to RStudio instances with the form `rstudio-$env.$domain_name` where `$env`
+is the environment identifier for the workspace, and `$domain_name` is the custom domain used for Galileo. This means that
+the certificate above must be a wildcard certificate for `*.$domain_name`. It also means that Galileo must be deployed
+with a custom domain for RStudio to work properly.
+
 
 ## Package and Deploy
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Added some information to the `machine-images` readme describing the additional items needed for the RStudio AMI. I'll add a note here that while the current implementation expects the domain of Galileo itself to be used as the base for the RStudio domain, changing that would be straightforward. It'd only require adding a config value for that domain, and then using that value instead of the Galileo one in the `getHostname` method of `environment-dns-service.js`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
