### PR TITLE
fixed cost api error bug

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/Dashboard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/Dashboard.js
@@ -16,10 +16,11 @@
 import React from 'react';
 import _ from 'lodash';
 import { decorate } from 'mobx';
-import { observer } from 'mobx-react';
+import { observer, inject } from 'mobx-react';
+import { withRouter } from 'react-router-dom';
 import { Pie } from 'react-chartjs-2';
 import { Container, Header, Segment, Icon } from 'semantic-ui-react';
-import { displayError } from '@aws-ee/base-ui/dist/helpers/notification';
+import { displayError, displayWarning } from '@aws-ee/base-ui/dist/helpers/notification';
 import ProgressPlaceHolder from '@aws-ee/base-ui/dist/parts/helpers/BasicProgressPlaceholder';
 
 import { getEnvironments, getEnvironmentCost, getScEnvironments, getScEnvironmentCost } from '../../helpers/api';
@@ -52,8 +53,23 @@ class Dashboard extends React.Component {
         isLoading: false,
       });
     } catch (error) {
-      displayError('Error encountered retrieving cost data. Please refresh the page or try again later.');
+      const store = this.getStore();
+
+      // "Something went wrong" is thrown when Cost Explorer hasn't been configured
+      if (error.message === 'Something went wrong' && store.user.isAdmin) {
+        displayWarning(
+          'Error encountered retrieving cost data. Please make sure Cost Explorer is set up in the AWS Management Console.',
+        );
+      } else if (error.message === 'Something went wrong') {
+        displayWarning('Could not retrieve cost data. Please contact your adminstrator for assistance.');
+      } else {
+        displayError('Error encountered retrieving cost data.');
+      }
     }
+  }
+
+  getStore() {
+    return this.props.userStore;
   }
 
   render() {
@@ -283,4 +299,4 @@ class Dashboard extends React.Component {
 // see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
 decorate(Dashboard, {});
 
-export default observer(Dashboard);
+export default inject('userStore')(withRouter(observer(Dashboard)));


### PR DESCRIPTION
Issue #, if available: https://sim.amazon.com/issues/GALI-266

Description of changes:
Fixed a bug where users would see an annoying error message in dashboard if cost explorer isn't set up. This fix replaces the error with a warning, directing admins to set up cost explorer and directing non-admins to see their administrator for guidance.

This is testing and working with cost explorer not enabled, unfortunately due to time constraints on my internship I was not able to test it with cost explorer enabled (since it takes 24 hours to start working), but I don't expect that this will introduce any new bugs to functionality with cost explorer enabled. 

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] ~~Have you written new tests for your core changes, as applicable?~~ Not applicable
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
