### PR TITLE
RStudio manual start-stop & BugFixes

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentsStore.js
@@ -160,17 +160,12 @@ const ScEnvironmentsStore = BaseStore.named('ScEnvironmentsStore')
     canChangeState(id) {
       const outputs = self.environments.get(id).outputs;
       let result = false;
-      // TODO: Remove isRStudio check after CNAME patch
-      let isRStudio = false;
       outputs.forEach(output => {
         if (output.OutputKey === 'Ec2WorkspaceInstanceId' || output.OutputKey === 'NotebookInstanceName') {
           result = true;
         }
-        if (output.OutputKey === 'MetaConnection1Type' && output.OutputValue === 'RStudio') {
-          isRStudio = true;
-        }
       });
-      return result && !isRStudio;
+      return result;
     },
 
     get user() {

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -217,9 +217,6 @@ Outputs:
   #  Currently this is applicable only when ConnectionScheme = 'ssh'.
   #  This instanceId will be used for sending user's SSH public key using AWS EC2 Instance Connect when user wants to SSH to the instance.
   #
-  MetaConnection1Info:
-    Description: The name of the RStudio notebook instance.
-    Value: !GetAtt [EC2Instance, PublicDnsName]
 
   MetaConnection1Type:
     Description: Type of environment this connection is for

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -32,6 +32,8 @@ const workflowIds = {
   delete: 'wf-terminate-environment-sc',
   stopEC2: 'wf-stop-ec2-environment-sc',
   startEC2: 'wf-start-ec2-environment-sc',
+  stopRStudio: 'wf-stop-rstudio-environment-sc',
+  startRStudio: 'wf-start-rstudio-environment-sc',
   stopSagemaker: 'wf-stop-sagemaker-environment-sc',
   startSagemaker: 'wf-start-sagemaker-environment-sc',
 };
@@ -307,9 +309,11 @@ class EnvironmentScService extends Service {
     let instanceType;
     let instanceIdentifier;
     const outputsObject = cfnOutputsArrayToObject(outputs);
-    // TODO: Remove MetaConnection1Type check to include RStudio after CNAME patch
     if ('Ec2WorkspaceInstanceId' in outputsObject && _.get(outputsObject, 'MetaConnection1Type') !== 'RStudio') {
       instanceType = 'ec2';
+      instanceIdentifier = outputsObject.Ec2WorkspaceInstanceId;
+    } else if ('Ec2WorkspaceInstanceId' in outputsObject && _.get(outputsObject, 'MetaConnection1Type') === 'RStudio') {
+      instanceType = 'rstudio';
       instanceIdentifier = outputsObject.Ec2WorkspaceInstanceId;
     } else if ('NotebookInstanceName' in outputsObject) {
       instanceType = 'sagemaker';

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/plugins/workflow-steps-plugin.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/plugins/workflow-steps-plugin.js
@@ -31,6 +31,13 @@ const startEC2Yaml = require('../steps/start-ec2-environment/start-ec2-environme
 const stopEC2 = require('../steps/stop-ec2-environment/stop-ec2-environment-sc.js');
 const stopEC2Yaml = require('../steps/stop-ec2-environment/stop-ec2-environment-sc.yml');
 
+const startRStudio = require('../steps/start-rstudio-environment/start-rstudio-environment-sc.js');
+const startRStudioYaml = require('../steps/start-rstudio-environment/start-rstudio-environment-sc.yml');
+
+// Stop RStudio is the same as Stop EC2
+const stopRStudio = require('../steps/stop-ec2-environment/stop-ec2-environment-sc.js');
+const stopRStudioYaml = require('../steps/stop-rstudio-environment/stop-rstudio-environment-sc.yml');
+
 const startSageMaker = require('../steps/start-sagemaker-environment/start-sagemaker-environment-sc.js');
 const startSageMakerYaml = require('../steps/start-sagemaker-environment/start-sagemaker-environment-sc.yml');
 
@@ -50,6 +57,8 @@ const steps = [
   add(launchProduct, launchProductYaml),
   add(startEC2, startEC2Yaml),
   add(stopEC2, stopEC2Yaml),
+  add(startRStudio, startRStudioYaml),
+  add(stopRStudio, stopRStudioYaml),
   add(startSageMaker, startSageMakerYaml),
   add(stopSageMaker, stopSageMakerYaml),
   add(terminateProduct, terminateProductYaml),

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/start-rstudio-environment-sc.test.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/start-rstudio-environment-sc.test.js
@@ -1,0 +1,168 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const WorkflowPayload = require('@aws-ee/workflow-engine/lib/workflow-payload');
+const StartRStudioEnvironmentSc = require('../start-rstudio-environment/start-rstudio-environment-sc');
+
+describe('StartRStudioEnvironmentStep', () => {
+  const requestContext = {
+    principal: {
+      isAdmin: true,
+      status: 'active',
+    },
+  };
+
+  const meta = { workflowId: `wf-start-rstudio-environment-sc` };
+  const input = {
+    environmentId: 12345678,
+    instanceIdentifier: 'ec2-instance-id',
+    requestContext,
+    cfnExecutionRole: 'exe-role-arn',
+    roleExternalId: 'swb',
+  };
+
+  const step = new StartRStudioEnvironmentSc({
+    step: { config: {} },
+    workflowPayload: new WorkflowPayload({
+      meta,
+      input,
+      workflowInstance: { steps: ['st-start-rstudio-environment-sc'] },
+    }),
+  });
+  let ec2;
+
+  beforeAll(async () => {
+    step.payload = {
+      string: stringInput => {
+        return stringInput;
+      },
+      object: () => {
+        return requestContext;
+      },
+    };
+
+    step.state = {
+      setKey: jest.fn(),
+      ...step.payload,
+    };
+  });
+
+  beforeEach(async () => {
+    ec2 = {
+      describeInstances: jest.fn(),
+      describeInstanceStatus: jest.fn(),
+      startInstances: jest.fn(),
+    };
+    step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+    step.getExistingEnvironmentRecord = jest.fn(() => {});
+    step.updateEnvironment = jest.fn(() => {});
+  });
+
+  afterEach(() => {});
+
+  describe('start', () => {
+    it('should throw error when ec2 describe instance throw error', async () => {
+      // BUILD
+      ec2.describeInstanceStatus = jest.fn().mockImplementation(() => {
+        throw new Error('EC2 describe error message');
+      });
+      step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+      // OPERATE n CHECK
+      await expect(step.start()).rejects.toThrow('EC2 describe error message');
+    });
+
+    it('should skip ec2 start call if the status is RUNNING', async () => {
+      // BUILD
+      ec2.describeInstanceStatus = jest.fn().mockImplementation(() => {
+        return {
+          promise: () => {
+            return { InstanceStatuses: [{ InstanceState: { Name: 'running' } }] };
+          },
+        };
+      });
+      step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+      // OPERATE
+      await step.start();
+      // CHECK
+      expect(ec2.startInstances).not.toHaveBeenCalled();
+    });
+
+    it('should throw EC2 instance is not stopped error if instance status is STOPPING', async () => {
+      // BUILD
+      ec2.describeInstanceStatus = jest.fn().mockImplementation(() => {
+        return {
+          promise: () => {
+            return { InstanceStatuses: [{ InstanceState: { Name: 'stopping' } }] };
+          },
+        };
+      });
+      step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+      // OPERATE n CHECK
+      await expect(step.start()).rejects.toThrow('EC2 instance [instanceIdentifier] is not stopped');
+    });
+
+    it('should throw error when ec2 start instance throw error', async () => {
+      // BUILD
+      ec2.describeInstanceStatus = jest.fn().mockImplementation(() => {
+        return {
+          promise: () => {
+            return { InstanceStatuses: [{ InstanceState: { Name: 'stopped' } }] };
+          },
+        };
+      });
+      ec2.startInstances = jest.fn().mockImplementation(() => {
+        throw new Error('EC2 start instance error message');
+      });
+      step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+      // OPERATE n CHECK
+      await expect(step.start()).rejects.toThrow('EC2 start instance error message');
+    });
+
+    it('should return resolved promise', async () => {
+      // BUILD
+      ec2.describeInstanceStatus = jest.fn().mockImplementation(() => {
+        return {
+          promise: () => {
+            return { InstanceStatuses: [{ InstanceState: { Name: 'stopped' } }] };
+          },
+        };
+      });
+      ec2.startInstances = jest.fn().mockImplementation(() => {
+        return {
+          promise: () => {
+            return {};
+          },
+        };
+      });
+      step.getEc2Service = jest.fn().mockResolvedValue(ec2);
+
+      // OPERATE n
+      const response = await step.start();
+
+      // CHECK
+      expect(response).toMatchObject({
+        waitDecision: {
+          check: { methodName: 'checkInstanceStarted', params: '[]' },
+          counter: 120,
+          max: 120,
+          otherwise: undefined,
+          seconds: 5,
+          thenCall: { methodName: 'updateEnvironmentStatusAndIp', params: '[]' },
+          type: 'wait',
+        },
+      });
+    });
+  });
+});

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.js
@@ -1,0 +1,190 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+class StartRStudioEnvironmentSc extends StepBase {
+  async start() {
+    const environmentId = await this.payload.string('environmentId');
+    this.state.setKey('STATE_ENVIRONMENT_ID', environmentId);
+
+    const requestContext = await this.payload.object('requestContext');
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+
+    const instanceId = await this.payload.string('instanceIdentifier');
+
+    const ec2 = await this.getEc2Service();
+
+    const params = {
+      InstanceIds: [instanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const paramsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(paramsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+    if (!['PENDING', 'RUNNING'].includes(status)) {
+      if (status !== 'STOPPED') {
+        throw new Error(`EC2 instance [${instanceId}] is not stopped`);
+      }
+      try {
+        await ec2.startInstances(params).promise();
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('start ec2 instance error: ', error);
+        throw error;
+      }
+    }
+    await this.updateEnvironment({ status: 'STARTING' });
+    this.state.setKey('STATE_INSTANCE_ID', instanceId);
+
+    return this.wait(5)
+      .maxAttempts(120)
+      .until('checkInstanceStarted')
+      .thenCall('updateEnvironmentStatusAndIp');
+  }
+
+  async checkInstanceStarted() {
+    const instanceId = await this.state.string('STATE_INSTANCE_ID');
+    this.print(`instanceId: [${instanceId}]`);
+
+    const ec2 = await this.getEc2Service();
+    const params = {
+      InstanceIds: [instanceId],
+    };
+
+    let instanceStatusInfo;
+    try {
+      const paramsForDescribe = { ...params, IncludeAllInstances: true };
+      instanceStatusInfo = await ec2.describeInstanceStatus(paramsForDescribe).promise();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('describe ec2 instance error: ', error);
+      throw error;
+    }
+
+    const status = _.get(instanceStatusInfo, 'InstanceStatuses[0].InstanceState.Name').toUpperCase();
+
+    if (['SHUTTING-DOWN', 'TERMINATED', 'STOPPING'].includes(status)) {
+      throw new Error(`EC2 instance [${instanceId}] is in [${status}] state and can not be started`);
+    }
+
+    return status === 'RUNNING';
+  }
+
+  async getEc2Service() {
+    const [aws] = await this.mustFindServices(['aws']);
+    const [requestContext, RoleArn, ExternalId] = await Promise.all([
+      this.payload.object('requestContext'),
+      this.payload.string('cfnExecutionRole'),
+      this.payload.string('roleExternalId'),
+    ]);
+
+    const sts = new aws.sdk.STS();
+    const {
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
+    } = await sts
+      .assumeRole({
+        RoleArn,
+        RoleSessionName: `RaaS-${requestContext.principalIdentifier.username}`,
+        ExternalId,
+      })
+      .promise();
+
+    return new aws.sdk.EC2({ accessKeyId, secretAccessKey, sessionToken });
+  }
+
+  async getExistingEnvironmentRecord() {
+    const environmentScService = await this.mustFindServices('environmentScService');
+    const id = await this.state.string('STATE_ENVIRONMENT_ID');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+    return environmentScService.mustFind(requestContext, { id });
+  }
+
+  getOutputValue(outputs, outputKey) {
+    let outputValue;
+    outputs.forEach(output => {
+      if (output.OutputKey === outputKey) {
+        outputValue = output.OutputValue;
+      }
+    });
+    return outputValue;
+  }
+
+  updateOutputValue(outputs, outputKey, updatedOutputValue) {
+    outputs.forEach(output => {
+      if (output.OutputKey === outputKey) {
+        output.OutputValue = updatedOutputValue;
+      }
+    });
+  }
+
+  async updateEnvironmentStatusAndIp() {
+    const ec2 = await this.getEc2Service();
+    const existingEnvRecord = await this.getExistingEnvironmentRecord();
+    const outputs = existingEnvRecord.outputs;
+    const instanceId = this.getOutputValue(outputs, 'Ec2WorkspaceInstanceId');
+    const oldDnsName = this.getOutputValue(outputs, 'Ec2WorkspaceDnsName');
+
+    const currentEC2Info = await ec2.describeInstances({ InstanceIds: [instanceId] }).promise();
+    const newDnsName = _.get(currentEC2Info, 'Reservations[0].Instances[0].PublicDnsName');
+    const publicIpAddress = _.get(currentEC2Info, 'Reservations[0].Instances[0].PublicIpAddress');
+    this.updateOutputValue(outputs, 'Ec2WorkspacePublicIp', publicIpAddress);
+    this.updateOutputValue(outputs, 'Ec2WorkspaceDnsName', newDnsName);
+
+    const envId = await this.state.string('STATE_ENVIRONMENT_ID');
+    await this.updateCnameRecords(envId, oldDnsName, newDnsName);
+
+    return this.updateEnvironment({ status: 'COMPLETED', outputs });
+  }
+
+  async updateCnameRecords(envId, oldDnsName, newDnsName) {
+    const environmentDnsService = await this.mustFindServices('environmentDnsService');
+    await environmentDnsService.deleteRecord('rstudio', envId, oldDnsName);
+    await environmentDnsService.createRecord('rstudio', envId, newDnsName);
+  }
+
+  async updateEnvironment(updatedAttributes) {
+    const environmentScService = await this.mustFindServices('environmentScService');
+    const requestContext = await this.state.optionalObject('STATE_REQUEST_CONTEXT');
+    const existingEnvRecord = await this.getExistingEnvironmentRecord();
+
+    // SECURITY NOTE
+    // add field to authorize update on behalf of user
+    // this is needed to allow shared envirnments to start/stop by other users
+    requestContext.fromWorkflow = true;
+
+    const newEnvironment = {
+      id: existingEnvRecord.id,
+      rev: existingEnvRecord.rev || 0,
+      ...updatedAttributes,
+    };
+    await environmentScService.update(requestContext, newEnvironment);
+  }
+
+  async onFail() {
+    return this.updateEnvironment({ status: 'STARTING_FAILED' });
+  }
+}
+
+module.exports = StartRStudioEnvironmentSc;

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.yml
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.yml
@@ -1,0 +1,8 @@
+id: st-start-rstudio-environment-sc
+v: 1
+title: Start RStudio Environment
+desc: |
+  Start an RStudio Instance.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/stop-rstudio-environment/stop-rstudio-environment-sc.yml
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/stop-rstudio-environment/stop-rstudio-environment-sc.yml
@@ -1,0 +1,8 @@
+id: st-stop-rstudio-environment-sc
+v: 1
+title: Stop RStudio Environment
+desc: |
+  Stop an RStudio Instance.
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/plugins/workflows-plugin.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/plugins/workflows-plugin.js
@@ -16,6 +16,8 @@
 const provisionEnvironmentScYaml = require('../workflows/provision-environment-sc.yml');
 const startEC2ScYaml = require('../workflows/start-ec2-environment-sc.yml');
 const stopEC2ScYaml = require('../workflows/stop-ec2-environment-sc.yml');
+const startRStudioScYaml = require('../workflows/start-rstudio-environment-sc.yml');
+const stopRStudioScYaml = require('../workflows/stop-rstudio-environment-sc.yml');
 const startSageMakerScYaml = require('../workflows/start-sagemaker-environment-sc.yml');
 const stopSageMakerScYaml = require('../workflows/stop-sagemaker-environment-sc.yml');
 const terminateEnvironmentScYaml = require('../workflows/terminate-environment-sc.yml');
@@ -27,6 +29,8 @@ const workflows = [
   add(provisionEnvironmentScYaml),
   add(startEC2ScYaml),
   add(stopEC2ScYaml),
+  add(startRStudioScYaml),
+  add(stopRStudioScYaml),
   add(startSageMakerScYaml),
   add(stopSageMakerScYaml),
   add(terminateEnvironmentScYaml),

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/workflows/start-rstudio-environment-sc.yml
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/workflows/start-rstudio-environment-sc.yml
@@ -1,0 +1,14 @@
+id: wf-start-rstudio-environment-sc
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Start an Service Catalog RStudio instance
+desc: |
+  Start an Service Catalog RStudio instance.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-start-rstudio-environment-sc
+    stepTemplateVer: 1
+    id: wf-step_1_1731283159486_05 # Randomly generated id, no need to change it

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/workflows/stop-rstudio-environment-sc.yml
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflows/lib/workflows/stop-rstudio-environment-sc.yml
@@ -1,0 +1,14 @@
+id: wf-stop-rstudio-environment-sc
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Stop an Service Catalog RStudio instance
+desc: |
+  Stop an Service Catalog RStudio instance.
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: st-stop-rstudio-environment-sc
+    stepTemplateVer: 1
+    id: wf-step_1_1314164454949_03 # Randomly generated id, no need to change it

--- a/docs/docs/user_guide/sidebar/common/workspaces/accessing_a_workspace.md
+++ b/docs/docs/user_guide/sidebar/common/workspaces/accessing_a_workspace.md
@@ -37,7 +37,10 @@ Since RStudio currently requires a custom domain name, please configure the same
 1. The EC2 instance backing this workspace must be in the **Ready** state. Also make sure its security group allows your IP HTTPS access to it.
 2. Click on the connections button and hit **Connect**.
 
-> Note: If your EC2 instance, which is backing RStudio, goes through a reboot (manual or automatic), it’s public DNS might change and would need to be updated manually in the Hosted Zone’s corresponding CNAME record.
+> Notes:
+>
+> 1. If you're provisioning an RStudio instance with studies selected, these studies will only get mounted on your instance once you click on the RStudio workspace's "Terminal" tab.
+> 2. If you started a previously stopped RStudio instance (manually or automatically) and connect to it, you might see an error dialog box saying the session closed abruptly. Although this typically does not affect your data, it is recommended to quit your session from within your RStudio workspace before stopping the instance through SWB.
 
 ### Common connection issues
 

--- a/main/solution/machine-images/README.md
+++ b/main/solution/machine-images/README.md
@@ -41,6 +41,11 @@ with a custom domain for RStudio to work properly. In order to configure your cu
 2. certificateArn
 3. hostedZoneId
 
+> Some RStudio-specific things to remember:
+>
+> 1. If you're provisioning an RStudio instance with studies selected, these studies will only get mounted on your instance once you click on the RStudio workspace's "Terminal" tab.
+> 2. Although stopping an instance directly typically does not affect your data, it is recommended to quit your session from within your RStudio workspace before stopping the instance through SWB. After starting it back, allow an extra minute for the RStudio Server to boot up after the workspace becomes available on SWB.
+
 ## Package and Deploy
 
 To build Amazon Machine Images:

--- a/main/solution/machine-images/config/infra/files/rstudio/set-password
+++ b/main/solution/machine-images/config/infra/files/rstudio/set-password
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Retrieving instance metadata information from within the EC2 instance
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+
 instance_id=$(curl -s "http://169.254.169.254/latest/meta-data/instance-id")
 secret=$(cat "/root/secret.txt")
 password=$(echo -n "${instance_id}${secret}" | sha256sum | awk '{print $1}')

--- a/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
+++ b/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
@@ -16,7 +16,7 @@ MOUNT_DIR="${HOME}/studies"
 # Exit if CONFIG doesn't exist or is 0 bytes
 [ ! -s "$CONFIG" ] && exit 0
 
-# Define a function to determine what type of environment this is (EMR, SageMaker, or EC2 Linux)
+# Define a function to determine what type of environment this is (EMR, SageMaker, RStudio, or EC2 Linux)
 env_type() {
     if [ -d "/usr/share/aws/emr" ]
     then
@@ -24,6 +24,9 @@ env_type() {
     elif [ -d "/home/ec2-user/SageMaker" ]
     then
         printf "sagemaker"
+    elif [ -d "/var/log/rstudio-server" ]
+    then
+        printf "rstudio"
     else
         printf "ec2-linux"
     fi

--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -15,7 +15,7 @@ S3_MOUNTS="$1"
 FILES_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GOOFYS_URL="https://github.com/kahing/goofys/releases/download/v0.21.0/goofys"
 
-# Define a function to determine what type of environment this is (EMR, SageMaker, or EC2 Linux)
+# Define a function to determine what type of environment this is (EMR, SageMaker, RStudio, or EC2 Linux)
 env_type() {
     if [ -d "/usr/share/aws/emr" ]
     then
@@ -23,6 +23,9 @@ env_type() {
     elif [ -d "/home/ec2-user/SageMaker" ]
     then
         printf "sagemaker"
+    elif [ -d "/var/log/rstudio-server" ]
+    then
+        printf "rstudio"
     else
         printf "ec2-linux"
     fi
@@ -91,6 +94,9 @@ case "$(env_type)" in
         ;;
     "ec2-linux") # Add mount script to bash profile
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/ec2-user/.bash_profile"
+        ;;
+    "rstudio") # Add mount script to bash profile
+        printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
         ;;
 esac
 


### PR DESCRIPTION
Issue #, if available:
GALI-479

Description of changes:
1. RStudio manual start/stop feature, managing CNAME updates and tested public key refresh
2. Added unit tests for RStudio start/stop
3. Tested Start/Stop functionality works as expected as long as DB status field is in sync
4. Bug fix: Study mounting on RStudio

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [x] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
