### PR TITLE
fix (End to End test): Creating workspace with correct project

### DIFF
--- a/main/end-to-end-tests/cypress/integration/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspaces.spec.js
@@ -80,7 +80,7 @@ describe('Launch a new sagemaker workspace', () => {
     // Select project id
     cy.get('[data-testid=project-id]').click();
     cy.get('[data-testid=project-id]')
-      .find('.selected')
+      .find('.item')
       .contains(workspaceParam.projectId)
       .click();
 


### PR DESCRIPTION
Description of changes:
There's an error in the end to end tests when is is testing creating new workspaces. During creation of new workspace, it fails to select the correct project because the test is looking at the wrong CSS element class. Screenshot below. All elements in the drop down menu will have the class `item`, but not all elements will have the class `selected`

![project-id](https://user-images.githubusercontent.com/3661906/95789622-deb0c600-0cab-11eb-95d8-9d242c19922d.png)

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
