### PR TITLE
feat: autostop SM and rstudio

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
@@ -27,6 +27,9 @@ Parameters:
     Description: >-
       An S3 URI (starting with "s3://") that specifies the location of files to be copied to
       the environment instance, including any bootstrap scripts
+  AutoStopIdleTimeInMinutes:
+    Type: Number
+    Description: Number of idle minutes for auto stop to shutdown the instance (0 to disable auto-stop)
 
 Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
@@ -124,6 +127,25 @@ Resources:
                 - logs:CreateLogGroup
               Resource:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/sagemaker/*
+
+  # This policy is attached to the role after the instance is created
+  # so that the instance can be referenced in the resource section
+  NotebookStopPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: NotebookStop
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sagemaker:DescribeNotebookInstance
+              - sagemaker:StopNotebookInstance
+            Resource:
+              - !Ref BasicNotebookInstance
+      Roles:
+        - !Ref IAMRole
+
   # TODO: Consider also passing DefaultCodeRepository to allow persisting notebook data
   BasicNotebookInstance:
     Type: 'AWS::SageMaker::NotebookInstance'
@@ -147,6 +169,16 @@ Resources:
               aws s3 cp "${EnvironmentInstanceFiles}/get_bootstrap.sh" "/tmp"
               chmod 500 "/tmp/get_bootstrap.sh"
               /tmp/get_bootstrap.sh "${EnvironmentInstanceFiles}" '${S3Mounts}'
+
+              # Stop Idle Script
+              if [ "${AutoStopIdleTimeInMinutes}" != "0" ]; then
+                echo "Fetching the autostop script"
+                curl -L -o /usr/local/bin/autostop.py https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
+                chmod a+x /usr/local/bin/autostop.py
+                IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
+                echo "Starting the SageMaker autostop script in cron"
+                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+              fi
 
 Outputs:
   NotebookInstanceName:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
@@ -124,25 +124,6 @@ Resources:
                 - logs:CreateLogGroup
               Resource:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/sagemaker/*
-
-  # This policy is attached to the role after the instance is created
-  # so that the instance can be referenced in the resource section
-  NotebookStopPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: NotebookStop
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - sagemaker:DescribeNotebookInstance
-              - sagemaker:StopNotebookInstance
-            Resource:
-              - !Ref BasicNotebookInstance
-      Roles:
-        - !Ref IAMRole
-
   # TODO: Consider also passing DefaultCodeRepository to allow persisting notebook data
   BasicNotebookInstance:
     Type: 'AWS::SageMaker::NotebookInstance'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/external/sagemaker.cfn.yml
@@ -27,9 +27,6 @@ Parameters:
     Description: >-
       An S3 URI (starting with "s3://") that specifies the location of files to be copied to
       the environment instance, including any bootstrap scripts
-  AutoStopIdleTimeInMinutes:
-    Type: Number
-    Description: Number of idle minutes for auto stop to shutdown the instance (0 to disable auto-stop)
 
 Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
@@ -169,16 +166,6 @@ Resources:
               aws s3 cp "${EnvironmentInstanceFiles}/get_bootstrap.sh" "/tmp"
               chmod 500 "/tmp/get_bootstrap.sh"
               /tmp/get_bootstrap.sh "${EnvironmentInstanceFiles}" '${S3Mounts}'
-
-              # Stop Idle Script
-              if [ "${AutoStopIdleTimeInMinutes}" != "0" ]; then
-                echo "Fetching the autostop script"
-                curl -L -o /usr/local/bin/autostop.py https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
-                chmod a+x /usr/local/bin/autostop.py
-                IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
-                echo "Starting the SageMaker autostop script in cron"
-                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
-              fi
 
 Outputs:
   NotebookInstanceName:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -84,6 +84,15 @@ Resources:
                     s3:prefix: !Sub
                       - '${S3Prefix}/*'
                       - S3Prefix: !Select [3, !Split ['/', !Ref EnvironmentInstanceFiles]]
+        - PolicyName: param-store-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - 'ssm:GetParameter'
+                  - 'ssm:PutParameter'
+                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
 
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -30,6 +30,9 @@ Parameters:
   EncryptionKeyArn:
     Type: String
     Description: The ARN of the KMS encryption Key used to encrypt data in the notebook
+  AutoStopIdleTimeInMinutes:
+    Type: Number
+    Description: Number of idle minutes for auto stop to shutdown the instance (0 to disable auto-stop)
 
 Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
@@ -94,6 +97,25 @@ Resources:
                 - logs:CreateLogGroup
               Resource:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/sagemaker/*
+
+  # This policy is attached to the role after the instance is created
+  # so that the instance can be referenced in the resource section
+  NotebookStopPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: NotebookStop
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sagemaker:DescribeNotebookInstance
+              - sagemaker:StopNotebookInstance
+            Resource:
+              - !Ref BasicNotebookInstance
+      Roles:
+        - !Ref IAMRole
+
   # TODO: Consider also passing DefaultCodeRepository to allow persisting notebook data
   BasicNotebookInstance:
     Type: 'AWS::SageMaker::NotebookInstance'
@@ -117,6 +139,16 @@ Resources:
               aws s3 cp "${EnvironmentInstanceFiles}/get_bootstrap.sh" "/tmp"
               chmod 500 "/tmp/get_bootstrap.sh"
               /tmp/get_bootstrap.sh "${EnvironmentInstanceFiles}" '${S3Mounts}'
+
+              # Stop Idle Script
+              if [ "${AutoStopIdleTimeInMinutes}" != "0" ]; then
+                echo "Fetching the autostop script"
+                curl -L -o /usr/local/bin/autostop.py https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
+                chmod a+x /usr/local/bin/autostop.py
+                IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
+                echo "Starting the SageMaker autostop script in cron"
+                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+              fi
 
 Outputs:
   NotebookInstanceName:

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-connection-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-connection-service.test.js
@@ -121,13 +121,15 @@ describe('EnvironmentScConnectionService', () => {
 
     it('should get RStudio auth URL correctly', async () => {
       // BUILD
+      const requestContext = 'sampleContext';
       const id = 'exampleId';
       const connection = { instanceId: 'RStudioInstanceId' };
       envDnsService.getHostname = jest.fn(() => `rstudio-${id}.example.com`);
       service.mustFindConnection = jest.fn(() => connection);
+      service.getRstudioPublicKey = jest.fn(() => `0001:SAMPLEPUBLICKEY`);
 
       // OPERATE
-      const authUrl = await service.getRStudioUrl(id, connection);
+      const authUrl = await service.getRStudioUrl(requestContext, id, connection);
 
       // CHECK
       expect(authUrl).toEqual(`https://rstudio-${id}.example.com/auth-do-sign-in?SampleEncodedParams`);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -125,7 +125,7 @@ async function updateEnvOnProvisioningSuccess({
     if (connectionTypeValue.toLowerCase() === 'rstudio') {
       const dnsName = _.find(outputs, o => o.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
       const environmentDnsService = await container.find('environmentDnsService');
-      environmentDnsService.createRecord('rstudio', envId, dnsName);
+      await environmentDnsService.createRecord('rstudio', envId, dnsName);
     }
   }
 
@@ -199,7 +199,7 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
 
   const existingEnvRecord = await environmentScService.mustFind(requestContext, {
     id: envId,
-    fields: ['rev'],
+    fields: ['rev', 'outputs'],
   });
 
   log.debug({ msg: `Updating environment record after successful termination`, envId });
@@ -216,16 +216,7 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
   log.debug({ msg: `Cleaning up local resource policies`, envId });
 
   // Delete DNS record for RStudio workspaces
-  const connectionType = _.find(updatedEnvironment.outputs, o => o.OutputKey === 'MetaConnection1Type');
-  let connectionTypeValue;
-  if (connectionType) {
-    connectionTypeValue = connectionType.OutputValue;
-    if (connectionTypeValue.toLowerCase() === 'rstudio') {
-      const dnsName = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
-      const environmentDnsService = await container.find('environmentDnsService');
-      environmentDnsService.deleteRecord('rstudio', envId, dnsName);
-    }
-  }
+  await rstudioCleanup(requestContext, updatedEnvironment, container);
 
   const indexesService = await container.find('indexesService');
   const { awsAccountId } = await indexesService.mustFind(requestContext, { id: updatedEnvironment.indexId });
@@ -251,6 +242,39 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
   await environmentScKeypairService.delete(requestContext, envId);
 
   return { requestContext, container, status, envId, record };
+}
+
+// This method checks if the environment being terminated is an RStudio.
+// If yes, this will delete the CNAME record in Route 53 service and the
+// SSM public kay parameter created during environment's provisioning
+async function rstudioCleanup(requestContext, updatedEnvironment, container) {
+  const connectionType = _.find(updatedEnvironment.outputs, o => o.OutputKey === 'MetaConnection1Type');
+  let connectionTypeValue;
+  if (connectionType) {
+    connectionTypeValue = connectionType.OutputValue;
+    if (connectionTypeValue.toLowerCase() === 'rstudio') {
+      const dnsName = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
+      const instanceId = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceInstanceId').OutputValue;
+      const environmentDnsService = await container.find('environmentDnsService');
+      const environmentScService = await container.find('environmentScService');
+      await environmentDnsService.deleteRecord('rstudio', updatedEnvironment.id, dnsName);
+
+      const ssm = await environmentScService.getClientSdkWithEnvMgmtRole(
+        requestContext,
+        { id: updatedEnvironment.id },
+        { clientName: 'SSM', options: { apiVersion: '2014-11-06' } },
+      );
+      await ssm
+        .deleteParameter({ Name: `/rstudio/publickey/sc-environments/ec2-instance/${instanceId}` })
+        .promise()
+        .catch(e => {
+          // Nothing to do if ParameterNotFound, rethrow any other errors
+          if (e.code !== 'ParameterNotFound') {
+            throw e;
+          }
+        });
+    }
+  }
 }
 
 // The "terminate-product' workflow call "onEnvTerminationFailure" in case of any errors

--- a/main/solution/machine-images/config/infra/files/rstudio/set-password
+++ b/main/solution/machine-images/config/infra/files/rstudio/set-password
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-instance_id=$(curl -s "http://169.254.169.254/1.0/meta-data/instance-id")
+instance_id=$(curl -s "http://169.254.169.254/latest/meta-data/instance-id")
 secret=$(cat "/root/secret.txt")
 password=$(echo -n "${instance_id}${secret}" | sha256sum | awk '{print $1}')
 echo "rstudio-user:$password" | /usr/sbin/chpasswd
 echo "Set rstudio-user password"
+
+public_key=$(curl http://localhost:8787/auth-public-key)
+instance_region=$(curl -s "http://169.254.169.254/latest/meta-data/placement/region")
+aws ssm put-parameter --name "/rstudio/publickey/sc-environments/ec2-instance/${instance_id}" --value $public_key --region $instance_region --type SecureString --overwrite 
+echo "Stored rstudio public key in SSM"

--- a/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -37,17 +37,13 @@ sudo crontab -l 2>/dev/null > "/tmp/crontab"
 echo '@reboot /usr/local/bin/set-password 2>&1 >> /var/log/set-password.log' >> "/tmp/crontab"
 sudo crontab "/tmp/crontab"
 
-
-# Auto-stop feature needs re-work that's coming soon. 
-# Right now, this auto-stop technique renders Route 53 CNAME record useless after restarting EC2
-
 # Install script that checks idle time and shuts down if max idle is reached
-# sudo mv "/tmp/rstudio/check-idle" "/usr/local/bin/"
-# sudo chown root: "/usr/local/bin/check-idle"
-# sudo chmod 775 "/usr/local/bin/check-idle"
-# sudo crontab -l 2>/dev/null > "/tmp/crontab"
-# echo '*/5 * * * * /usr/local/bin/check-idle 2>&1 >> /var/log/check-idle.log' >> "/tmp/crontab"
-# sudo crontab "/tmp/crontab"
+sudo mv "/tmp/rstudio/check-idle" "/usr/local/bin/"
+sudo chown root: "/usr/local/bin/check-idle"
+sudo chmod 775 "/usr/local/bin/check-idle"
+sudo crontab -l 2>/dev/null > "/tmp/crontab"
+echo '*/5 * * * * /usr/local/bin/check-idle 2>&1 >> /var/log/check-idle.log' >> "/tmp/crontab"
+sudo crontab "/tmp/crontab"
 
 
 # Wipe out all traces of provisioning files


### PR DESCRIPTION
Issue #, if available:
GALI-476
GALI-477

Description of changes:

Added auto-stop scripts for Sagemaker and RStudio
Added security enhancement for RStudio (environments do not need to be open to internet anymore)

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
