### PR TITLE
Add a check list item for adding end-to-end tests 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,6 @@ Checklist:
 * [ ] Have you linted your code locally prior to submission?
 * [ ] Have you written new tests for your core changes, as applicable?
 * [ ] Have you successfully ran unit tests and manual tests with your changes locally?
+* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
Description of changes:
Add a check list item for adding end-to-end tests if user is running manual tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
