### PR TITLE
Apply version name to products out of the box

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/__tests__/create-service-catalog-portfolio.test.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/__tests__/create-service-catalog-portfolio.test.js
@@ -220,5 +220,18 @@ describe('CreateServiceCatalogPortfolio', () => {
       // CHECK
       expect(nextVersion).toEqual(expectedNextVersion);
     });
+
+    it('should carry on version updates with updated format', async () => {
+      // BUILD
+      const lastVersion = 'v10';
+      const expectedNextVersion = 'v11';
+
+      // OPERATE
+      // Happy-path: Make sure no exceptions are thrown
+      const nextVersion = await service.getNextArtifactVersion(lastVersion);
+
+      // CHECK
+      expect(nextVersion).toEqual(expectedNextVersion);
+    });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/__tests__/create-service-catalog-portfolio.test.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/__tests__/create-service-catalog-portfolio.test.js
@@ -168,5 +168,57 @@ describe('CreateServiceCatalogPortfolio', () => {
       // CHECK
       expect(service.createPortfolio).toHaveBeenCalled();
     });
+
+    it('should NOT fail if a previous version was undefined', async () => {
+      // BUILD
+      const lastVersion = undefined;
+      const expectedNextVersion = 'v2';
+
+      // OPERATE
+      // Happy-path: Make sure no exceptions are thrown
+      const nextVersion = await service.getNextArtifactVersion(lastVersion);
+
+      // CHECK
+      expect(nextVersion).toEqual(expectedNextVersion);
+    });
+
+    it('should NOT fail if a previous version had a different version format', async () => {
+      // BUILD
+      const lastVersion = 'ABC-XYZ';
+      const expectedNextVersion = 'v2';
+
+      // OPERATE
+      // Happy-path: Make sure no exceptions are thrown
+      const nextVersion = await service.getNextArtifactVersion(lastVersion);
+
+      // CHECK
+      expect(nextVersion).toEqual(expectedNextVersion);
+    });
+
+    it('should give the next best version for format V2.0.0', async () => {
+      // BUILD
+      const lastVersion = 'V2.0.0';
+      const expectedNextVersion = 'v3';
+
+      // OPERATE
+      // Happy-path: Make sure no exceptions are thrown
+      const nextVersion = await service.getNextArtifactVersion(lastVersion);
+
+      // CHECK
+      expect(nextVersion).toEqual(expectedNextVersion);
+    });
+
+    it('should give the next best version for format V50', async () => {
+      // BUILD
+      const lastVersion = 'V50';
+      const expectedNextVersion = 'v51';
+
+      // OPERATE
+      // Happy-path: Make sure no exceptions are thrown
+      const nextVersion = await service.getNextArtifactVersion(lastVersion);
+
+      // CHECK
+      expect(nextVersion).toEqual(expectedNextVersion);
+    });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
@@ -320,7 +320,7 @@ class CreateServiceCatalogPortfolio extends Service {
     if (latestVersionInSC) {
       const parsedOutput = latestVersionInSC.match(pattern);
       if (parsedOutput && parsedOutput.length > 0) {
-        returnVal = `v${parsedOutput[1]}`;
+        returnVal = `v${parseInt(parsedOutput[1], 10) + 1}`;
       }
     }
     return returnVal;

--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
@@ -308,22 +308,19 @@ class CreateServiceCatalogPortfolio extends Service {
     return data.ProvisioningArtifactDetail.Id;
   }
 
+  // For product artifacts in Service Catalog, versions and names are the same thing
+  // If no previous version found, assign 'v2' (this will help in next update cycle)
+  // This supports matching previous version format ("V1.0.0") but for simplification
+  // the upcoming product artifact versions will have the format "v2"
   async getNextArtifactVersion(latestVersionInSC) {
-    // For product artifacts in Service Catalog, versions and names are the same thing
-    // If no previous version found, assign 'v2' (this will help in next update cycle)
     let returnVal = 'v2';
     // Only finds version strings that match patterns:
     // "V<n>", "V<n>.0", "V<n>.0.0", "v<n>", "v<n>.0", "v<n>.0.0"
-    const pattern = /^(v|V)(\d+\.)?(\d+\.)?(\*|\d+)$/;
-    let latestVersionNo;
+    const pattern = /^(?:v|V)(\d+)?(?:\.\d+)?(?:\.(?:\d+))?$/;
     if (latestVersionInSC) {
       const parsedOutput = latestVersionInSC.match(pattern);
-      if (parsedOutput && parsedOutput.length > 1) {
-        const longestMatch = parsedOutput.sort(function(a, b) {
-          return b.length - a.length;
-        })[0];
-        latestVersionNo = longestMatch.substring(1);
-        returnVal = `v${parseInt(latestVersionNo.split('.')[0], 10) + 1}`;
+      if (parsedOutput && parsedOutput.length > 0) {
+        returnVal = `v${parsedOutput[1]}`;
       }
     }
     return returnVal;

--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
@@ -323,26 +323,7 @@ class CreateServiceCatalogPortfolio extends Service {
           return b.length - a.length;
         })[0];
         latestVersionNo = longestMatch.substring(1);
-        // Increment major version of the string and assign to the new artifact
-        const versionToCompute = [latestVersionNo]
-          .map(a =>
-            a
-              .split('.')
-              .map(n => +n + 100000)
-              .join('.'),
-          )
-          .sort()
-          .reverse()
-          .map(a =>
-            a
-              .split('.')
-              .map(n => +n - 100000)
-              .join('.'),
-          );
-        // Only consider the major of the highest version
-        // in the list to keep versioning easy
-        const highestVersion = versionToCompute[0];
-        returnVal = `v${parseInt(highestVersion.split('.')[0], 10) + 1}`;
+        returnVal = `v${parseInt(latestVersionNo.split('.')[0], 10) + 1}`;
       }
     }
     return returnVal;

--- a/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
+++ b/addons/addon-base-raas/packages/base-raas-post-deployment/lib/steps/create-service-catalog-portfolio.js
@@ -318,7 +318,6 @@ class CreateServiceCatalogPortfolio extends Service {
     let latestVersionNo;
     if (latestVersionInSC) {
       const parsedOutput = latestVersionInSC.match(pattern);
-      this.log.info(`${parsedOutput}`);
       if (parsedOutput && parsedOutput.length > 1) {
         const longestMatch = parsedOutput.sort(function(a, b) {
           return b.length - a.length;


### PR DESCRIPTION
Issue #, if available:
GALI-481

Description of changes:
Currently when an existing SC product template is updated and deployed to SWB, the auto-create code does not assign a name to the new provisioning artifact. This displays the new product version on SWB UI as "<ProductName> undefined".

To avoid this, the PR achieves the following:

1. Change the default "autoCreateVersion" variable to something simpler like "v1"
2. Add "Name" field in the params used in createProductArtifact().
3. Before attempting to create a new product artifact, call servicecatalog.ListProvisioningArtifacts() to retrieve latest version of product already in SC.
4. Assign the next logical version name to the "Name" field

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
