### PR TITLE
bugfix: Ensure that new cross account roles in member accounts can be assumed by main account

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/account/account-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/account/account-service.js
@@ -102,6 +102,10 @@ class AccountService extends Service {
     }
     const workflowRoleArn = this.settings.get(settingKeys.workflowRoleArn);
     const apiHandlerArn = this.settings.get(settingKeys.apiHandlerArn);
+    const aws = await this.service('aws');
+    const { Account: callerAccountId } = await new aws.sdk.STS({ apiVersion: '2011-06-15' })
+      .getCallerIdentity()
+      .promise();
 
     // trigger the provision environment workflow
     // TODO: remove CIDR default once its in the gui and backend
@@ -114,6 +118,7 @@ class AccountService extends Service {
       description,
       workflowRoleArn,
       apiHandlerArn,
+      callerAccountId,
     };
     await workflowTriggerService.triggerWorkflow(requestContext, { workflowId: 'wf-provision-account' }, input);
 

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/provision-account/provision-account.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/provision-account/provision-account.js
@@ -108,11 +108,11 @@ class ProvisionAccount extends StepBase {
     const [userService] = await this.mustFindServices(['userService']);
     const user = await userService.mustFindUser({ uid: by });
     const externalId = await this.payload.string('externalId');
-    const [workflowRoleArn, apiHandlerArn] = await Promise.all([
+    const [workflowRoleArn, apiHandlerArn, callerAccountId] = await Promise.all([
       this.payload.string('workflowRoleArn'),
       this.payload.string('apiHandlerArn'),
+      this.payload.string('callerAccountId'),
     ]);
-    const centralAccountId = await this.state.string('ACCOUNT_ID');
     // deploy basic stacks to the account just created
     const [cfnTemplateService] = await this.mustFindServices(['cfnTemplateService']);
     const cfn = await this.getCloudFormationService();
@@ -123,7 +123,7 @@ class ProvisionAccount extends StepBase {
     const addParam = (key, v) => cfnParams.push({ ParameterKey: key, ParameterValue: v });
 
     addParam('Namespace', stackName);
-    addParam('CentralAccountId', centralAccountId);
+    addParam('CentralAccountId', callerAccountId);
     addParam('ExternalId', externalId);
     // TODO: consider if following params are needed
     // addParam('TrustUserArn', userArn);

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -469,7 +469,9 @@ Resources:
         - PolicyName: assume-role
           PolicyDocument:
             Statement:
-              Action: 'sts:AssumeRole'
+              Action:
+                - sts:AssumeRole
+                - sts:GetCallerIdentity
               Effect: Allow
               Resource: '*' # TODO: LOCK THIS DOWN!
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* The change makes sts-caller-identity call in provision-account API to figure out accountId of the main account
* The main accountId is further used to whitelist in cross account role of member account so that main account can always assume root account roles
* I further tested the ec2 poll handler functionality and verified that poll handler lambda was able to successfully update the DynamoDB state which correctly reflected in the UI later.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
