### PR TITLE
nameFix: using a better suited name for dep item

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
@@ -343,12 +343,21 @@ class CreateServiceCatalogPortfolio extends Service {
 
   async findDeploymentItem({ id }) {
     const [deploymentStore] = await this.service(['deploymentStoreService']);
-    return deploymentStore.find({ type: 'post-deployment-step', id });
+    let record = await deploymentStore.find({ type: 'default-sc-portfolio', id });
+    if (!record) {
+      // The old code had type = 'post-deployment-step', due to this the DB may have record with old type value
+      record = await deploymentStore.find({ type: 'post-deployment-step', id });
+    }
+    return record;
   }
 
   async createDeploymentItem({ id, strValue }) {
     const [deploymentStore] = await this.service(['deploymentStoreService']);
-    return deploymentStore.createOrUpdate({ type: 'post-deployment-step', id, value: strValue });
+    // The old code had type = 'post-deployment-step', due to this the DB may have record with old type value
+    const recordWithOldType = await deploymentStore.find({ type: 'post-deployment-step', id });
+    // Continue to use type = 'post-deployment-step' if db already has a record with that type
+    const recordType = recordWithOldType ? 'post-deployment-step' : 'default-sc-portfolio';
+    return deploymentStore.createOrUpdate({ type: recordType, id, value: strValue });
   }
 
   async execute() {


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Using a better suited name instead of generic 'post-deployment-step' for creating SC portfolio.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
