### PR TITLE
Allowing instance profile access

### DIFF
--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -199,8 +199,7 @@ Resources:
                 - iam:GetInstanceProfile
                 - iam:DeleteInstanceProfile
                 - iam:RemoveRoleFromInstanceProfile
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
+              Resource: '*'
   # =============================================================================================
   # Dynamo db
   # =============================================================================================


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
When Main and Member account are not the same, this change would allow IAM instance profile access for EC2 launching.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
