### PR TITLE
Added accessType property at study level and also added route for upd…

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
@@ -50,6 +50,33 @@ async function configure(context) {
   );
 
   // ===============================================================
+  //  PUT /:id (mounted to /api/studies)
+  // ===============================================================
+  router.put(
+    '/:id',
+    wrap(async (req, res) => {
+      const studyId = req.params.id;
+      const requestContext = res.locals.requestContext;
+      const updateRequest = req.body;
+
+      // verify that studyId in request params is equal to the studyId provided in body of the request
+      const updateRequestId = updateRequest.id;
+      if (studyId !== updateRequestId) {
+        throw context.boom.badRequest(
+          `PUT request for "${studyId}" does not match id "${updateRequestId}" specified in the request`,
+          true,
+        );
+      }
+
+      // Validate permissions and usage
+      await studyPermissionService.verifyRequestorAccess(requestContext, studyId, req.method);
+
+      const result = await studyService.update(requestContext, updateRequest);
+      res.status(200).json(result);
+    }),
+  );
+
+  // ===============================================================
   //  POST / (mounted to /api/studies)
   // ===============================================================
   router.post(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
@@ -47,6 +47,10 @@
           }
         }    
       ]
+    },
+    "accessType": {
+      "type": "string",
+      "enum": ["ReadOnly", "ReadWrite"]
     }
   },
   "required": ["id", "category"]

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
@@ -37,6 +37,10 @@
           }
         }    
       ]
+    },
+    "accessType": {
+      "type": "string",
+      "enum": ["ReadOnly", "ReadWrite"]
     }
   },
   "required": ["id", "rev"]

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
@@ -176,6 +176,135 @@ describe('studyService', () => {
         { action: 'create-study', body: undefined },
       );
     });
+
+    it('should try to create the study successfully when accessType is ReadOnly', async () => {
+      // BUILD
+      const dataIpt = {
+        id: 'doppelganger',
+        category: 'Open Data',
+        accessType: 'ReadOnly',
+      };
+
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.create({ principal: { userRole: 'admin' } }, dataIpt);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        { principal: { userRole: 'admin' } },
+        { action: 'create-study', body: undefined },
+      );
+    });
+
+    it('should try to create the study successfully when accessType is ReadWrite for My Studies', async () => {
+      // BUILD
+      projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
+        return true;
+      });
+      const dataIpt = {
+        id: 'doppelganger',
+        category: 'My Studies',
+        accessType: 'ReadWrite',
+        projectId: 'some_project_id',
+      };
+
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.create({ principal: { userRole: 'admin' } }, dataIpt);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        { principal: { userRole: 'admin' } },
+        { action: 'create-study', body: undefined },
+      );
+    });
+
+    it('should try to create the study successfully when accessType is ReadWrite for Organization', async () => {
+      // BUILD
+      projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
+        return true;
+      });
+      const dataIpt = {
+        id: 'doppelganger',
+        category: 'Organization',
+        accessType: 'ReadWrite',
+        projectId: 'some_project_id',
+      };
+
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.create({ principal: { userRole: 'admin' } }, dataIpt);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        { principal: { userRole: 'admin' } },
+        { action: 'create-study', body: undefined },
+      );
+    });
+
+    it('should fail because accessType specified is readonly in lowercase', async () => {
+      // BUILD
+      const ipt = {
+        name: 'doppelganger',
+        category: 'My Studies',
+        accessType: 'readonly',
+      };
+
+      // OPERATE
+      try {
+        await service.create({ principal: { userRole: 'admin' } }, ipt);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail because accessType specified is random', async () => {
+      // BUILD
+      const ipt = {
+        name: 'doppelganger',
+        category: 'My Studies',
+        accessType: 'random',
+      };
+
+      // OPERATE
+      try {
+        await service.create({ principal: { userRole: 'admin' } }, ipt);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail because accessType is ReadWrite for Open Data', async () => {
+      // BUILD
+      projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
+        return true;
+      });
+      const ipt = {
+        id: 'doppelganger',
+        category: 'Open Data',
+        accessType: 'ReadWrite',
+        projectId: 'some_project_id',
+      };
+
+      // OPERATE
+      try {
+        await service.create({ principal: { userRole: 'admin' } }, ipt);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Open Data study cannot be read/write');
+      }
+    });
   });
 
   describe('update', () => {
@@ -192,6 +321,46 @@ describe('studyService', () => {
       } catch (err) {
         // CATCH
         expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail due to invalid accessType', async () => {
+      // BUILD
+      const ipt = {
+        name: 'tasDevil',
+        rev: 1,
+        accessType: 'random',
+      };
+
+      // OPERATE
+      try {
+        await service.update({}, ipt);
+        expect.hasAssertions();
+      } catch (err) {
+        // CATCH
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+
+    it('should fail due to ReadWrite accessType on Open Data study', async () => {
+      // BUILD
+      const dataIpt = {
+        id: 'doppelganger',
+        accessType: 'ReadWrite',
+        rev: 1,
+      };
+      service.find = jest.fn().mockImplementationOnce(() => {
+        return { id: 'doppelganger', category: 'Open Data' };
+      });
+      service.audit = jest.fn();
+
+      // OPERATE
+      try {
+        await service.update({}, dataIpt);
+        expect.hasAssertions();
+      } catch (err) {
+        // CATCH
+        expect(err.message).toEqual('Open Data study cannot be read/write');
       }
     });
 
@@ -216,7 +385,7 @@ describe('studyService', () => {
         expect.hasAssertions();
       } catch (err) {
         // CHECK
-        expect(err.message).toEqual('study with id "doppelganger" does not exist');
+        expect(err.message).toEqual('Study with id "doppelganger" does not exist');
       }
     });
 
@@ -225,15 +394,21 @@ describe('studyService', () => {
       const dataIpt = {
         id: 'doppelganger',
         rev: 1,
+        accessType: 'ReadOnly',
       };
 
       dbService.table.update.mockImplementationOnce(() => {
         throw error;
       });
 
-      service.find = jest.fn().mockImplementationOnce(() => {
-        return { updatedBy: { username: 'another doppelganger' } };
-      });
+      service.find = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          return { id: 'doppelganger', updatedBy: { username: 'another doppelganger' }, category: 'Organization' };
+        })
+        .mockImplementationOnce(() => {
+          return { id: 'doppelganger', updatedBy: { username: 'another doppelganger' }, category: 'Organization' };
+        });
 
       // OPERATE
       try {
@@ -253,6 +428,49 @@ describe('studyService', () => {
         id: 'doppelganger',
         rev: 1,
       };
+      service.find = jest.fn().mockImplementationOnce(() => {
+        return { id: 'doppelganger', category: 'Organization' };
+      });
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.update({}, dataIpt);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'update-study', body: undefined });
+    });
+
+    it('should succeed with ReadWrite accessType', async () => {
+      // BUILD
+      const dataIpt = {
+        id: 'doppelganger',
+        accessType: 'ReadWrite',
+        rev: 1,
+      };
+      service.find = jest.fn().mockImplementationOnce(() => {
+        return { id: 'doppelganger', category: 'Organization' };
+      });
+      service.audit = jest.fn();
+
+      // OPERATE
+      await service.update({}, dataIpt);
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith({}, { action: 'update-study', body: undefined });
+    });
+
+    it('should succeed with ReadOnly accessType', async () => {
+      // BUILD
+      const dataIpt = {
+        id: 'doppelganger',
+        accessType: 'ReadOnly',
+        rev: 1,
+      };
+      service.find = jest.fn().mockImplementationOnce(() => {
+        return { id: 'doppelganger', category: 'My Studies' };
+      });
       service.audit = jest.fn();
 
       // OPERATE

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -88,6 +88,9 @@ class StudyService extends Service {
     // For now, we assume that 'createdBy' and 'updatedBy' are always users and not groups
     const by = _.get(requestContext, 'principalIdentifier'); // principalIdentifier shape is { username, ns: user.ns }
 
+    // validate if study can be read/write
+    this.validateStudyType(rawData.accessType, rawData.category);
+
     // The open data studies do not need to be associated to any project
     // for everything else make sure projectId is specified
     if (rawData.category !== 'Open Data') {
@@ -158,6 +161,16 @@ class StudyService extends Service {
     // For now, we assume that 'updatedBy' is always a user and not a group
     const by = _.get(requestContext, 'principalIdentifier'); // principalIdentifier shape is { username, ns: user.ns }
     const { id, rev } = rawData;
+
+    const study = await this.mustFind(requestContext, id);
+
+    // validate if study can be read/write
+    this.validateStudyType(rawData.accessType, study.category);
+
+    // TODO: Add logic for the following when full write functionality is implemented:
+    // 1. Permissions removal for Read/Write and Write if ReadWrite accessType switches to ReadOnly
+    // 2. Workspace mounts to be corrected
+    // 3. Deleting any additional resources created as part of the ReadWrite functionality
 
     // Prepare the db object
     const dbObject = _.omit(this.fromRawToDbObject(rawData, { updatedBy: by }), ['rev']);
@@ -387,6 +400,13 @@ class StudyService extends Service {
     // If the main call also needs to fail in case writing to any audit destination fails then switch to "write" method as follows
     // return auditWriterService.write(requestContext, auditEvent);
     return auditWriterService.writeAndForget(requestContext, auditEvent);
+  }
+
+  // ensure that study accessType is read/write for Open Data category
+  validateStudyType(accessType, studyCategory) {
+    if (accessType === 'ReadWrite' && studyCategory === 'Open Data') {
+      throw this.boom.badRequest('Open Data study cannot be read/write', true);
+    }
   }
 }
 


### PR DESCRIPTION
Issue #, if available: GALI-456

Description of changes:
* Added accessType enum in study schema for update and create calls
* Added route for Study PUT for updates
* Added check to disallow ReadWrite accessType on Open Data Studies


Note: These are just backend changes- it is expected that UI will set accessType property when we integrate. Additionally, for backwards compatibility missing accessType will be assumed to be 'ReadOnly'

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

[✓] Have you successfully deployed to an AWS account with your changes? 
[✓] Have you linted your code locally prior to submission?
[✓] Have you written new tests for your core changes, as applicable?
[✓] Have you successfully ran unit tests and manual tests with your changes locally?
[ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)? Didn't run manual tests since the changes are made to Study API which isn't added yet. Additionally, these are backend changes and not being called from UI yet, will tackle this bit when we do the UI integration.

### UI testing
* Verified that create study works
* Verified that all the studies are being displayed correctly

### Testing done via Postman
* CREATE Study call with valid and invalid accessType
* CREATE Study call without accessType
* CREATE Study call on Open Data Study with ReadWrite accessType
* Above pattern of calls with PUT calls
* Verified GET Study call on Studies with and without accessType

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
