### PR TITLE
Write permissions studies

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
@@ -161,6 +161,9 @@ async function configure(context) {
       if (study.category === 'My Studies') {
         throw context.boom.forbidden('Permissions cannot be set for studies in the "My Studies" category', true);
       }
+      if (study.category === 'Open Data') {
+        throw context.boom.forbidden('Permissions cannot be set for studies in the "Open Data" category', true);
+      }
 
       const result = await studyPermissionService.update(requestContext, studyId, updateRequest);
       res.status(200).json(result);

--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/study-controller.js
@@ -120,9 +120,10 @@ async function configure(context) {
       const requestContext = res.locals.requestContext;
       const filenames = req.query.filenames.split(',');
 
-      // Check permissions against a PUT request since uploading files to the study
-      //   is a mutating action
-      await studyPermissionService.verifyRequestorAccess(requestContext, studyId, 'PUT');
+      // Check permissions against an UPLOAD request.
+      // Note that we are not checking against 'PUT' which is an admin only feature since a user with 'Write'
+      // access should also be able to upload files to the study
+      await studyPermissionService.verifyRequestorAccess(requestContext, studyId, 'UPLOAD');
 
       const result = await studyService.createPresignedPostRequests(requestContext, studyId, filenames);
       res.status(200).json(result);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
@@ -50,7 +50,7 @@
     },
     "accessType": {
       "type": "string",
-      "enum": ["ReadOnly", "ReadWrite"]
+      "enum": ["readonly", "readwrite"]
     }
   },
   "required": ["id", "category"]

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study-permissions.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study-permissions.json
@@ -13,7 +13,7 @@
     },
     "permissionLevel": {
       "type": "string",
-      "enum": ["admin", "readonly"]
+      "enum": ["admin", "readonly", "writeonly", "readwrite"]
     },
     "userEntry": {
       "type": "object",

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
@@ -40,7 +40,7 @@
     },
     "accessType": {
       "type": "string",
-      "enum": ["ReadOnly", "ReadWrite"]
+      "enum": ["readonly", "readwrite"]
     }
   },
   "required": ["id", "rev"]

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-permission-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-permission-service.test.js
@@ -87,6 +87,66 @@ describe('studyPermissionService', () => {
       }
     });
 
+    it('should try to create a study permission for new write permissions', async () => {
+      // BUILD
+      const context = {
+        principalIdentifier: {
+          username: 'elmerfudd',
+          ns: 'elmerfudd.ltunes',
+        },
+      };
+
+      const retVal = {
+        id: 'Study:bugsbunny',
+        recordType: 'study',
+        adminUsers: [context.principalIdentifier],
+        readonlyUsers: [],
+        writeonlyUsers: [],
+        readwriteUsers: [],
+        createdBy: context.principalIdentifier,
+      };
+
+      const studyPermissionRecord = {
+        id: 'Study:bugsbunny',
+        recordType: 'study',
+        adminUsers: [context.principalIdentifier],
+        readonlyUsers: [],
+        writeonlyUsers: [],
+        readwriteUsers: [],
+        createdBy: context.principalIdentifier,
+      };
+
+      const userPermissionRecord = {
+        id: 'User:elmerfudd',
+        recordType: 'user',
+        principalIdentifier: context.principalIdentifier,
+        adminAccess: ['bugsbunny'],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      dbService.table.update.mockReturnValueOnce(retVal);
+
+      // OPERATE
+      const result = await service.create(context, 'bugsbunny');
+
+      // CHECK
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:elmerfudd' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'Study:bugsbunny' });
+      expect(dbService.table.item).toHaveBeenCalledWith(studyPermissionRecord);
+      expect(dbService.table.item).toHaveBeenCalledWith(userPermissionRecord);
+      expect(result).toEqual({
+        id: 'bugsbunny',
+        recordType: undefined,
+        adminUsers: [context.principalIdentifier],
+        readonlyUsers: [],
+        writeonlyUsers: [],
+        readwriteUsers: [],
+        createdBy: context.principalIdentifier,
+      });
+    });
+
     it('should try to create a study permission', async () => {
       // BUILD
       const context = {
@@ -218,6 +278,461 @@ describe('studyPermissionService', () => {
       expect(dbService.table.update).toHaveBeenCalled();
       expect(res).toMatchObject({ id: 'EXAMPLE' });
     });
+
+    it('update permissions should fail if same user is specified multiple non-admin permissions', async () => {
+      // BUILD
+      const multiplePermissionsUserWithReadOnly = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.multiple',
+          username: 'speedygonzales.multiple',
+        },
+        permissionLevel: 'readonly',
+      };
+
+      const multiplePermissionsUserWithWriteOnly = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.multiple',
+          username: 'speedygonzales.multiple',
+        },
+        permissionLevel: 'writeonly',
+      };
+
+      const readonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readonly',
+          username: 'speedygonzales.readonly',
+        },
+        permissionLevel: 'readonly',
+      };
+
+      const readwriteuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readwrite',
+          username: 'speedygonzales.readwrite',
+        },
+        permissionLevel: 'readwrite',
+      };
+
+      const writeonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.writeonly',
+          username: 'speedygonzales.writeonly',
+        },
+        permissionLevel: 'writeonly',
+      };
+
+      const updateRequest = {
+        usersToAdd: [
+          readonlyuser,
+          readwriteuser,
+          writeonlyuser,
+          multiplePermissionsUserWithWriteOnly,
+          multiplePermissionsUserWithReadOnly,
+        ],
+        usersToRemove: [],
+      };
+
+      service.findByStudy = jest.fn().mockResolvedValue({
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [],
+      });
+
+      dbService.table.update.mockReturnValueOnce({
+        id: 'Study:studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [{ ns: 'speedygonzales.looneytunes.readonly', username: 'speedygonzales.readonly' }],
+        writeonlyUsers: [{ ns: 'speedygonzales.looneytunes.writeonly', username: 'speedygonzales.writeonly' }],
+        readwriteUsers: [{ ns: 'speedygonzales.looneytunes.readwrite', username: 'speedygonzales.readwrite' }],
+      });
+
+      // OPERATE
+      try {
+        await service.update({}, 'studyId', updateRequest);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual(
+          'User speedygonzales.multiple cannot have multiple permissions: readonly,writeonly',
+        );
+      }
+    });
+
+    it('update permissions for study with multiple admins', async () => {
+      // BUILD
+      const admin1 = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin1',
+          username: 'speedygonzales.admin1',
+        },
+        permissionLevel: 'admin',
+      };
+
+      const admin2 = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin2',
+          username: 'speedygonzales.admin2',
+        },
+        permissionLevel: 'admin',
+      };
+
+      const writeonlyadmin = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin1',
+          username: 'speedygonzales.admin1',
+        },
+        permissionLevel: 'writeonly',
+      };
+
+      const updateRequest = {
+        usersToAdd: [admin1, admin2, writeonlyadmin],
+        usersToRemove: [],
+      };
+
+      const studyPermissionRecord = {
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [
+          { ns: 'efudd.looneytunes', username: 'efudd' },
+          { ns: 'speedygonzales.looneytunes.admin1', username: 'speedygonzales.admin1' },
+          { ns: 'speedygonzales.looneytunes.admin2', username: 'speedygonzales.admin2' },
+        ],
+        readonlyUsers: [],
+        updatedBy: undefined,
+        writeonlyUsers: [
+          {
+            ns: 'speedygonzales.looneytunes.admin1',
+            username: 'speedygonzales.admin1',
+          },
+        ],
+        readwriteUsers: [],
+      };
+
+      const admin1UserPermission = {
+        id: 'User:speedygonzales.admin1',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin1',
+          username: 'speedygonzales.admin1',
+        },
+        adminAccess: ['studyId'],
+        readonlyAccess: [],
+        writeonlyAccess: ['studyId'],
+        readwriteAccess: [],
+      };
+
+      const admin2UserPermission = {
+        id: 'User:speedygonzales.admin2',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin2',
+          username: 'speedygonzales.admin2',
+        },
+        adminAccess: ['studyId'],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      service.findByStudy = jest.fn().mockResolvedValue({
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [],
+      });
+
+      service.findByUser = jest.fn().mockImplementation((_, key) => {
+        switch (key) {
+          case 'speedygonzales.admin1':
+            return {
+              id: 'User:speedygonzales.admin1',
+              recordType: 'user',
+              principalIdentifier: {
+                ns: 'speedygonzales.looneytunes.admin1',
+                username: 'speedygonzales.admin1',
+              },
+              adminAccess: ['studyId'],
+              readonlyAccess: [],
+              writeonlyAccess: [],
+              readwriteAccess: [],
+            };
+          default:
+            return undefined;
+        }
+      });
+
+      dbService.table.update.mockReturnValueOnce({
+        id: 'Study:studyId',
+        recordType: 'TEST',
+        adminUsers: [
+          { ns: 'efudd.looneytunes', username: 'efudd' },
+          { ns: 'speedygonzales.looneytunes.admin1', username: 'speedygonzales.admin1' },
+          { ns: 'speedygonzales.looneytunes.admin2', username: 'speedygonzales.admin2' },
+        ],
+        readonlyUsers: [],
+        writeonlyUsers: [{ ns: 'speedygonzales.looneytunes.admin1', username: 'speedygonzales.admin1' }],
+        readwriteUsers: [],
+      });
+
+      // OPERATE
+      const res = await service.update({}, 'studyId', updateRequest);
+
+      // CHECK
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.admin1' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.admin2' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'Study:studyId' });
+      expect(dbService.table.item).toHaveBeenCalledWith(studyPermissionRecord);
+      expect(dbService.table.item).toHaveBeenCalledWith(admin1UserPermission);
+      expect(dbService.table.item).toHaveBeenCalledWith(admin2UserPermission);
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(res).toMatchObject({ id: 'studyId' });
+    });
+
+    it('update permissions for study that switched to readwrite', async () => {
+      // BUILD
+      const readonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readonly',
+          username: 'speedygonzales.readonly',
+        },
+        permissionLevel: 'readonly',
+      };
+
+      const readwriteuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readwrite',
+          username: 'speedygonzales.readwrite',
+        },
+        permissionLevel: 'readwrite',
+      };
+
+      const writeonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.writeonly',
+          username: 'speedygonzales.writeonly',
+        },
+        permissionLevel: 'writeonly',
+      };
+
+      const updateRequest = {
+        usersToAdd: [readonlyuser, readwriteuser, writeonlyuser],
+        usersToRemove: [],
+      };
+
+      const studyPermissionRecord = {
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [
+          {
+            ns: 'speedygonzales.looneytunes.readonly',
+            username: 'speedygonzales.readonly',
+          },
+        ],
+        updatedBy: undefined,
+        writeonlyUsers: [
+          {
+            ns: 'speedygonzales.looneytunes.writeonly',
+            username: 'speedygonzales.writeonly',
+          },
+        ],
+        readwriteUsers: [
+          {
+            ns: 'speedygonzales.looneytunes.readwrite',
+            username: 'speedygonzales.readwrite',
+          },
+        ],
+      };
+
+      const readOnlyUserPermission = {
+        id: 'User:speedygonzales.readonly',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readonly',
+          username: 'speedygonzales.readonly',
+        },
+        adminAccess: [],
+        readonlyAccess: ['studyId'],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      const writeOnlyUserPermission = {
+        id: 'User:speedygonzales.writeonly',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.writeonly',
+          username: 'speedygonzales.writeonly',
+        },
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: ['studyId'],
+        readwriteAccess: [],
+      };
+
+      const readWriteUserPermission = {
+        id: 'User:speedygonzales.readwrite',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readwrite',
+          username: 'speedygonzales.readwrite',
+        },
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: ['studyId'],
+      };
+
+      service.findByStudy = jest.fn().mockResolvedValue({
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [],
+      });
+
+      dbService.table.update.mockReturnValueOnce({
+        id: 'Study:studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [{ ns: 'speedygonzales.looneytunes.readonly', username: 'speedygonzales.readonly' }],
+        writeonlyUsers: [{ ns: 'speedygonzales.looneytunes.writeonly', username: 'speedygonzales.writeonly' }],
+        readwriteUsers: [{ ns: 'speedygonzales.looneytunes.readwrite', username: 'speedygonzales.readwrite' }],
+      });
+
+      // OPERATE
+      const res = await service.update({}, 'studyId', updateRequest);
+
+      // CHECK
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.writeonly' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.readonly' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.readwrite' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'Study:studyId' });
+      expect(dbService.table.item).toHaveBeenCalledWith(studyPermissionRecord);
+      expect(dbService.table.item).toHaveBeenCalledWith(readOnlyUserPermission);
+      expect(dbService.table.item).toHaveBeenCalledWith(readWriteUserPermission);
+      expect(dbService.table.item).toHaveBeenCalledWith(writeOnlyUserPermission);
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(res).toMatchObject({ id: 'studyId' });
+    });
+
+    it('remove permissions for readwrite users', async () => {
+      // BUILD
+      const readonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readonly',
+          username: 'speedygonzales.readonly',
+        },
+        permissionLevel: 'readonly',
+      };
+
+      const readwriteuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readwrite',
+          username: 'speedygonzales.readwrite',
+        },
+        permissionLevel: 'readwrite',
+      };
+
+      const writeonlyuser = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.writeonly',
+          username: 'speedygonzales.writeonly',
+        },
+        permissionLevel: 'writeonly',
+      };
+
+      const updateRequest = {
+        usersToAdd: [readonlyuser],
+        usersToRemove: [readwriteuser, writeonlyuser],
+      };
+
+      const studyPermissionRecord = {
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [
+          {
+            ns: 'speedygonzales.looneytunes.readonly',
+            username: 'speedygonzales.readonly',
+          },
+        ],
+        updatedBy: undefined,
+        writeonlyUsers: [],
+        readwriteUsers: [],
+      };
+
+      const readOnlyUserPermission = {
+        id: 'User:speedygonzales.readonly',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readonly',
+          username: 'speedygonzales.readonly',
+        },
+        adminAccess: [],
+        readonlyAccess: ['studyId'],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      const writeOnlyUserPermissionRemoved = {
+        id: 'User:speedygonzales.writeonly',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.writeonly',
+          username: 'speedygonzales.writeonly',
+        },
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      const readWriteUserPermissionRemoved = {
+        id: 'User:speedygonzales.readwrite',
+        recordType: 'user',
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.readwrite',
+          username: 'speedygonzales.readwrite',
+        },
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      };
+
+      service.findByStudy = jest.fn().mockResolvedValue({
+        id: 'studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [],
+      });
+
+      dbService.table.update.mockReturnValueOnce({
+        id: 'Study:studyId',
+        recordType: 'TEST',
+        adminUsers: [{ ns: 'efudd.looneytunes', username: 'efudd' }],
+        readonlyUsers: [{ ns: 'speedygonzales.looneytunes.readonly', username: 'speedygonzales.readonly' }],
+        writeonlyUsers: [{ ns: 'speedygonzales.looneytunes.writeonly', username: 'speedygonzales.writeonly' }],
+        readwriteUsers: [{ ns: 'speedygonzales.looneytunes.readwrite', username: 'speedygonzales.readwrite' }],
+      });
+
+      // OPERATE
+      const res = await service.update({}, 'studyId', updateRequest);
+
+      // CHECK
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.writeonly' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.readonly' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'User:speedygonzales.readwrite' });
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'Study:studyId' });
+      expect(dbService.table.item).toHaveBeenCalledWith(studyPermissionRecord);
+      expect(dbService.table.item).toHaveBeenCalledWith(readOnlyUserPermission);
+      expect(dbService.table.item).toHaveBeenCalledWith(readWriteUserPermissionRemoved);
+      expect(dbService.table.item).toHaveBeenCalledWith(writeOnlyUserPermissionRemoved);
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(res).toMatchObject({ id: 'studyId' });
+    });
   });
 
   describe('delete function', () => {
@@ -250,6 +765,375 @@ describe('studyPermissionService', () => {
       await service.delete(studyRecord, 'exampleStudyId');
       expect(service.upsertUserRecord).toHaveBeenCalledTimes(2);
       expect(dbService.table.delete).toHaveBeenCalled();
+    });
+
+    it('delete study with accessType defined as readwrite', async () => {
+      // BUILD
+      const adminUser = {
+        principalIdentifier: {
+          username: 'foghorn',
+          ns: 'foghorn.leghorn',
+        },
+        permissionLevel: 'admin',
+      };
+      const writeOnlyUser = {
+        principalIdentifier: {
+          username: 'tweety.writeonly',
+          ns: 'tweety.bird.writeonly',
+        },
+        permissionLevel: 'writeonly',
+      };
+      const readWriteUser = {
+        principalIdentifier: {
+          username: 'tweety.readwrite',
+          ns: 'tweety.bird.readwrite',
+        },
+        permissionLevel: 'readwrite',
+      };
+      const studyRecord = {
+        adminUsers: [adminUser],
+        readonlyUsers: [],
+        writeonlyUsers: [writeOnlyUser],
+        readwriteUsers: [readWriteUser],
+      };
+
+      lockService.getLockKey = jest.fn();
+      service.findByStudy = jest.fn().mockResolvedValueOnce(studyRecord);
+      dbService.table.delete.mockResolvedValueOnce({ id: 'study:DELETETEST', recordType: 'extraneous' });
+      service.upsertUserRecord = jest.fn();
+
+      await service.delete(studyRecord, 'exampleStudyId');
+      expect(service.upsertUserRecord).toHaveBeenCalledTimes(3);
+      expect(dbService.table.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('verify requestor access', () => {
+    it('admin should have UPLOAD access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: ['studyId'],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'UPLOAD');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('admin should have GET access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: ['studyId'],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'GET');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('admin should have PUT access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes.admin1',
+          username: 'speedygonzales.admin1',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales.admin1',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: ['studyId'],
+        readonlyAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'PUT');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('writeonly user should have UPLOAD access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: ['studyId'],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'UPLOAD');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('writeonly user should have GET access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: ['studyId'],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'GET');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('writeonly user should not have PUT access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: ['studyId'],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      try {
+        await service.verifyRequestorAccess(request, 'studyId', 'PUT');
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('');
+      }
+    });
+
+    it('readwrite user should have UPLOAD access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: ['studyId'],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'UPLOAD');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('readwrite user should have GET access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: ['studyId'],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'GET');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('readwrite user should not have PUT access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: [],
+        writeonlyAccess: [],
+        readwriteAccess: ['studyId'],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      try {
+        await service.verifyRequestorAccess(request, 'studyId', 'PUT');
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('');
+      }
+    });
+
+    it('readonly user should not have UPLOAD access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: ['studyId'],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      try {
+        await service.verifyRequestorAccess(request, 'studyId', 'UPLOAD');
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('');
+      }
+    });
+
+    it('readonly user should have GET access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: ['studyId'],
+        writeonlyAccess: [],
+        readwriteAccess: [],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      await service.verifyRequestorAccess(request, 'studyId', 'GET');
+      expect(service.findByUser).toHaveBeenCalled();
+    });
+
+    it('readonly user should not have PUT access', async () => {
+      // BUILD
+      const request = {
+        principalIdentifier: {
+          ns: 'speedygonzales.looneytunes',
+          username: 'speedygonzales',
+        },
+      };
+      service.findByUser = jest.fn().mockResolvedValue({
+        id: 'User:speedygonzales',
+        recordType: 'user',
+        principalIdentifier: request.principalIdentifier,
+        adminAccess: [],
+        readonlyAccess: ['studyId'],
+      });
+
+      lockService.getLockKey = jest.fn();
+
+      // OPERATE
+      try {
+        await service.verifyRequestorAccess(request, 'studyId', 'PUT');
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('');
+      }
+    });
+
+    it('invalid action', async () => {
+      // OPERATE
+      try {
+        await service.verifyRequestorAccess({}, 'studyId', 'GARBAGE');
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Invalid action passed to verifyRequestorAccess(): GARBAGE');
+      }
     });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
@@ -177,12 +177,12 @@ describe('studyService', () => {
       );
     });
 
-    it('should try to create the study successfully when accessType is ReadOnly', async () => {
+    it('should try to create the study successfully when accessType is readonly', async () => {
       // BUILD
       const dataIpt = {
         id: 'doppelganger',
         category: 'Open Data',
-        accessType: 'ReadOnly',
+        accessType: 'readonly',
       };
 
       service.audit = jest.fn();
@@ -198,7 +198,7 @@ describe('studyService', () => {
       );
     });
 
-    it('should try to create the study successfully when accessType is ReadWrite for My Studies', async () => {
+    it('should try to create the study successfully when accessType is readwrite for My Studies', async () => {
       // BUILD
       projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
         return true;
@@ -206,7 +206,7 @@ describe('studyService', () => {
       const dataIpt = {
         id: 'doppelganger',
         category: 'My Studies',
-        accessType: 'ReadWrite',
+        accessType: 'readwrite',
         projectId: 'some_project_id',
       };
 
@@ -223,7 +223,7 @@ describe('studyService', () => {
       );
     });
 
-    it('should try to create the study successfully when accessType is ReadWrite for Organization', async () => {
+    it('should try to create the study successfully when accessType is readwrite for Organization', async () => {
       // BUILD
       projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
         return true;
@@ -231,7 +231,7 @@ describe('studyService', () => {
       const dataIpt = {
         id: 'doppelganger',
         category: 'Organization',
-        accessType: 'ReadWrite',
+        accessType: 'readwrite',
         projectId: 'some_project_id',
       };
 
@@ -248,12 +248,12 @@ describe('studyService', () => {
       );
     });
 
-    it('should fail because accessType specified is readonly in lowercase', async () => {
+    it('should fail because accessType specified is ReadOnly in camelcase', async () => {
       // BUILD
       const ipt = {
         name: 'doppelganger',
         category: 'My Studies',
-        accessType: 'readonly',
+        accessType: 'ReadOnly',
       };
 
       // OPERATE
@@ -284,7 +284,7 @@ describe('studyService', () => {
       }
     });
 
-    it('should fail because accessType is ReadWrite for Open Data', async () => {
+    it('should fail because accessType is readwrite for Open Data', async () => {
       // BUILD
       projectService.verifyUserProjectAssociation = jest.fn().mockImplementationOnce(() => {
         return true;
@@ -292,7 +292,7 @@ describe('studyService', () => {
       const ipt = {
         id: 'doppelganger',
         category: 'Open Data',
-        accessType: 'ReadWrite',
+        accessType: 'readwrite',
         projectId: 'some_project_id',
       };
 
@@ -342,11 +342,11 @@ describe('studyService', () => {
       }
     });
 
-    it('should fail due to ReadWrite accessType on Open Data study', async () => {
+    it('should fail due to readwrite accessType on Open Data study', async () => {
       // BUILD
       const dataIpt = {
         id: 'doppelganger',
-        accessType: 'ReadWrite',
+        accessType: 'readwrite',
         rev: 1,
       };
       service.find = jest.fn().mockImplementationOnce(() => {
@@ -394,7 +394,7 @@ describe('studyService', () => {
       const dataIpt = {
         id: 'doppelganger',
         rev: 1,
-        accessType: 'ReadOnly',
+        accessType: 'readonly',
       };
 
       dbService.table.update.mockImplementationOnce(() => {
@@ -441,11 +441,11 @@ describe('studyService', () => {
       expect(service.audit).toHaveBeenCalledWith({}, { action: 'update-study', body: undefined });
     });
 
-    it('should succeed with ReadWrite accessType', async () => {
+    it('should succeed with readwrite accessType', async () => {
       // BUILD
       const dataIpt = {
         id: 'doppelganger',
-        accessType: 'ReadWrite',
+        accessType: 'readwrite',
         rev: 1,
       };
       service.find = jest.fn().mockImplementationOnce(() => {
@@ -461,11 +461,11 @@ describe('studyService', () => {
       expect(service.audit).toHaveBeenCalledWith({}, { action: 'update-study', body: undefined });
     });
 
-    it('should succeed with ReadOnly accessType', async () => {
+    it('should succeed with readonly accessType', async () => {
       // BUILD
       const dataIpt = {
         id: 'doppelganger',
-        accessType: 'ReadOnly',
+        accessType: 'readonly',
         rev: 1,
       };
       service.find = jest.fn().mockImplementationOnce(() => {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -404,7 +404,7 @@ class StudyService extends Service {
 
   // ensure that study accessType is read/write for Open Data category
   validateStudyType(accessType, studyCategory) {
-    if (accessType === 'ReadWrite' && studyCategory === 'Open Data') {
+    if (accessType === 'readwrite' && studyCategory === 'Open Data') {
       throw this.boom.badRequest('Open Data study cannot be read/write', true);
     }
   }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -402,7 +402,7 @@ class StudyService extends Service {
     return auditWriterService.writeAndForget(requestContext, auditEvent);
   }
 
-  // ensure that study accessType is read/write for Open Data category
+  // ensure that study accessType isn't read/write for Open Data category
   validateStudyType(accessType, studyCategory) {
     if (accessType === 'readwrite' && studyCategory === 'Open Data') {
       throw this.boom.badRequest('Open Data study cannot be read/write', true);


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Deny permissions change for Open Data study
* Enum for accessType changed to lower case to match existing permission case
* Added check to disallow ReadWrite accessType on Open Data Studies
* Added writeonly and readwrite permission levels for studies
* Disallow same user to have multiple non-admin permissions
* Allow UPLOAD access for users with write access
* Added new unit tests to verify check permissions functionality

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

[✓] Have you successfully deployed to an AWS account with your changes? 
[✓] Have you linted your code locally prior to submission?
[✓] Have you written new tests for your core changes, as applicable?
[✓] Have you successfully ran unit tests and manual tests with your changes locally?
[] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)? Didn't run manual tests since the changes are made to Study API which isn't added yet. Additionally, these are backend changes and not being called from UI yet, will tackle this bit when we do the UI integration.

### UI testing
* Verified that create study works for both personal and org studies
* Verified that studies can be edited correctly
* Verified that upload functionality still works as expected

### Testing done via Postman
* UPDATE Study permissions of an existing read only study and give writeonly/readwrite access
* Tested error scenarios when readonly user shouldn't have upload access
* Tested writeonly, write and admin have upload access
* Tested that same user cannot have multiple non-admin permissions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
