### PR TITLE
Fix - Environment-delete S3 removal

### DIFF
--- a/main/cicd/cicd-pipeline/package.json
+++ b/main/cicd/cicd-pipeline/package.json
@@ -9,8 +9,7 @@
     "@aws-ee/base-serverless-settings-helper": "workspace:*",
     "serverless": "^1.63.0",
     "serverless-deployment-bucket": "^1.1.0",
-    "serverless-hooks-plugin": "^1.1.0",
-    "serverless-s3-remover": "^0.6.0"
+    "serverless-hooks-plugin": "^1.1.0"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/main/cicd/cicd-pipeline/serverless.yml
+++ b/main/cicd/cicd-pipeline/serverless.yml
@@ -21,11 +21,6 @@ custom:
   settings: ${file(./config/settings/.settings.js):merged}
   tags:
     Name: ${self:custom.settings.envName}-${self:service}
-  remover:
-    prompt: false
-    buckets:
-      - ${self:custom.settings.cicdAppArtifactBucketName}
-      - ${self:custom.settings.deploymentBucketName}
   hooks:
     'aws:deploy:finalize:cleanup':
       - scripts/upload-env-config.bash ${self:provider.profile} ${self:provider.deploymentBucket} ${self:custom.settings.stgEnvName}
@@ -38,4 +33,3 @@ resources:
 plugins:
   - serverless-deployment-bucket
   - serverless-hooks-plugin
-  - serverless-s3-remover

--- a/main/solution/backend/package.json
+++ b/main/solution/backend/package.json
@@ -62,7 +62,6 @@
     "serverless": "^1.63.0",
     "serverless-deployment-bucket": "^1.1.0",
     "serverless-offline": "^5.12.1",
-    "serverless-s3-remover": "^0.6.0",
     "serverless-s3-sync": "^1.12.0",
     "serverless-webpack": "^5.3.1",
     "source-map-support": "^0.5.16",

--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -69,12 +69,6 @@ custom:
   s3Sync:
     - bucketName: ${self:custom.settings.externalCfnTemplatesBucketName} # required
       localDir: ../../../addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external
-  remover:
-    prompt: false
-    buckets:
-      - ${self:custom.settings.studyDataBucketName}
-      - ${self:custom.settings.externalCfnTemplatesBucketName}
-      - ${self:custom.settings.environmentsBootstrapBucketName}
 
 functions: ${file(./config/infra/functions.yml)}
 
@@ -87,5 +81,4 @@ plugins:
   - serverless-offline
   - serverless-deployment-bucket
   - serverless-s3-sync
-  - serverless-s3-remover
   - '@aws-ee/base-serverless-backend-tools'

--- a/main/solution/infrastructure/package.json
+++ b/main/solution/infrastructure/package.json
@@ -8,7 +8,6 @@
   "devDependencies": {
     "@aws-ee/base-serverless-settings-helper": "workspace:*",
     "serverless": "^1.63.0",
-    "serverless-deployment-bucket": "^1.1.0",
-    "serverless-s3-remover": "^0.6.0"
+    "serverless-deployment-bucket": "^1.1.0"
   }
 }

--- a/main/solution/infrastructure/serverless.yml
+++ b/main/solution/infrastructure/serverless.yml
@@ -23,11 +23,6 @@ custom:
     Name: ${self:custom.settings.envName}-${self:service}
   deploymentBucket:
     policy: ${self:custom.settings.deploymentBucketPolicy}
-  remover:
-    prompt: false
-    buckets:
-      - ${self:custom.settings.loggingBucketName}
-      - ${self:custom.settings.websiteBucketName}
 
 resources:
   - Description: Galileo-Gateway ${self:custom.settings.version} ${self:custom.settings.solutionName} ${self:custom.settings.envName} Infrastructure
@@ -35,4 +30,3 @@ resources:
 
 plugins:
   - serverless-deployment-bucket
-  - serverless-s3-remover

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,7 +1706,6 @@ importers:
       serverless: 1.67.3
       serverless-deployment-bucket: 1.1.1
       serverless-hooks-plugin: 1.1.0
-      serverless-s3-remover: 0.6.0
     optionalDependencies:
       fsevents: 2.1.2
     specifiers:
@@ -1715,7 +1714,6 @@ importers:
       serverless: ^1.63.0
       serverless-deployment-bucket: ^1.1.0
       serverless-hooks-plugin: ^1.1.0
-      serverless-s3-remover: ^0.6.0
   main/cicd/cicd-source:
     devDependencies:
       '@aws-ee/base-serverless-settings-helper': 'link:../../../addons/addon-base/packages/serverless-settings-helper'
@@ -1897,7 +1895,6 @@ importers:
       serverless: 1.67.3
       serverless-deployment-bucket: 1.1.1
       serverless-offline: 5.12.1_serverless@1.67.3
-      serverless-s3-remover: 0.6.0
       serverless-s3-sync: 1.12.0
       serverless-webpack: 5.3.1_webpack@4.42.1
       source-map-support: 0.5.16
@@ -1960,7 +1957,6 @@ importers:
       serverless: ^1.63.0
       serverless-deployment-bucket: ^1.1.0
       serverless-offline: ^5.12.1
-      serverless-s3-remover: ^0.6.0
       serverless-s3-sync: ^1.12.0
       serverless-webpack: ^5.3.1
       services: 'workspace:*'
@@ -1982,12 +1978,10 @@ importers:
       '@aws-ee/base-serverless-settings-helper': 'link:../../../addons/addon-base/packages/serverless-settings-helper'
       serverless: 1.67.3
       serverless-deployment-bucket: 1.1.1
-      serverless-s3-remover: 0.6.0
     specifiers:
       '@aws-ee/base-serverless-settings-helper': 'workspace:*'
       serverless: ^1.63.0
       serverless-deployment-bucket: ^1.1.0
-      serverless-s3-remover: ^0.6.0
   main/solution/machine-images:
     devDependencies:
       '@aws-ee/base-serverless-settings-helper': 'link:../../../addons/addon-base/packages/serverless-settings-helper'
@@ -5579,14 +5573,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-  /async/0.9.2:
-    dev: true
-    resolution:
-      integrity: sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-  /async/1.0.0:
-    dev: true
-    resolution:
-      integrity: sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
   /async/1.5.2:
     dev: true
     resolution:
@@ -6938,12 +6924,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
-  /colors/1.0.3:
-    dev: true
-    engines:
-      node: '>=0.1.90'
-    resolution:
-      integrity: sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
   /colors/1.3.3:
     dev: true
     engines:
@@ -7663,6 +7643,7 @@ packages:
     resolution:
       integrity: sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
   /cycle/1.0.3:
+    dev: false
     engines:
       node: '>=0.4.0'
     resolution:
@@ -7820,10 +7801,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
-  /deep-equal/0.2.2:
-    dev: true
-    resolution:
-      integrity: sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=
   /deep-equal/1.1.1:
     dependencies:
       is-arguments: 1.0.4
@@ -9437,12 +9414,6 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-  /eyes/0.1.8:
-    dev: true
-    engines:
-      node: '> 0.1.90'
-    resolution:
-      integrity: sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
   /fast-deep-equal/3.1.1:
     resolution:
       integrity: sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
@@ -10060,7 +10031,6 @@ packages:
     resolution:
       integrity: sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==
   /fsevents/2.1.2:
-    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -10866,12 +10836,6 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
-  /i/0.3.6:
-    dev: true
-    engines:
-      node: '>=0.4'
-    resolution:
-      integrity: sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=
   /iconv-lite/0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -13929,11 +13893,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-gxh5Sgait8HyclaulfhgetHQGyhFm00ZQqISIfqtwFVnyWJ20rk+55SUamo9n3KhM6Vk63gemKPxIDYiSV/xZw==
-  /ncp/1.0.1:
-    dev: true
-    hasBin: true
-    resolution:
-      integrity: sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=
   /nearley/2.19.4:
     dependencies:
       commander: 2.20.3
@@ -14943,18 +14902,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  /pkginfo/0.3.1:
-    dev: true
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=
-  /pkginfo/0.4.1:
-    dev: true
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
   /please-upgrade-node/3.2.0:
     dependencies:
       semver-compare: 1.0.0
@@ -15887,19 +15834,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
-  /prompt/1.0.0:
-    dependencies:
-      colors: 1.4.0
-      pkginfo: 0.4.1
-      read: 1.0.7
-      revalidator: 0.1.8
-      utile: 0.3.0
-      winston: 2.1.1
-    dev: true
-    engines:
-      node: '>= 0.6.6'
-    resolution:
-      integrity: sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=
   /prompts/2.3.2:
     dependencies:
       kleur: 3.0.3
@@ -16626,14 +16560,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  /read/1.0.7:
-    dependencies:
-      mute-stream: 0.0.8
-    dev: true
-    engines:
-      node: '>=0.8'
-    resolution:
-      integrity: sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
   /readable-stream/2.3.7:
     dependencies:
       core-util-is: 1.0.2
@@ -17093,12 +17019,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-  /revalidator/0.1.8:
-    dev: true
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha1-/s5hv6DBtSoga9axgZgYS91SOjs=
   /rework-visit/1.0.0:
     dev: true
     resolution:
@@ -17485,13 +17405,6 @@ packages:
       serverless: '>= 1.48.1'
     resolution:
       integrity: sha512-OXgfXWZM8RxXie1NXNvjQk7TpM3KI/lyJd4pmakcL7XNZADCd1ph5yOvVdDlJAZgmrkaq2tzSG8ZaKDE66JTmg==
-  /serverless-s3-remover/0.6.0:
-    dependencies:
-      chalk: 2.4.2
-      prompt: 1.0.0
-    dev: true
-    resolution:
-      integrity: sha512-gwyqBLqcvru4csJ1IxrwJTgCrFIRkBl81EoqwsIRwV5+O+CUPTPlu3pR/4+aqTNbcaA/xykvfYCU9E9jt8hI0A==
   /serverless-s3-sync/1.12.0:
     dependencies:
       '@auth0/s3': 1.0.0
@@ -19299,19 +19212,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
-  /utile/0.3.0:
-    dependencies:
-      async: 0.9.2
-      deep-equal: 0.2.2
-      i: 0.3.6
-      mkdirp: 0.5.5
-      ncp: 1.0.1
-      rimraf: 2.7.1
-    dev: true
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=
   /utils-merge/1.0.1:
     engines:
       node: '>= 0.4.0'
@@ -19768,20 +19668,6 @@ packages:
       node: '>= 6.4.0'
     resolution:
       integrity: sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==
-  /winston/2.1.1:
-    dependencies:
-      async: 1.0.0
-      colors: 1.0.3
-      cycle: 1.0.3
-      eyes: 0.1.8
-      isstream: 0.1.2
-      pkginfo: 0.3.1
-      stack-trace: 0.0.10
-    dev: true
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=
   /winston/3.2.1:
     dependencies:
       async: 2.6.3


### PR DESCRIPTION
**Description of changes:**

Focused on the refinement of the `/scripts/environment-delete.sh script`.
The S3 Buckets were not properly cleaned before Cloudformation tries to delete them. 
The serverless plugin `serverless-s3-remover` does not handle versioned buckets the bucket. 
Therefore, I removed the plugin and replaced it with a bash function cleaning up buckets reliably before triggering a stack removal.

--> Refined the bash function emptying the S3 buckets and use it before the removal of each stack
--> Refined the bash function checking if there is SSM parameters that should be cleaned up.
--> Removed `serverless-s3-remover` from the dependencies and from the serverless templates.

_Note to reviewers : I will squash the branch into one commit if it gets validated._

**Checklist:**

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ~ran unit tests and~ manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
