### PR TITLE
chore: Env delete logs

### DIFF
--- a/scripts/environment-delete.sh
+++ b/scripts/environment-delete.sh
@@ -138,13 +138,17 @@ function emptyS3Bucket() {
     local bucket=$1
     local region=$2
     local delete_option=$3
-    printf "\n- Emptying bucket $bucket ... "
+
+    blank="                                                                                                                        "
+    message="\\r$blank\\r- Emptying bucket $bucket ... "
+    printf "\n$message"
 
     # Remove Versions for all objects
     versions=$(aws s3api list-object-versions --bucket $bucket | jq '.Versions')
     let count=$(echo $versions | jq 'length')-1
     if [ $count -gt -1 ]; then
         for i in $(seq 0 $count); do
+            printf "$message Removing objects versions : $i/$count"
             key=$(echo $versions | jq .[$i].Key | sed -e 's/\"//g')
             versionId=$(echo $versions | jq .[$i].VersionId | sed -e 's/\"//g')
             cmd=$(aws s3api delete-object --bucket $bucket --key $key --version-id $versionId)
@@ -156,12 +160,13 @@ function emptyS3Bucket() {
     let count=$(echo $markers | jq 'length')-1
     if [ $count -gt -1 ]; then
         for i in $(seq 0 $count); do
+            printf "$message Removing markers : $i/$count"
             key=$(echo $markers | jq .[$i].Key | sed -e 's/\"//g')
             versionId=$(echo $markers | jq .[$i].VersionId | sed -e 's/\"//g')
             cmd=$(aws s3api delete-object --bucket $bucket --key $key --version-id $versionId)
         done
     fi
-    printf "Done !"
+    printf "$message Done !"
 
     if [ $delete_option == "DELETE_AFTER_EMPTYING" ]; then
         printf "\n- Deleting bucket $bucket ... "

--- a/scripts/environment-delete.sh
+++ b/scripts/environment-delete.sh
@@ -28,7 +28,9 @@ function removeComponentWithNoStack() {
 
     if [ "$shouldRemoveComponent" == "TRUE" ]; then
         printf "\n- Removing Component $COMPONENT_NAME ... \n"
+        set +e
         $EXEC sls remove -s "$STAGE"
+        set -e
     fi
 }
 
@@ -47,7 +49,9 @@ function removeStack() {
     if [[ "$shouldBeRemoved" == "TRUE" && "$stackName" != "NO_STACK" ]]; then
         emptyS3BucketsFromNames "DO_NOT_DELETE" ${bucket_names[@]}
         printf "\n- Removing Stack $COMPONENT_NAME ...\n"
+        set +e
         $EXEC sls remove -s "$STAGE"
+        set -e
     fi
 }
 


### PR DESCRIPTION
Description of changes:

The script `scripts/environment-delete.sh` can take incredible time to end. It is mostly due to the operations of cleaning the S3 buckets before trying to delete them (in order to avoid cloudformation errors). Last time it took 1 hour to run completely (because the version of SWB was up for several months and accumulated a lot of logs in its buckets). Several times I thought there might be an error with the script freezing my terminal whereas the script actually worked fine, but the operations take time and no progress was displayed. Also during this scenario I interrupted the script after it removed the backend stack. From then on it would crash at the beginning when trying to remove non-existing stacks.

The following commits aim at making things clear :
- commit 94dd532 : display the progression of the S3 operations.
- commit 7ec953d  : avoid script interruptions on serverless operations that throw errors in case a stack does not exist.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x ] Have you successfully deployed to an AWS account with your changes? 
* [x ] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [x ] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Result : for each S3, terminal display progress in one single line updated alongside the operations. 
For instance one line could be updated with the following content displayed successively :
` <S3_bucket> <Operation_1> ...  $progress/$total ...` 
` <S3_bucket> <Operation_2> ...  $progress/$total ...` 
` <S3_bucket> <Operation_2> ...  Done !.` 
![Screenshot from 2020-10-13 11-45-06](https://user-images.githubusercontent.com/33128425/95966895-f1daa780-0e0b-11eb-9fcf-5757e3e282f4.png)

