### PR TITLE
feat: add functionality for creating a Storage Gateway

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/plugins/cfn-templates-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/plugins/cfn-templates-plugin.js
@@ -21,6 +21,7 @@ import ec2WindowsInstance from '../templates/ec2-windows-instance.cfn.yml';
 import sagemakerInstance from '../templates/sagemaker-notebook-instance.cfn.yml';
 import emrCluster from '../templates/emr-cluster.cfn.yml';
 import onboardAccount from '../templates/onboard-account.cfn.yml';
+import storageGatewayNetworkInfra from '../templates/storage-gateway/network-infrastructure.cfn.yml';
 
 const add = (name, yaml) => ({ name, yaml });
 
@@ -32,6 +33,7 @@ const templates = [
   add('sagemaker-notebook-instance', sagemakerInstance),
   add('emr-cluster', emrCluster),
   add('onboard-account', onboardAccount),
+  add('storage-gateway-network-infra', storageGatewayNetworkInfra),
 ];
 
 async function registerCfnTemplates(registry) {

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/storage-gateway/network-infrastructure.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/storage-gateway/network-infrastructure.cfn.yml
@@ -1,0 +1,216 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Service-Workbench-on-AWS Networking Infrastructure for Storage Gateway
+
+Parameters:
+  Namespace:
+    Type: String
+    Description: An environment name that will be prefixed to resource names
+    Default: jeetend
+  VpcCidr:
+    Description: Please enter the IP range (CIDR notation) for this VPC
+    Type: String
+    Default: 10.0.0.0/16
+  VpcPublicSubnet1Cidr:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the 1st Availability Zone
+    Type: String
+    Default: 10.0.0.0/19
+  AmiId:
+    Type: String
+    Description: Amazon Machine Image for the EC2 instance
+  InstanceType:
+    Type: String
+    Description: EC2 instance type to launch
+    Default: m5.xlarge
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Shared Configuration
+        Parameters:
+          - Namespace
+      - Label:
+          default: Deployment Configuration
+        Parameters:
+          - VpcCidr
+          - VpcPublicSubnet1Cidr
+
+Resources:
+  IAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Join ['-', [Ref: Namespace, 'ec2-storage-gateway-role']]
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ec2.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+
+  InstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      InstanceProfileName: !Join ['-', [Ref: Namespace, 'ec2-storage-gateway-profile']]
+      Path: '/'
+      Roles:
+        - Ref: IAMRole
+
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} vpc
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} igw
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [0, !GetAZs ]
+      CidrBlock: !Ref VpcPublicSubnet1Cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} public subnet 1
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} public routes
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet1
+
+  SecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: EC2 workspace security group
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [Ref: Namespace, 'ec2-storage-gateway']]
+        - Key: Description
+          Value: EC2 workspace security group
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: 0.0.0.0/0
+
+  EC2Instance:
+    Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: 'PT20M'
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: 'true'
+          DeviceIndex: '0'
+          GroupSet:
+            - !Ref SecurityGroup
+          SubnetId: !Ref PublicSubnet1
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [Ref: Namespace, 'ec2-storage-gateway-linux']]
+        - Key: Description
+          Value: EC2 workspace instance
+      UserData:
+        Fn::Base64: !Sub |
+          #!/usr/bin/env bash
+          # Signal result to CloudFormation
+          /opt/aws/bin/cfn-signal -e $? --stack "${AWS::StackName}" --resource "EC2Instance" --region "${AWS::Region}"
+
+  VolumeAttach:
+    Type: 'AWS::EC2::VolumeAttachment'
+    Properties:
+      Device: /dev/sdc
+      InstanceId: !Ref EC2Instance
+      VolumeId: !Ref CacheVolume
+
+  CacheVolume:
+    Type: 'AWS::EC2::Volume'
+    Properties:
+      AvailabilityZone: !GetAtt
+        - EC2Instance
+        - AvailabilityZone
+      Size: 150
+      VolumeType: gp2
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [Ref: Namespace, 'ec2-storage-gateway-volume']]
+
+  ElasticIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      InstanceId: !Ref EC2Instance
+
+Outputs:
+  VPC:
+    Description: VPC ID
+    Value: !Ref VPC
+
+  VpcPublicSubnet1:
+    Description: A reference to the public subnet in the 1st Availability Zone
+    Value: !Ref PublicSubnet1
+
+  EC2Instance:
+    Description: EC2 ID
+    Value: !Ref EC2Instance
+
+  ElasticIP:
+    Description: Elastic IP
+    Value: !Ref ElasticIP
+
+  CacheVolume:
+    Description: EC2 Volume
+    Value: !Ref CacheVolume
+
+  SecurityGroup:
+    Description: Security Group
+    Value: !Ref SecurityGroup
+
+  EC2RoleArn:
+    Description: EC2 Role Arn
+    Value: !GetAtt [IAMRole, Arn]
+
+  Region:
+    Description: AWS Region
+    Value: !Ref "AWS::Region"

--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
@@ -18,6 +18,7 @@ const UserAuthzService = require('@aws-ee/base-raas-services/lib/user/user-authz
 const UserService = require('@aws-ee/base-raas-services/lib/user/user-service');
 const UserAttributesMapperService = require('@aws-ee/base-raas-services/lib/user/user-attributes-mapper-service');
 const StudyService = require('@aws-ee/base-raas-services/lib/study/study-service');
+const StorageGateway = require('@aws-ee/base-raas-services/lib/storage-gateway/storage-gateway');
 const StudyPermissionService = require('@aws-ee/base-raas-services/lib/study/study-permission-service');
 const EnvironmentService = require('@aws-ee/base-raas-services/lib/environment/built-in/environment-service');
 const EnvironmentKeypairService = require('@aws-ee/base-raas-services/lib/environment/built-in/environment-keypair-service');
@@ -78,6 +79,7 @@ async function registerServices(container, pluginRegistry) {
   container.register('awsAccountsService', new AwsAccountsService());
   container.register('budgetsService', new BudgetsService());
   container.register('costsService', new CostsService());
+  container.register('storageGateway', new StorageGateway());
   container.register('costApiCacheService', new CostApiCacheService());
   container.register('indexesService', new IndexesService());
   container.register('projectService', new ProjectService());
@@ -125,6 +127,7 @@ function getStaticSettings(existingStaticSettings, settings, pluginRegistry) {
   table('dbAccounts', 'Accounts');
   table('dbProjects', 'Projects');
   table('dbStudyPermissions', 'StudyPermissions');
+  table('StorageGateway', 'StorageGateway');
 
   return staticSettings;
 }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/storage-gateway-db-record.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/storage-gateway-db-record.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "vpcId": {
+      "type": "string",
+      "pattern": "^vpc-[a-f0-9]{8,17}$"
+    },
+    "subnetId": {
+      "type": "string",
+      "pattern": "^subnet-[a-f0-9]{8,17}$"
+    },
+    "ec2Instance": {
+      "type": "string"
+    },
+    "elasticIP": {
+      "type": "string",
+      "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"
+    },
+    "securityGroup": {
+      "type": "string"
+    },
+    "ec2RoleARN": {
+      "type": "string",
+      "minLength": 10
+    },
+    "volumeIds": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string",
+          "minLength": 1
+        }
+      ]
+    },
+    "cfnStackId": {
+      "type": "string",
+      "description": "Cloudformation StackId for bringing up Network Infrastructure for this Storage Gateway instance"
+    }
+  },
+  "required": ["vpcId", "subnetId", "ec2Instance", "elasticIP", "securityGroup", "ec2RoleARN", "volumeIds"]
+}

--- a/addons/addon-base-raas/packages/base-raas-services/lib/storage-gateway/__tests__/storage-gateway.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/storage-gateway/__tests__/storage-gateway.test.js
@@ -1,0 +1,508 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const AwsService = require('@aws-ee/base-services/lib/aws/aws-service');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+const Logger = require('@aws-ee/base-services/lib/logger/logger-service');
+const AWSMock = require('aws-sdk-mock');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/user/user-service');
+const UserServiceMock = require('@aws-ee/base-services/lib/user/user-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+const StorageGateway = require('../storage-gateway');
+
+describe('storageGateway', () => {
+  let storageGateway;
+  let userService;
+  let log;
+  let dbService;
+  const context = { principalIdentifier: { uid: 'u-daffyduck' } };
+
+  beforeAll(async () => {
+    // Initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('log', new Logger());
+    container.register('aws', new AwsService());
+    container.register('storageGateway', new StorageGateway());
+    container.register('dbService', new DbServiceMock());
+    container.register('userService', new UserServiceMock());
+    container.register('settings', new SettingsServiceMock());
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    storageGateway = await container.find('storageGateway');
+    userService = await container.find('userService');
+    log = await container.find('log');
+    dbService = await container.find('dbService');
+  });
+
+  beforeEach(async () => {
+    const aws = await storageGateway.service('aws');
+    AWSMock.setSDKInstance(aws.sdk);
+  });
+
+  afterEach(() => {
+    AWSMock.restore();
+  });
+
+  describe('activateGateway', () => {
+    it('should fail if storage gateway throws exception', async () => {
+      const rawDataInput = {
+        publicIp: '11.11.11.11',
+        region: 'us-west-2',
+        securityGroup: 'security-group-id',
+        timezone: 'GMT',
+      };
+      const whitelistIPInput = {
+        GroupId: rawDataInput.securityGroup,
+        IpPermissions: [
+          {
+            FromPort: 80,
+            IpProtocol: 'tcp',
+            IpRanges: [
+              {
+                CidrIp: `22.22.22.22/32`,
+                Description: 'Temporary SSH access from Lambda function',
+              },
+            ],
+            ToPort: 80,
+          },
+        ],
+      };
+      userService.mustFindUser = jest.fn().mockImplementationOnce(params => {
+        expect(params).toMatchObject(context.principalIdentifier);
+        return { username: 'hello@activate_gateway.com' };
+      });
+      storageGateway.fetchIP = jest.fn().mockImplementationOnce(() => {
+        return '22.22.22.22';
+      });
+      storageGateway.fetchRedirect = jest.fn().mockImplementationOnce(params => {
+        expect(params).toEqual('http://11.11.11.11/?activationRegion=us-west-2&gatewayType=FILE_S3');
+        return 'http://11.11.11.11?activationRegion=us-west-2&activationKey=11111-11111-11111-11111-11111&gatewayType=FILE_S3';
+      });
+      AWSMock.mock('StorageGateway', 'activateGateway', (params, callback) => {
+        expect(params).toMatchObject(
+          expect.objectContaining({
+            ActivationKey: '11111-11111-11111-11111-11111',
+            GatewayName: expect.any(String),
+            GatewayRegion: 'us-west-2',
+            GatewayTimezone: 'GMT',
+            GatewayType: 'FILE_S3',
+            Tags: [
+              {
+                Key: 'CreatedBy',
+                Value: 'hello@activate_gateway.com',
+              },
+            ],
+          }),
+        );
+        callback({ code: 'InvalidGatewayRequestException' }, null);
+      });
+      AWSMock.mock('EC2', 'authorizeSecurityGroupIngress', (params, callback) => {
+        expect(params).toMatchObject(whitelistIPInput);
+        callback(null, null);
+      });
+      let revokeCalled = false;
+      AWSMock.mock('EC2', 'revokeSecurityGroupIngress', (params, callback) => {
+        expect(params).toMatchObject(whitelistIPInput);
+        revokeCalled = true;
+        callback(null, null);
+      });
+      try {
+        await storageGateway.activateGateway(context, rawDataInput);
+        expect.fail('Expected to throw error InvalidGatewayRequestException');
+      } catch (error) {
+        expect(error).toMatchObject({ code: 'InvalidGatewayRequestException' });
+        expect(storageGateway.fetchIP).toHaveBeenCalledTimes(1);
+        expect(storageGateway.fetchRedirect).toHaveBeenCalledTimes(1);
+        expect(userService.mustFindUser).toHaveBeenCalledTimes(1);
+        // ensure that even though we have an error, permissions should be revoked
+        expect(revokeCalled).toEqual(true);
+      }
+    });
+
+    it('should succeed', async () => {
+      const rawDataInput = {
+        publicIp: '11.11.11.11',
+        region: 'us-west-2',
+        securityGroup: 'security-group-id',
+        timezone: 'GMT',
+      };
+      const whitelistIPInput = {
+        GroupId: rawDataInput.securityGroup,
+        IpPermissions: [
+          {
+            FromPort: 80,
+            IpProtocol: 'tcp',
+            IpRanges: [
+              {
+                CidrIp: `22.22.22.22/32`,
+                Description: 'Temporary SSH access from Lambda function',
+              },
+            ],
+            ToPort: 80,
+          },
+        ],
+      };
+      const expectedGatewayARN = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      userService.mustFindUser = jest.fn().mockImplementationOnce(params => {
+        expect(params).toMatchObject(context.principalIdentifier);
+        return { username: 'hello@activate_gateway.com' };
+      });
+      storageGateway.fetchIP = jest.fn().mockImplementationOnce(() => {
+        return '22.22.22.22';
+      });
+      storageGateway.fetchRedirect = jest.fn().mockImplementationOnce(params => {
+        expect(params).toEqual('http://11.11.11.11/?activationRegion=us-west-2&gatewayType=FILE_S3');
+        return 'http://11.11.11.11?activationRegion=us-west-2&gatewayType=FILE_S3&activationKey=11111-11111-11111-11111-11111';
+      });
+      AWSMock.mock('StorageGateway', 'activateGateway', (params, callback) => {
+        expect(params).toMatchObject(
+          expect.objectContaining({
+            ActivationKey: '11111-11111-11111-11111-11111',
+            GatewayName: expect.any(String),
+            GatewayRegion: 'us-west-2',
+            GatewayTimezone: 'GMT',
+            GatewayType: 'FILE_S3',
+            Tags: [
+              {
+                Key: 'CreatedBy',
+                Value: 'hello@activate_gateway.com',
+              },
+            ],
+          }),
+        );
+        callback(null, expectedGatewayARN);
+      });
+      AWSMock.mock('EC2', 'authorizeSecurityGroupIngress', (params, callback) => {
+        expect(params).toMatchObject(whitelistIPInput);
+        callback(null, null);
+      });
+      AWSMock.mock('EC2', 'revokeSecurityGroupIngress', (params, callback) => {
+        expect(params).toMatchObject(whitelistIPInput);
+        callback(null, null);
+      });
+      const receivedResponse = await storageGateway.activateGateway(context, rawDataInput);
+      expect(expectedGatewayARN.GatewayARN).toEqual(receivedResponse);
+      expect(storageGateway.fetchIP).toHaveBeenCalledTimes(1);
+      expect(storageGateway.fetchRedirect).toHaveBeenCalledTimes(1);
+      expect(userService.mustFindUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteGateway', () => {
+    it('should fail on bad GatewayARN', async () => {
+      const expectedRequest = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      AWSMock.mock('StorageGateway', 'deleteGateway', (params, callback) => {
+        expect(params).toMatchObject(expectedRequest);
+        callback({ code: 'InvalidGatewayARN' }, null);
+      });
+      try {
+        await storageGateway.deleteGateway(
+          context,
+          'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+        );
+        expect.fail('Expected to throw error InvalidGatewayARN');
+      } catch (error) {
+        expect(error).toEqual({ code: 'InvalidGatewayARN' });
+      }
+    });
+
+    it('should succeed on correct GatewayARN', async () => {
+      const deleteResponse = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      const expectedRequest = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      AWSMock.mock('StorageGateway', 'deleteGateway', (params, callback) => {
+        expect(params).toMatchObject(expectedRequest);
+        callback(null, deleteResponse);
+      });
+      await storageGateway.deleteGateway(context, 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111');
+    });
+  });
+
+  describe('addCacheToGateway', () => {
+    it('should fail on invalid GatewayARN', async () => {
+      const rawData = {
+        volumeId: 'volume-123',
+        gatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      const volumeIdRequest = {
+        VolumeIds: [rawData.volumeId],
+      };
+      const gatewayARNParam = {
+        GatewayARN: rawData.gatewayARN,
+      };
+      const volumeResponse = {
+        Volumes: [
+          {
+            Attachments: [
+              {
+                Device: '/dev/sdc',
+              },
+            ],
+            Size: 150,
+          },
+        ],
+      };
+      AWSMock.mock('EC2', 'describeVolumes', (params, callback) => {
+        expect(params).toMatchObject(volumeIdRequest);
+        callback(null, volumeResponse);
+      });
+      AWSMock.mock('StorageGateway', 'listLocalDisks', (params, callback) => {
+        expect(params).toMatchObject(gatewayARNParam);
+        callback({ code: 'InvalidGatewayARN' }, null);
+      });
+      try {
+        await storageGateway.addCacheToGateway(context, rawData);
+        expect.fail('Expected to throw error InvalidGatewayARN');
+      } catch (error) {
+        expect(error).toEqual({ code: 'InvalidGatewayARN' });
+      }
+    });
+
+    it('should succeed on valid GatewayARN', async () => {
+      const rawData = {
+        volumeId: 'volume-123',
+        gatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      const volumeIdRequest = {
+        VolumeIds: [rawData.volumeId],
+      };
+      const gatewayARNParam = {
+        GatewayARN: rawData.gatewayARN,
+      };
+      const volumeResponse = {
+        Volumes: [
+          {
+            Attachments: [
+              {
+                Device: '/dev/sdc',
+              },
+            ],
+            Size: 150,
+          },
+        ],
+      };
+      const localDisksResponse = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+        Disks: [
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7bd1',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdc',
+            DiskStatus: 'present',
+            DiskSizeInBytes: 161061273600,
+            DiskAllocationType: 'CACHE STORAGE',
+            DiskAttributeList: [],
+          },
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7bd2',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdc',
+            DiskStatus: 'present',
+            DiskSizeInBytes: 161061273600 * 2,
+            DiskAllocationType: 'available',
+            DiskAttributeList: [],
+          },
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7b3',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdb',
+            DiskStatus: 'present',
+            DiskSizeInBytes: 161061273600,
+            DiskAllocationType: 'available',
+            DiskAttributeList: [],
+          },
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7bd4',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdc',
+            DiskStatus: 'present',
+            DiskSizeInBytes: 161061273600,
+            DiskAllocationType: 'available',
+            DiskAttributeList: [],
+          },
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7bd5',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdc',
+            DiskStatus: 'absent',
+            DiskSizeInBytes: 161061273600,
+            DiskAllocationType: 'available',
+            DiskAttributeList: [],
+          },
+        ],
+      };
+      const addToCacheParams = {
+        // Pick the disk which is present, available and matches input disk spec
+        DiskIds: [localDisksResponse.Disks[3].DiskId],
+        GatewayARN: rawData.gatewayARN,
+      };
+      AWSMock.mock('EC2', 'describeVolumes', (params, callback) => {
+        expect(params).toMatchObject(volumeIdRequest);
+        callback(null, volumeResponse);
+      });
+      AWSMock.mock('StorageGateway', 'listLocalDisks', (params, callback) => {
+        expect(params).toMatchObject(gatewayARNParam);
+        callback(null, localDisksResponse);
+      });
+      let addCacheCalled = 0;
+      AWSMock.mock('StorageGateway', 'addCache', (params, callback) => {
+        addCacheCalled += 1;
+        expect(params).toMatchObject(addToCacheParams);
+        callback(null, null);
+      });
+      await storageGateway.addCacheToGateway(context, rawData);
+      expect(addCacheCalled).toEqual(1);
+    });
+  });
+
+  describe('listLocalDisks', () => {
+    it('should fail on invalid GatewayARN', async () => {
+      const expectedRequest = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      AWSMock.mock('StorageGateway', 'listLocalDisks', (params, callback) => {
+        expect(params).toMatchObject(expectedRequest);
+        callback({ code: 'InvalidGatewayARN' }, null);
+      });
+      try {
+        await storageGateway.listLocalDisks(
+          context,
+          'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+        );
+        expect.fail('Expected to throw error InvalidGatewayARN');
+      } catch (error) {
+        expect(error).toEqual({ code: 'InvalidGatewayARN' });
+      }
+    });
+
+    it('should succeed on valid GatewayARN', async () => {
+      const localDisksResponse = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+        Disks: [
+          {
+            DiskId: '7c3164b9-b237-40d2-9647-a4839a9b7bd3',
+            DiskPath: '/dev/nvme1n1',
+            DiskNode: '/dev/sdc',
+            DiskStatus: 'present',
+            DiskSizeInBytes: 161061273600,
+            DiskAllocationType: 'CACHE STORAGE',
+            DiskAttributeList: [],
+          },
+        ],
+      };
+      const expectedRequest = {
+        GatewayARN: 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      };
+      AWSMock.mock('StorageGateway', 'listLocalDisks', (params, callback) => {
+        expect(params).toMatchObject(expectedRequest);
+        callback(null, localDisksResponse);
+      });
+      const receivedResponse = await storageGateway.listLocalDisks(
+        context,
+        'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111',
+      );
+      expect(localDisksResponse).toEqual(receivedResponse);
+    });
+  });
+
+  describe('saveToDDB', () => {
+    it('should fail on invalid input', async () => {
+      const dbData = {
+        vpcId: 'vpc-123',
+        subnetId: 'subnet-123',
+        ec2Instance: 'gateway-instance123',
+        elasticIP: '11.11.11.aa',
+        securityGroup: 'gateway-sg',
+        ec2RoleARN: 'arn:aws:iam:us-west-2:111111111111:role/gateway-role',
+        invalidField: 'invalid',
+      };
+      const gatewayArn = 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111';
+      try {
+        await storageGateway.saveToDDB(context, dbData, gatewayArn);
+        expect.fail('Expected to have validation errors');
+      } catch (error) {
+        // extra field
+        // invalid vpcId
+        // invalid subnetId
+        // invalid IP address
+        // volumeIds field is missing
+        expect(error.payload.validationErrors.length).toEqual(5);
+        log.error(error);
+      }
+      expect(dbService.table.key).toHaveBeenCalledTimes(0);
+      expect(dbService.table.item).toHaveBeenCalledTimes(0);
+      expect(dbService.table.update).toHaveBeenCalledTimes(0);
+    });
+
+    it('should succeed on valid input', async () => {
+      const dbData = {
+        vpcId: 'vpc-12345678',
+        subnetId: 'subnet-12345678',
+        ec2Instance: 'gateway-instance123',
+        elasticIP: '11.11.11.11',
+        securityGroup: 'gateway-sg',
+        ec2RoleARN: 'arn:aws:iam:us-west-2:111111111111:role/gateway-role',
+        volumeIds: ['volume-123'],
+        cfnStackId: 'arn:aws:cloudformation:us-east-2:123456789012:stack/mystack/newstack123',
+      };
+      const userId = context.principalIdentifier.uid;
+      const gatewayArn = 'arn:aws:storagegateway:us-west-2:111111111111:gateway/sgw-11111111';
+      try {
+        await storageGateway.saveToDDB(context, dbData, gatewayArn);
+      } catch (error) {
+        log.error(error);
+        throw error;
+      }
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: gatewayArn });
+      expect(dbService.table.item).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vpcId: dbData.vpcId,
+          subnetId: dbData.subnetId,
+          ec2Instance: dbData.ec2Instance,
+          elasticIP: dbData.elasticIP,
+          securityGroup: dbData.securityGroup,
+          ec2RoleARN: dbData.ec2RoleARN,
+          volumeIds: dbData.volumeIds,
+          rev: 0,
+          createdBy: userId,
+          updatedBy: userId,
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+        }),
+      );
+      expect(dbService.table.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/storage-gateway/storage-gateway.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/storage-gateway/storage-gateway.js
@@ -1,0 +1,218 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const Service = require('@aws-ee/base-services-container/lib/service');
+const { runAndCatch } = require('@aws-ee/base-services/lib/helpers/utils');
+
+const uuid = require('uuid/v1');
+let fetch = require('node-fetch');
+const storageGatewayDbRecord = require('../schema/storage-gateway-db-record');
+
+// Webpack messes with the fetch function import and it breaks in lambda.
+if (typeof fetch !== 'function' && fetch.default && typeof fetch.default === 'function') {
+  fetch = fetch.default;
+}
+
+const settingKeys = {
+  tableName: 'StorageGateway',
+};
+
+class StorageGateway extends Service {
+  constructor() {
+    super();
+    this.dependency(['aws', 'dbService', 'userService', 'jsonSchemaValidationService']);
+  }
+
+  async init() {
+    // Get services
+    const dbService = await this.service('dbService');
+    const table = this.settings.get(settingKeys.tableName);
+    this._updater = () => dbService.helper.updater().table(table);
+  }
+
+  async activateGateway(requestContext, rawData) {
+    // 1. Fetch the public IP address of EC2 instance and make http request to get the activation key.
+    // 2. Use the activation key and create a new Storage Gateway. Note that activateGateway is actually creating a
+    // new gateway
+    const user = await this.getUser(requestContext);
+    const ipaddress = await this.fetchIP();
+    this.log.info(`Whiteliting IP address ${ipaddress.origin}`);
+    // whitelist the ipaddress making this request
+    const authorizeSecurityGroupParams = {
+      GroupId: rawData.securityGroup,
+      IpPermissions: [
+        {
+          FromPort: 80,
+          IpProtocol: 'tcp',
+          IpRanges: [
+            {
+              CidrIp: `${ipaddress}/32`,
+              Description: 'Temporary SSH access from Lambda function',
+            },
+          ],
+          ToPort: 80,
+        },
+      ],
+    };
+    const ec2 = await this.getEC2();
+    await ec2.authorizeSecurityGroupIngress(authorizeSecurityGroupParams).promise();
+    let gatewayARN;
+    try {
+      const activationUrl = await this.fetchRedirect(
+        `http://${rawData.publicIp}/?activationRegion=${rawData.region}&gatewayType=FILE_S3`,
+      );
+      const activationKey = activationUrl.match(/activationKey=[A-Z0-9-]+/)[0].split('=')[1];
+
+      const activateGatewayParams = {
+        ActivationKey: activationKey,
+        GatewayName: uuid(),
+        GatewayRegion: rawData.region,
+        GatewayTimezone: rawData.timezone,
+        GatewayType: 'FILE_S3',
+        Tags: [
+          {
+            Key: 'CreatedBy',
+            Value: user.username,
+          },
+        ],
+      };
+      const storageGateway = await this.getStorageGateway();
+      const activateGatewayOutput = await storageGateway.activateGateway(activateGatewayParams).promise();
+      gatewayARN = activateGatewayOutput.GatewayARN;
+    } finally {
+      await ec2.revokeSecurityGroupIngress(authorizeSecurityGroupParams).promise();
+    }
+    return gatewayARN;
+  }
+
+  async fetchIP() {
+    const ipAddressResult = await fetch('http://httpbin.org/get').then(function(res) {
+      return res.json();
+    });
+    return ipAddressResult.origin;
+  }
+
+  async fetchRedirect(url) {
+    const original = await fetch(url);
+    return original.url;
+  }
+
+  async listLocalDisks(requestContext, gatewayARN) {
+    const gatewayARNParam = {
+      GatewayARN: gatewayARN,
+    };
+    const storageGateway = await this.getStorageGateway();
+    const localDisks = await storageGateway.listLocalDisks(gatewayARNParam).promise();
+    return localDisks;
+  }
+
+  async deleteGateway(requestContext, gatewayARN) {
+    const gatewayARNParam = {
+      GatewayARN: gatewayARN,
+    };
+    const storageGateway = await this.getStorageGateway();
+    await storageGateway.deleteGateway(gatewayARNParam).promise();
+  }
+
+  async addCacheToGateway(requestContext, rawData) {
+    // 1. List Local disks in gateway and
+    // 2. Attach the disk which is available and matches the volume spec
+    const volumeIds = {
+      VolumeIds: [rawData.volumeId],
+    };
+    const ec2 = await this.getEC2();
+    const volumeOutput = await ec2.describeVolumes(volumeIds).promise();
+    const diskNode = volumeOutput.Volumes[0].Attachments[0].Device;
+    const diskSizeBytes = volumeOutput.Volumes[0].Size * 1024 * 1024 * 1024;
+    const localDisksOutput = await this.listLocalDisks(requestContext, rawData.gatewayARN);
+    const ebsDiskToAdd = localDisksOutput.Disks.filter(disk => disk.DiskStatus.toLowerCase() === 'present')
+      .filter(disk => disk.DiskNode === diskNode)
+      .filter(disk => disk.DiskAllocationType.toLowerCase() === 'available')
+      .filter(disk => disk.DiskSizeInBytes === diskSizeBytes)[0];
+    const addToCacheParams = {
+      DiskIds: [ebsDiskToAdd.DiskId],
+      GatewayARN: rawData.gatewayARN,
+    };
+    const storageGateway = await this.getStorageGateway();
+    await storageGateway.addCache(addToCacheParams).promise();
+  }
+
+  async saveToDDB(requestContext, rawData, id) {
+    // Validate input
+    const jsonSchemaValidationService = await this.service('jsonSchemaValidationService');
+    await jsonSchemaValidationService.ensureValid(rawData, storageGatewayDbRecord);
+
+    const by = _.get(requestContext, 'principalIdentifier.uid');
+    // Prepare the db object
+    const date = new Date().toISOString();
+    const dbObject = this._fromRawToDbObject(rawData, {
+      rev: 0,
+      createdBy: by,
+      updatedBy: by,
+      createdAt: date,
+      updatedAt: date,
+    });
+    // Time to save the the db object
+    let dbResult;
+    try {
+      dbResult = await runAndCatch(
+        async () => {
+          return this._updater()
+            .condition('attribute_not_exists(id)') // ensure that id doesn't already exist
+            .key({ id })
+            .item(dbObject)
+            .update();
+        },
+        async () => {
+          throw new Error(`Storage Gateway with id "${id}" already exists`);
+        },
+      );
+    } catch (error) {
+      this.log.log(error);
+    }
+    return dbResult;
+  }
+
+  // Do some properties renaming to prepare the object to be saved in the database
+  _fromRawToDbObject(rawObject, overridingProps = {}) {
+    const dbObject = { ...rawObject, ...overridingProps };
+    return dbObject;
+  }
+
+  async getUser(requestContext) {
+    const by = _.get(requestContext, 'principalIdentifier.uid');
+    const userService = await this.service('userService');
+    const user = await userService.mustFindUser({ uid: by });
+    return user;
+  }
+
+  async getStorageGateway() {
+    const aws = await this.getAWS();
+    return new aws.sdk.StorageGateway();
+  }
+
+  async getEC2() {
+    const aws = await this.getAWS();
+    return new aws.sdk.EC2();
+  }
+
+  async getAWS() {
+    const aws = await this.service('aws');
+    return aws;
+  }
+}
+
+module.exports = StorageGateway;

--- a/addons/addon-base-raas/packages/base-raas-services/package.json
+++ b/addons/addon-base-raas/packages/base-raas-services/package.json
@@ -17,7 +17,7 @@
     "uuid": "^3.4.0",
     "xml": "^1.0.1",
     "moment": "^2.27.0",
-    "sinon": "^9.0.3"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
@@ -33,7 +33,8 @@
     "jest-junit": "^10.0.0",
     "prettier": "^1.19.1",
     "pretty-quick": "^1.11.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "sinon": "^9.0.3"
   },
   "scripts": {
     "test": "NODE_ENV=test jest --config jest.config.js --passWithNoTests",

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/plugins/workflow-steps-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/plugins/workflow-steps-plugin.js
@@ -28,6 +28,8 @@ const startEC2Environment = require('../steps/start-ec2-environment/start-ec2-en
 const startEC2EnvironmentYaml = require('../steps/start-ec2-environment/start-ec2-environment.yml');
 const stopEC2Environment = require('../steps/stop-ec2-environment/stop-ec2-environment');
 const stopEC2EnvironmentYaml = require('../steps/stop-ec2-environment/stop-ec2-environment.yml');
+const networkInfra = require('../steps/storage-gateway/create-network-infrastructure');
+const networkInfraYaml = require('../steps/storage-gateway/create-network-infrastructure.yml');
 
 const add = (implClass, yaml) => ({ implClass, yaml });
 
@@ -40,6 +42,7 @@ const steps = [
   add(stopSageMakerEnvironment, stopSageMakerEnvironmentYaml),
   add(startEC2Environment, startEC2EnvironmentYaml),
   add(stopEC2Environment, stopEC2EnvironmentYaml),
+  add(networkInfra, networkInfraYaml),
 ];
 
 async function registerWorkflowSteps(registry) {

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/__test__/create-network-infrastructure.test.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/__test__/create-network-infrastructure.test.js
@@ -1,0 +1,529 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const WorkflowPayload = require('@aws-ee/workflow-engine/lib/workflow-payload');
+const AWSMock = require('aws-sdk-mock');
+const AwsService = require('@aws-ee/base-services/lib/aws/aws-service');
+const CreateNetworkInfrastructure = require('../storage-gateway/create-network-infrastructure');
+
+describe('CreateNetworkInfra', () => {
+  const requestContext = { principalIdentifier: { uid: 'u-daffyduck' } };
+
+  const meta = { workflowId: `wf-create-network-infrastructure` };
+  const input = {
+    requestContext,
+  };
+
+  const reporter = jest.fn();
+  reporter.print = jest.fn();
+
+  let container;
+  let step;
+
+  beforeAll(async () => {
+    container = new ServicesContainer();
+    container.register('aws', new AwsService());
+    await container.initServices();
+  });
+
+  beforeEach(async () => {
+    step = new CreateNetworkInfrastructure({
+      step: { config: {} },
+      stepReporter: reporter,
+      workflowPayload: new WorkflowPayload({
+        meta,
+        input,
+        workflowInstance: { steps: ['create-network-infrastructure'] },
+      }),
+    });
+
+    step.payload = {
+      string: stringInput => {
+        return stringInput;
+      },
+      object: () => {
+        return requestContext;
+      },
+    };
+
+    const awsService = await container.find('aws');
+    AWSMock.setSDKInstance(awsService.sdk);
+    step.getAWS = jest.fn(function() {
+      return awsService;
+    });
+    step.createNetworkInfra = jest.fn();
+  });
+
+  afterEach(() => {
+    AWSMock.restore();
+  });
+
+  describe('start', () => {
+    it('should start', async () => {
+      const ssmParameter = { Name: '/aws/service/storagegateway/ami/FILE_S3/latest' };
+      const ssmParamValue = {
+        Parameter: {
+          Name: '/aws/service/storagegateway/ami/FILE_S3/latest',
+          Type: 'String',
+          Value: 'ami-099415e970e96839e',
+        },
+      };
+      AWSMock.mock('SSM', 'getParameter', (params, callback) => {
+        expect(params).toMatchObject(ssmParameter);
+        callback(null, ssmParamValue);
+      });
+      step.state = {
+        setKey: jest.fn(),
+        ...step.payload,
+      };
+      const response = await step.start();
+      expect(step.state.setKey).toHaveBeenCalledWith('STORAGE_GATEWAY_AMI', ssmParamValue.Parameter.Value);
+      expect(step.state.setKey).toHaveBeenCalledWith('STATE_REQUEST_CONTEXT', requestContext);
+      expect(step.createNetworkInfra).toHaveBeenCalledTimes(1);
+      expect(response).toMatchObject({
+        waitDecision: {
+          check: { methodName: 'checkCfnCompleted', params: '[]' },
+          counter: 60,
+          max: 60,
+          otherwise: undefined,
+          seconds: 20,
+          thenCall: { methodName: 'createStorageGateway', params: '[]' },
+          type: 'wait',
+        },
+      });
+    });
+  });
+
+  describe('createStorageGateway', () => {
+    it('should call validate and addToCache', async () => {
+      step.activateGateway = jest.fn();
+      const response = await step.createStorageGateway();
+      expect(step.activateGateway).toHaveBeenCalledTimes(1);
+      expect(response).toMatchObject({
+        waitDecision: {
+          check: { methodName: 'validateGateway', params: '[]' },
+          counter: 5,
+          max: 5,
+          otherwise: undefined,
+          seconds: 5,
+          thenCall: { methodName: 'addCacheToGateway', params: '[]' },
+          type: 'wait',
+        },
+      });
+    });
+  });
+
+  describe('activateGateway', () => {
+    it('activate successful', async () => {
+      const activateGatewayMockFn = jest.fn().mockImplementationOnce(() => 'gateway-1234');
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.activateGateway = activateGatewayMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        string: jest.fn(),
+        setKey: jest.fn(),
+      };
+      const activateGatewayInput = {
+        publicIp: '11.11.11.11',
+        region: 'us-west-2',
+        securityGroup: 'sg-1234567',
+        timezone: 'GMT',
+      };
+      step.state.string.mockImplementation(param => {
+        switch (param) {
+          case 'PUBLIC_IP': {
+            return activateGatewayInput.publicIp;
+          }
+          case 'REGION_ID': {
+            return activateGatewayInput.region;
+          }
+          case 'SECURITY_GROUP': {
+            return activateGatewayInput.securityGroup;
+          }
+          default:
+            throw Error('Invalid key');
+        }
+      });
+      await step.activateGateway();
+      expect(step.state.string).toHaveBeenCalledWith('PUBLIC_IP');
+      expect(step.state.string).toHaveBeenCalledWith('REGION_ID');
+      expect(step.state.string).toHaveBeenCalledWith('SECURITY_GROUP');
+      expect(step.state.setKey).toHaveBeenCalledWith('GATEWAY_ARN', 'gateway-1234');
+      expect(getStorageGatewayMock.activateGateway).toHaveBeenCalledWith(requestContext, activateGatewayInput);
+    });
+  });
+
+  describe('addCacheToGateway', () => {
+    it('add cache and records to ddb', async () => {
+      const addCacheToGatewayMockFn = jest.fn();
+      const saveToDDBMockFn = jest.fn();
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.addCacheToGateway = addCacheToGatewayMockFn;
+      getStorageGatewayMock.saveToDDB = saveToDDBMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        string: jest.fn(),
+      };
+      const addToCacheInput = {
+        gatewayARN: 'gateway-1234',
+        volumeId: 'volume-1234567',
+      };
+      const ddbInput = {
+        vpcId: 'vpc-1212312313',
+        subnetId: 'subnet-124324556',
+        ec2Instance: 'instance-12345678',
+        elasticIP: '11.11.11.11',
+        securityGroup: 'sg-1234567',
+        ec2RoleARN: 'arn:aws:iam:us-west-2:111111111111:role/gateway-role',
+        volumeIds: [addToCacheInput.volumeId],
+        cfnStackId: 'arn:aws:cloudformation:us-east-2:123456789012:stack/mystack/newstack123',
+      };
+      step.state.string.mockImplementation(param => {
+        switch (param) {
+          case 'PUBLIC_IP': {
+            return ddbInput.elasticIP;
+          }
+          case 'SUBNET_ID': {
+            return ddbInput.subnetId;
+          }
+          case 'SECURITY_GROUP': {
+            return ddbInput.securityGroup;
+          }
+          case 'VPC_ID': {
+            return ddbInput.vpcId;
+          }
+          case 'EC2_INSTANCE_ID': {
+            return ddbInput.ec2Instance;
+          }
+          case 'IAM_ROLE_ARN': {
+            return ddbInput.ec2RoleARN;
+          }
+          case 'GATEWAY_ARN': {
+            return addToCacheInput.gatewayARN;
+          }
+          case 'VOLUME_ID': {
+            return addToCacheInput.volumeId;
+          }
+          case 'STATE_STACK_ID': {
+            return ddbInput.cfnStackId;
+          }
+          default:
+            throw Error('Invalid key');
+        }
+      });
+      await step.addCacheToGateway();
+      expect(getStorageGatewayMock.addCacheToGateway).toHaveBeenCalledWith(requestContext, addToCacheInput);
+      expect(getStorageGatewayMock.saveToDDB).toHaveBeenCalledWith(
+        requestContext,
+        ddbInput,
+        addToCacheInput.gatewayARN,
+      );
+    });
+  });
+
+  describe('validateGateway', () => {
+    it('validation successful', async () => {
+      const listLocalDisksMockFn = jest.fn();
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.listLocalDisks = listLocalDisksMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(param => {
+        if (param === 'GATEWAY_ARN') {
+          return 'gateway-1234';
+        }
+        throw Error('Key not found');
+      });
+      const valid = await step.validateGateway();
+      expect(step.state.string).toHaveBeenCalledWith('GATEWAY_ARN');
+      expect(getStorageGatewayMock.listLocalDisks).toHaveBeenCalledWith(requestContext, 'gateway-1234');
+      expect(valid).toEqual(true);
+    });
+
+    it('validation failed', async () => {
+      const listLocalDisksMockFn = jest.fn().mockImplementation(() => {
+        throw new Error('Gateway not found');
+      });
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.listLocalDisks = listLocalDisksMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(param => {
+        if (param === 'GATEWAY_ARN') {
+          return 'gateway-1234';
+        }
+        throw Error('Key not found');
+      });
+      const valid = await step.validateGateway();
+      expect(step.state.string).toHaveBeenCalledWith('GATEWAY_ARN');
+      expect(getStorageGatewayMock.listLocalDisks).toHaveBeenCalledWith(requestContext, 'gateway-1234');
+      expect(valid).toEqual(false);
+    });
+  });
+
+  describe('onFail', () => {
+    it('successful rollback', async () => {
+      let deleteStackCalled = false;
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'CREATE_FAILED',
+            StackStatusReason: 'VPC limit exceeded',
+          },
+        ],
+      };
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      AWSMock.mock('CloudFormation', 'deleteStack', (params, callback) => {
+        deleteStackCalled = true;
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, null);
+      });
+      const deleteGatewayMockFn = jest.fn();
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.deleteGateway = deleteGatewayMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+        optionalString: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(param => {
+        if (param === 'STATE_STACK_ID') {
+          return 'storage-gateway-stack';
+        }
+        throw Error('Key not found');
+      });
+      step.state.optionalString.mockImplementationOnce(param => {
+        if (param === 'GATEWAY_ARN') {
+          return 'gateway-1234';
+        }
+        throw Error('Key not found');
+      });
+      await step.onFail();
+      expect(step.state.string).toHaveBeenCalledWith('STATE_STACK_ID');
+      expect(step.state.optionalString).toHaveBeenCalledWith('GATEWAY_ARN');
+      expect(getStorageGatewayMock.deleteGateway).toHaveBeenCalledWith(requestContext, 'gateway-1234');
+      expect(deleteStackCalled).toEqual(true);
+    });
+
+    it('onFail when cloudformation delete fails', async () => {
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'CREATE_FAILED',
+            StackStatusReason: 'VPC limit exceeded',
+          },
+        ],
+      };
+      let deleteStackCalled = false;
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      AWSMock.mock('CloudFormation', 'deleteStack', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        deleteStackCalled = true;
+        callback({ code: 'CannotDelete' }, null);
+      });
+      const deleteGatewayMockFn = jest.fn();
+      const getStorageGatewayMock = {};
+      getStorageGatewayMock.deleteGateway = deleteGatewayMockFn;
+      step.getStorageGateway = jest.fn().mockImplementationOnce(() => getStorageGatewayMock);
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+        optionalString: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(param => {
+        if (param === 'STATE_STACK_ID') {
+          return 'storage-gateway-stack';
+        }
+        throw Error('Key not found');
+      });
+      step.state.optionalString.mockImplementationOnce(param => {
+        if (param === 'GATEWAY_ARN') {
+          return 'gateway-1234';
+        }
+        throw Error('Key not found');
+      });
+      try {
+        await step.onFail();
+        expect.fail('Expected fail to throw error');
+      } catch (error) {
+        expect(step.state.string).toHaveBeenCalledWith('STATE_STACK_ID');
+        expect(step.state.optionalString).toHaveBeenCalledWith('GATEWAY_ARN');
+        // ensure that delete gateway was still called
+        expect(getStorageGatewayMock.deleteGateway).toHaveBeenCalledWith(requestContext, 'gateway-1234');
+        expect(deleteStackCalled).toEqual(true);
+      }
+    });
+  });
+
+  describe('checkCfnCompleted', () => {
+    it('stack creation failed', async () => {
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'CREATE_FAILED',
+            StackStatusReason: 'VPC limit exceeded',
+          },
+        ],
+      };
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(() => 'storage-gateway-stack');
+      try {
+        await step.checkCfnCompleted();
+        expect.fail('Expected to throw stack operation failed error');
+      } catch (error) {
+        expect(error.message).toEqual('Stack operation failed with message: VPC limit exceeded');
+      }
+    });
+
+    it('stack creation in progress', async () => {
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'IN_PROGRESS',
+          },
+        ],
+      };
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(() => 'storage-gateway-stack');
+      const status = await step.checkCfnCompleted();
+      expect(status).toEqual(false);
+    });
+
+    it('stack deleted', async () => {
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'DELETE_COMPLETE',
+          },
+        ],
+      };
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(() => 'storage-gateway-stack');
+      try {
+        await step.checkCfnCompleted();
+        expect.fail('Expected to throw stack deleted error');
+      } catch (error) {
+        expect(error.message).toEqual('Stack deleted');
+      }
+    });
+
+    it('stack creation complete', async () => {
+      const stackIdParam = { StackName: 'storage-gateway-stack' };
+      const cfnToEnvKeys = {
+        CacheVolume: 'VOLUME_ID',
+        Region: 'REGION_ID',
+        ElasticIP: 'PUBLIC_IP',
+        SecurityGroup: 'SECURITY_GROUP',
+        VpcPublicSubnet1: 'SUBNET_ID',
+        VPC: 'VPC_ID',
+        EC2RoleArn: 'IAM_ROLE_ARN',
+        EC2Instance: 'EC2_INSTANCE_ID',
+      };
+      const stackDesc = {
+        Stacks: [
+          {
+            StackStatus: 'CREATE_COMPLETE',
+            Outputs: [
+              {
+                OutputKey: 'CacheVolume',
+                OutputValue: 'volume-1234',
+              },
+              {
+                OutputKey: 'Region',
+                OutputValue: 'us-west-2',
+              },
+              {
+                OutputKey: 'ElasticIP',
+                OutputValue: '11.11.11.11',
+              },
+              {
+                OutputKey: 'SecurityGroup',
+                OutputValue: 'sg-123456',
+              },
+              {
+                OutputKey: 'VpcPublicSubnet1',
+                OutputValue: 'subnet-12345678',
+              },
+              {
+                OutputKey: 'VPC',
+                OutputValue: 'vpc-12345678',
+              },
+              {
+                OutputKey: 'EC2RoleArn',
+                OutputValue: 'arn:aws:iam:us-west-2:111111111111:role/gateway-role',
+              },
+              {
+                OutputKey: 'EC2Instance',
+                OutputValue: 'instance-121245',
+              },
+            ],
+          },
+        ],
+      };
+      AWSMock.mock('CloudFormation', 'describeStacks', (params, callback) => {
+        expect(params).toMatchObject(stackIdParam);
+        callback(null, stackDesc);
+      });
+      step.state = {
+        setKey: jest.fn(),
+        string: jest.fn(),
+      };
+      step.state.string.mockImplementationOnce(() => 'storage-gateway-stack');
+      const status = await step.checkCfnCompleted();
+      expect(status).toEqual(true);
+      stackDesc.Stacks[0].Outputs.forEach(option => {
+        expect(step.state.setKey).toHaveBeenCalledWith(cfnToEnvKeys[option.OutputKey], option.OutputValue);
+      });
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/storage-gateway/create-network-infrastructure.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/storage-gateway/create-network-infrastructure.js
@@ -1,0 +1,251 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
+
+const STACK_FAILED = [
+  'CREATE_FAILED',
+  'ROLLBACK_FAILED',
+  'DELETE_FAILED',
+  'UPDATE_ROLLBACK_FAILED',
+  'ROLLBACK_COMPLETE',
+  'UPDATE_ROLLBACK_COMPLETE',
+];
+
+const STACK_SUCCESS = ['CREATE_COMPLETE', 'DELETE_COMPLETE', 'UPDATE_COMPLETE'];
+
+class CreateNetworkInfrastructure extends StepBase {
+  async start() {
+    this.print('start creating network infrastructure for storage gateway');
+    const [requestContext] = await Promise.all([this.payload.object('requestContext')]);
+
+    // Get the SSM parameter for AMI to use for Storage Gateway instance
+    const ssm = await this.getSSM();
+    const storageGatewayAMI = await ssm
+      .getParameter({ Name: '/aws/service/storagegateway/ami/FILE_S3/latest' })
+      .promise();
+
+    // set state
+    this.state.setKey('STORAGE_GATEWAY_AMI', storageGatewayAMI.Parameter.Value);
+    this.state.setKey('STATE_REQUEST_CONTEXT', requestContext);
+    await this.createNetworkInfra();
+    return this.wait(20)
+      .maxAttempts(60)
+      .until('checkCfnCompleted')
+      .thenCall('createStorageGateway');
+  }
+
+  async createNetworkInfra() {
+    // create all the network infrastructure required for storage gateway. Note that Storage Gateway doesn't
+    // have CloudFormation integration, so it's creation is being done outside of CloudFormation
+    this.print('start to deploy initial stacks in newly created AWS account');
+    const requestContext = await this.payload.object('requestContext');
+    const by = _.get(requestContext, 'principalIdentifier.uid');
+    const userService = await this.getUserService();
+    const user = await userService.mustFindUser({ uid: by });
+    // deploy basic stacks to the account just created
+    const [cfnTemplateService] = await this.mustFindServices(['cfnTemplateService']);
+    const cfn = await this.getCloudFormationService();
+
+    const [template] = await Promise.all([cfnTemplateService.getTemplate('storage-gateway-network-infra')]);
+    const stackName = `initial-stack-${new Date().getTime()}`;
+    const cfnParams = [];
+    const addParam = (key, v) => cfnParams.push({ ParameterKey: key, ParameterValue: v });
+
+    addParam('Namespace', stackName);
+    addParam('AmiId', await this.state.string('STORAGE_GATEWAY_AMI'));
+
+    const input = {
+      StackName: stackName,
+      Parameters: cfnParams,
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      TemplateBody: template,
+      Tags: [
+        {
+          Key: 'Description',
+          Value: `Created by ${user.username} for newly created AWS account`,
+        },
+        {
+          Key: 'CreatedBy',
+          Value: user.username,
+        },
+      ],
+    };
+    const response = await cfn.createStack(input).promise();
+
+    // Update workflow state and poll for stack creation completion
+    this.state.setKey('STATE_STACK_ID', response.StackId);
+    this.state.setKey('USER_ID', user.username);
+  }
+
+  async checkCfnCompleted() {
+    const stackId = await this.state.string('STATE_STACK_ID');
+    const cfn = await this.getCloudFormationService();
+    const stackInfo = (await cfn.describeStacks({ StackName: stackId }).promise()).Stacks[0];
+
+    if (STACK_FAILED.includes(stackInfo.StackStatus)) {
+      throw new Error(`Stack operation failed with message: ${stackInfo.StackStatusReason}`);
+    } else if (STACK_SUCCESS.includes(stackInfo.StackStatus)) {
+      // handle the case where the cloudformation is deleted before the creation could finish
+      if (stackInfo.StackStatus !== 'DELETE_COMPLETE') {
+        const cfnOutputs = this.getCfnOutputs(stackInfo);
+        this.print(`updating stack deployed completed: ${cfnOutputs}`);
+        this.state.setKey('VOLUME_ID', cfnOutputs.CacheVolume);
+        this.state.setKey('REGION_ID', cfnOutputs.Region);
+        this.state.setKey('PUBLIC_IP', cfnOutputs.ElasticIP);
+        this.state.setKey('SECURITY_GROUP', cfnOutputs.SecurityGroup);
+        this.state.setKey('SUBNET_ID', cfnOutputs.VpcPublicSubnet1);
+        this.state.setKey('VPC_ID', cfnOutputs.VPC);
+        this.state.setKey('IAM_ROLE_ARN', cfnOutputs.EC2RoleArn);
+        this.state.setKey('EC2_INSTANCE_ID', cfnOutputs.EC2Instance);
+        return true;
+      }
+      throw new Error(`Stack deleted`);
+    } // else CFN is still pending
+    return false;
+  }
+
+  async createStorageGateway() {
+    await this.activateGateway();
+    return this.wait(5)
+      .maxAttempts(5)
+      .until('validateGateway')
+      .thenCall('addCacheToGateway');
+  }
+
+  async activateGateway() {
+    const storageGateway = await this.getStorageGateway();
+    const publicIp = await this.state.string('PUBLIC_IP');
+    const region = await this.state.string('REGION_ID');
+    const securityGroup = await this.state.string('SECURITY_GROUP');
+    const requestContext = await this.payload.object('requestContext');
+    const rawData = {
+      publicIp,
+      region,
+      securityGroup,
+      timezone: 'GMT', // TODO: Default it based on AWS region and take it optionally as a parameter from admin
+    };
+    const gatewayARN = await storageGateway.activateGateway(requestContext, rawData);
+    this.print(`Found GatewayARN as ${gatewayARN} from storage-gateway`);
+    this.state.setKey('GATEWAY_ARN', gatewayARN);
+  }
+
+  async validateGateway() {
+    // Validate that the gateway creation went through. Without this validation we cannot perform any operations
+    // on the Gateway like adding cache
+    const storageGateway = await this.getStorageGateway();
+    const requestContext = await this.payload.object('requestContext');
+    try {
+      const gatewayARN = await this.state.string('GATEWAY_ARN');
+      await storageGateway.listLocalDisks(requestContext, gatewayARN);
+    } catch (error) {
+      this.print(`Gateway validation failed: ${error.stack}`);
+      return false;
+    }
+    return true;
+  }
+
+  async addCacheToGateway() {
+    // Add the volume created by this workflow step as a cache
+    const gatewayARN = await this.state.string('GATEWAY_ARN');
+    const volumeId = await this.state.string('VOLUME_ID');
+    const rawData = {
+      gatewayARN,
+      volumeId,
+    };
+    const requestContext = await this.payload.object('requestContext');
+    const storageGateway = await this.getStorageGateway();
+    await storageGateway.addCacheToGateway(requestContext, rawData);
+
+    // save result to DDB
+    const vpcId = await this.state.string('VPC_ID');
+    const subnetId = await this.state.string('SUBNET_ID');
+    const ec2Instance = await this.state.string('EC2_INSTANCE_ID');
+    const elasticIP = await this.state.string('PUBLIC_IP');
+    const securityGroup = await this.state.string('SECURITY_GROUP');
+    const ec2RoleARN = await this.state.string('IAM_ROLE_ARN');
+    const cfnStackId = await this.state.string('STATE_STACK_ID');
+    const dbData = {
+      vpcId,
+      subnetId,
+      ec2Instance,
+      elasticIP,
+      securityGroup,
+      ec2RoleARN,
+      volumeIds: [volumeId],
+      cfnStackId,
+    };
+    await storageGateway.saveToDDB(requestContext, dbData, gatewayARN);
+  }
+
+  async onFail() {
+    // 1. Delete the stack if it was created
+    // 2. Delete the Storage Gateway if it was created
+    try {
+      const stackId = await this.state.string('STATE_STACK_ID');
+      const cfn = await this.getCloudFormationService();
+      const stackInfo = (await cfn.describeStacks({ StackName: stackId }).promise()).Stacks[0];
+      this.print(`Found stack status: ${stackInfo.StackStatus}`);
+      if (stackInfo.StackStatus !== 'DELETE_COMPLETE') {
+        this.print(`Deleting stack: ${stackId}`);
+        await cfn.deleteStack({ StackName: stackId }).promise();
+        this.print(`Deleted stack: ${stackId}`);
+      }
+    } finally {
+      const storageGateway = await this.getStorageGateway();
+      const requestContext = await this.payload.object('requestContext');
+      const gatewayARN = await this.state.optionalString('GATEWAY_ARN');
+      if (gatewayARN) {
+        await storageGateway.deleteGateway(requestContext, gatewayARN);
+      }
+    }
+  }
+
+  async getUserService() {
+    const [userService] = await this.mustFindServices(['userService']);
+    return userService;
+  }
+
+  async getCloudFormationService() {
+    const aws = await this.getAWS();
+    return new aws.sdk.CloudFormation();
+  }
+
+  async getSSM() {
+    const aws = await this.getAWS();
+    return new aws.sdk.SSM({ apiVersion: '2014-11-06' });
+  }
+
+  async getStorageGateway() {
+    const [storageGateway] = await this.mustFindServices(['storageGateway']);
+    return storageGateway;
+  }
+
+  async getAWS() {
+    const [aws] = await this.mustFindServices(['aws']);
+    return aws;
+  }
+
+  getCfnOutputs(stackInfo) {
+    const details = {};
+    stackInfo.Outputs.forEach(option => {
+      _.set(details, option.OutputKey, option.OutputValue);
+    });
+    return details;
+  }
+}
+
+module.exports = CreateNetworkInfrastructure;

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/storage-gateway/create-network-infrastructure.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/storage-gateway/create-network-infrastructure.yml
@@ -1,0 +1,8 @@
+id: create-network-infrastructure
+v: 1
+title: Provision Network for Storage Gateway
+desc: |
+  Provision Network for Storage Gateway
+
+skippable: true # this means that if there is an error in a previous step, then this step will be skipped
+hidden: true

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/package.json
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/package.json
@@ -12,6 +12,8 @@
     "slugify": "^1.4.0"
   },
   "devDependencies": {
+    "@aws-ee/workflow-engine": "workspace:*",
+    "@aws-ee/base-services-container": "workspace:*",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-airbnb-base": "^14.1.0",
@@ -25,7 +27,8 @@
     "jest-junit": "^10.0.0",
     "prettier": "^1.19.1",
     "pretty-quick": "^1.11.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "aws-sdk-mock": "^5.1.0"
   },
   "scripts": {
     "test": "NODE_ENV=test jest --config jest.config.js --passWithNoTests",

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/plugins/workflows-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/plugins/workflows-plugin.js
@@ -20,6 +20,7 @@ const startSageMakerYaml = require('../workflows/start-sagemaker-environment.yml
 const stopSageMakerYaml = require('../workflows/stop-sagemaker-environment.yml');
 const startEC2Yaml = require('../workflows/start-ec2-environment.yml');
 const stopEC2Yaml = require('../workflows/stop-ec2-environment.yml');
+const networkInfraYaml = require('../workflows/create-network-infra.yml');
 
 const add = yaml => ({ yaml });
 
@@ -32,6 +33,7 @@ const workflows = [
   add(stopSageMakerYaml),
   add(startEC2Yaml),
   add(stopEC2Yaml),
+  add(networkInfraYaml),
 ];
 
 async function registerWorkflows(registry) {

--- a/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/create-network-infra.yml
+++ b/addons/addon-base-raas/packages/base-raas-workflows/lib/workflows/create-network-infra.yml
@@ -1,0 +1,17 @@
+id: wf-create-network-infra
+v: 1
+workflowTemplateId: wt-empty
+workflowTemplateVer: 1
+title: Create New Network Infra for Storage Gateway
+desc: |
+  Create new environment
+hidden: false
+builtin: true
+instanceTtl: 30 # In days, however, empty value means that it is indefinite
+selectedSteps:
+  - stepTemplateId: create-network-infrastructure
+    stepTemplateVer: 1
+    id: wf-step_1_1571231231232_20 # Randomly generated id, no need to change it
+    # configs: # add configuration key/value pairs (if needed)
+    # key1: value1
+    # key2: value2

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -371,6 +371,7 @@ Resources:
                 - !GetAtt [AccountsDb, Arn]
                 - !GetAtt [KeyPairsDb, Arn]
                 - !Join ['', [!GetAtt [KeyPairsDb, Arn], '/index/*']]
+                - !GetAtt [StorageGatewayDb, Arn]
 
         - PolicyName: param-store-access
           PolicyDocument:
@@ -378,7 +379,9 @@ Resources:
               Effect: Allow
               Action:
                 - ssm:GetParameter
-              Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${self:custom.settings.paramStoreRoot}/*'
+              Resource:
+                - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${self:custom.settings.paramStoreRoot}/*'
+                - !Sub 'arn:aws:ssm:${AWS::Region}:*:parameter/aws/service/storagegateway/ami/FILE_S3/latest'
 
         - PolicyName: step-functions-invocation
           PolicyDocument:
@@ -548,16 +551,23 @@ Resources:
                 - !GetAtt [IndexesDb, Arn]
                 - !GetAtt [CostApiCachesDb, Arn]
                 - !GetAtt [UserRolesDb, Arn]
+                - !GetAtt [StorageGatewayDb, Arn]
 
         - PolicyName: param-store-access
           PolicyDocument:
             Statement:
-              Effect: Allow
-              Action:
-                - ssm:GetParameter
-                - ssm:PutParameter
-                - ssm:DeleteParameter
-              Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${self:custom.settings.paramStoreRoot}/*'
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource:
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${self:custom.settings.paramStoreRoot}/*'
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:*:parameter/aws/service/storagegateway/ami/FILE_S3/latest'
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                Resource:
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${self:custom.settings.paramStoreRoot}/*'
 
         - PolicyName: dns-record-access
           PolicyDocument:
@@ -572,10 +582,18 @@ Resources:
             Statement:
               - Effect: 'Allow'
                 Action:
-                  - ec2:CreateKeyPair
-                  - ec2:DeleteKeyPair
-                  - ec2:ModifyImageAttribute
-                  - ec2:DescribeImages
+                  - ec2:*
+                Resource: '*'
+
+        - PolicyName: storage-gateway
+          PolicyDocument:
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - storagegateway:ActivateGateway
+                  - storagegateway:ListLocalDisks
+                  - storagegateway:AddCache
+                  - storagegateway:DeleteGateway
                 Resource: '*'
 
         - PolicyName: study-s3-policy-update
@@ -1316,6 +1334,18 @@ Resources:
               KeyType: 'HASH'
           Projection:
             ProjectionType: 'ALL'
+      BillingMode: PAY_PER_REQUEST
+
+  StorageGatewayDb:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: ${self:custom.settings.dbStorageGateway}
+      AttributeDefinitions:
+        - AttributeName: 'id'
+          AttributeType: 'S'
+      KeySchema:
+        - AttributeName: 'id'
+          KeyType: 'HASH'
       BillingMode: PAY_PER_REQUEST
 
   # =============================================================================================

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -174,6 +174,9 @@ dbStudyPermissions: ${self:custom.settings.dbPrefix}-StudyPermissions
 # DynamoDB table name for KeyPairs
 dbKeyPairs: ${self:custom.settings.dbPrefix}-KeyPairs
 
+# DynamoDB table for managing StorageGateway
+dbStorageGateway: ${self:custom.settings.dbPrefix}-StorageGateway
+
 # ================================ DB Settings - Depreciated ===========================================
 
 # DynamoDB table name for supported authentication provider types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,31 @@
 importers:
+  .:
+    devDependencies:
+      babel-plugin-inline-import: 3.0.0
+      eslint: 7.11.0
+      eslint-config-airbnb: 18.2.0_74bcc3ac45f6a99aa08aa67ef2092323
+      eslint-config-airbnb-base: 14.2.0_b0107ac66144325cec64acec0bc152ec
+      eslint-config-prettier: 6.12.0_eslint@7.11.0
+      eslint-plugin-import: 2.22.1_eslint@7.11.0
+      eslint-plugin-jest: 23.20.0_eslint@7.11.0
+      eslint-plugin-jsx-a11y: 6.3.1_eslint@7.11.0
+      eslint-plugin-prettier: 3.1.4_eslint@7.11.0
+      eslint-plugin-react: 7.21.4_eslint@7.11.0
+      eslint-plugin-react-hooks: 4.1.2_eslint@7.11.0
+      prettier-eslint: 11.0.0
+    specifiers:
+      babel-plugin-inline-import: ^3.0.0
+      eslint: ^7.2.0
+      eslint-config-airbnb: ^18.2.0
+      eslint-config-airbnb-base: ^14.2.0
+      eslint-config-prettier: ^6.11.0
+      eslint-plugin-import: ^2.22.0
+      eslint-plugin-jest: ^23.20.0
+      eslint-plugin-jsx-a11y: ^6.3.1
+      eslint-plugin-prettier: ^3.1.4
+      eslint-plugin-react: ^7.20.5
+      eslint-plugin-react-hooks: ^4.0.0
+      prettier-eslint: ^11.0.0
   addons/addon-base-post-deployment/packages/base-post-deployment:
     dependencies:
       '@aws-ee/base-api-services': 'link:../../../addon-base-rest-api/packages/services'
@@ -305,9 +332,9 @@ importers:
       lodash: 4.17.15
       moment: 2.27.0
       node-cache: 4.2.1
+      node-fetch: 2.6.0
       request: 2.88.2
       request-promise-native: 1.0.8_request@2.88.2
-      sinon: 9.0.3
       uuid: 3.4.0
       xml: 1.0.1
     devDependencies:
@@ -324,6 +351,7 @@ importers:
       jest-junit: 10.0.0
       prettier: 1.19.1
       pretty-quick: 1.11.1_prettier@1.19.1
+      sinon: 9.0.3
       source-map-support: 0.5.16
     specifiers:
       '@aws-ee/base-api-services': 'workspace:*'
@@ -344,6 +372,7 @@ importers:
       lodash: ^4.17.15
       moment: ^2.27.0
       node-cache: ^4.2.1
+      node-fetch: ^2.6.0
       prettier: ^1.19.1
       pretty-quick: ^1.11.1
       request: ^2.88.2
@@ -359,6 +388,9 @@ importers:
       lodash: 4.17.15
       slugify: 1.4.0
     devDependencies:
+      '@aws-ee/base-services-container': 'link:../../../addon-base/packages/services-container'
+      '@aws-ee/workflow-engine': 'link:../../../addon-base-workflow/packages/workflow-engine'
+      aws-sdk-mock: 5.1.0
       eslint: 6.8.0
       eslint-config-airbnb: 18.1.0_8cdb6d8c18c3319a1365bd5afa0063a3
       eslint-config-airbnb-base: 14.1.0_8cdb6d8c18c3319a1365bd5afa0063a3
@@ -375,7 +407,10 @@ importers:
       source-map-support: 0.5.16
     specifiers:
       '@aws-ee/base-services': 'workspace:*'
+      '@aws-ee/base-services-container': 'workspace:*'
       '@aws-ee/base-workflow-core': 'workspace:*'
+      '@aws-ee/workflow-engine': 'workspace:*'
+      aws-sdk-mock: ^5.1.0
       eslint: ^6.8.0
       eslint-config-airbnb: ^18.1.0
       eslint-config-airbnb-base: ^14.1.0
@@ -3427,6 +3462,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ayjSOxuK2GaSDJFCtLgHnYjuMyIpViNujWrZo8GUpN60/n7juzJKK5yOo6RFVb0zdU9ACJFK+MsZrUnj3OmXMw==
+  /@babel/runtime-corejs3/7.11.2:
+    dependencies:
+      core-js-pure: 3.6.4
+      regenerator-runtime: 0.13.5
+    dev: true
+    resolution:
+      integrity: sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
   /@babel/runtime-corejs3/7.9.2:
     dependencies:
       core-js-pure: 3.6.4
@@ -3617,6 +3659,23 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+  /@eslint/eslintrc/0.1.3:
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.1.1
+      espree: 7.3.0
+      globals: 12.4.0
+      ignore: 4.0.6
+      import-fresh: 3.2.1
+      js-yaml: 3.14.0
+      lodash: 4.17.20
+      minimatch: 3.0.4
+      strip-json-comments: 3.1.1
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    resolution:
+      integrity: sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
   /@hapi/accept/3.2.4:
     dependencies:
       '@hapi/boom': 7.4.11
@@ -4489,17 +4548,20 @@ packages:
   /@sinonjs/commons/1.7.2:
     dependencies:
       type-detect: 4.0.8
+    dev: true
     resolution:
       integrity: sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==
   /@sinonjs/fake-timers/6.0.1:
     dependencies:
       '@sinonjs/commons': 1.7.2
+    dev: true
     resolution:
       integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   /@sinonjs/formatio/5.0.1:
     dependencies:
       '@sinonjs/commons': 1.7.2
       '@sinonjs/samsam': 5.1.0
+    dev: true
     resolution:
       integrity: sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
   /@sinonjs/samsam/5.1.0:
@@ -4507,9 +4569,11 @@ packages:
       '@sinonjs/commons': 1.7.2
       lodash.get: 4.4.2
       type-detect: 4.0.8
+    dev: true
     resolution:
       integrity: sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
   /@sinonjs/text-encoding/0.7.1:
+    dev: true
     resolution:
       integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
   /@stardust-ui/react-component-event-listener/0.38.0_react-dom@16.13.1+react@16.13.1:
@@ -4753,14 +4817,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  /@types/json-schema/7.0.4:
-    dev: true
-    resolution:
-      integrity: sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
   /@types/json-schema/7.0.5:
     dev: true
     resolution:
       integrity: sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+  /@types/json5/0.0.29:
+    dev: true
+    resolution:
+      integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
   /@types/lodash/4.14.149:
     dev: true
     resolution:
@@ -4878,11 +4942,11 @@ packages:
       integrity: sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
   /@typescript-eslint/experimental-utils/2.27.0_eslint@6.8.0:
     dependencies:
-      '@types/json-schema': 7.0.4
+      '@types/json-schema': 7.0.5
       '@typescript-eslint/typescript-estree': 2.27.0
       eslint: 6.8.0
-      eslint-scope: 5.0.0
-      eslint-utils: 2.0.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -4890,6 +4954,36 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
+  /@typescript-eslint/experimental-utils/2.27.0_eslint@7.11.0:
+    dependencies:
+      '@types/json-schema': 7.0.5
+      '@typescript-eslint/typescript-estree': 2.27.0
+      eslint: 7.11.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+    dev: true
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: '*'
+    resolution:
+      integrity: sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@6.8.0+typescript@3.9.7:
+    dependencies:
+      '@types/json-schema': 7.0.5
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@3.9.7
+      eslint: 6.8.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    resolution:
+      integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
   /@typescript-eslint/parser/2.27.0_eslint@6.8.0:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
@@ -4908,6 +5002,32 @@ packages:
         optional: true
     resolution:
       integrity: sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==
+  /@typescript-eslint/parser/3.10.1_eslint@6.8.0+typescript@3.9.7:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@6.8.0+typescript@3.9.7
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@3.9.7
+      eslint: 6.8.0
+      eslint-visitor-keys: 1.3.0
+      typescript: 3.9.7
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==
+  /@typescript-eslint/types/3.10.1:
+    dev: true
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
   /@typescript-eslint/typescript-estree/1.13.0:
     dependencies:
       lodash.unescape: 4.0.1
@@ -4920,10 +5040,10 @@ packages:
   /@typescript-eslint/typescript-estree/2.27.0:
     dependencies:
       debug: 4.1.1
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.3.0
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.15
+      lodash: 4.17.20
       semver: 6.3.0
       tsutils: 3.17.1
     dev: true
@@ -4939,10 +5059,10 @@ packages:
   /@typescript-eslint/typescript-estree/2.27.0_typescript@3.8.3:
     dependencies:
       debug: 4.1.1
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.3.0
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.15
+      lodash: 4.17.20
       semver: 6.3.0
       tsutils: 3.17.1_typescript@3.8.3
       typescript: 3.8.3
@@ -4956,6 +5076,35 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
+  /@typescript-eslint/typescript-estree/3.10.1_typescript@3.9.7:
+    dependencies:
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/visitor-keys': 3.10.1
+      debug: 4.1.1
+      glob: 7.1.6
+      is-glob: 4.0.1
+      lodash: 4.17.20
+      semver: 7.3.2
+      tsutils: 3.17.1_typescript@3.9.7
+      typescript: 3.9.7
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
+  /@typescript-eslint/visitor-keys/3.10.1:
+    dependencies:
+      eslint-visitor-keys: 1.3.0
+    dev: true
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   /@webassemblyjs/ast/1.8.5:
     dependencies:
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -5238,9 +5387,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
-  /acorn-jsx/5.2.0_acorn@7.3.1:
+  /acorn-jsx/5.2.0_acorn@7.4.1:
     dependencies:
-      acorn: 7.3.1
+      acorn: 7.4.1
     dev: true
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
@@ -5273,13 +5422,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
-  /acorn/7.3.1:
+  /acorn/7.4.1:
     dev: true
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
+      integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
   /address/1.1.2:
     dev: true
     engines:
@@ -5387,6 +5536,15 @@ packages:
       uri-js: 4.2.2
     resolution:
       integrity: sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  /ajv/6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.2.2
+    dev: true
+    resolution:
+      integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   /alphanum-sort/1.0.2:
     dev: true
     resolution:
@@ -5413,6 +5571,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+  /ansi-colors/4.1.1:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
   /ansi-escapes/3.2.0:
     dev: true
     engines:
@@ -5612,6 +5776,15 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  /aria-query/4.2.2:
+    dependencies:
+      '@babel/runtime': 7.10.3
+      '@babel/runtime-corejs3': 7.11.2
+    dev: true
+    engines:
+      node: '>=6.0'
+    resolution:
+      integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
   /arity-n/1.0.4:
     dev: true
     resolution:
@@ -5707,6 +5880,16 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  /array.prototype.flatmap/1.2.3:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.17.6
+      function-bind: 1.1.1
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
   /arraybuffer.slice/0.0.7:
     dev: true
     resolution:
@@ -5877,6 +6060,12 @@ packages:
   /aws4/1.9.1:
     resolution:
       integrity: sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+  /axe-core/3.5.5:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
   /axios/0.19.2:
     dependencies:
       follow-redirects: 1.5.10
@@ -6804,6 +6993,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  /chalk/4.1.0:
+    dependencies:
+      ansi-styles: 4.2.1
+      supports-color: 7.1.0
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   /character-entities-legacy/1.1.4:
     dev: false
     resolution:
@@ -8415,6 +8613,7 @@ packages:
     resolution:
       integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
   /diff/4.0.2:
+    dev: true
     engines:
       node: '>=0.3.1'
     resolution:
@@ -8459,6 +8658,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+  /dlv/1.1.3:
+    dev: true
+    resolution:
+      integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
   /dns-equal/1.0.0:
     dev: true
     resolution:
@@ -8700,6 +8903,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+  /emoji-regex/9.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-AaWyDiNO9rbtMIcGl7tdxMcNu8SOLaDLxmQEFT5JhgKufOJzPPkYmgN2QwqTgw4doWMZZQttC6sUWVQjb+1VdA==
   /emojis-list/2.1.0:
     dev: true
     engines:
@@ -8792,6 +8999,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
+  /enquirer/2.3.6:
+    dependencies:
+      ansi-colors: 4.1.1
+    dev: true
+    engines:
+      node: '>=8.6'
+    resolution:
+      integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   /entities/1.1.2:
     dev: true
     resolution:
@@ -8913,13 +9128,31 @@ packages:
       is-regex: 1.1.0
       object-inspect: 1.8.0
       object-keys: 1.1.1
-      object.assign: 4.1.0
+      object.assign: 4.1.1
       string.prototype.trimend: 1.0.1
       string.prototype.trimstart: 1.0.1
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+  /es-abstract/1.18.0-next.1:
+    dependencies:
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.1
+      is-callable: 1.2.2
+      is-negative-zero: 2.0.0
+      is-regex: 1.1.1
+      object-inspect: 1.8.0
+      object-keys: 1.1.1
+      object.assign: 4.1.1
+      string.prototype.trimend: 1.0.1
+      string.prototype.trimstart: 1.0.1
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
   /es-cookie/1.3.2:
     dev: false
     resolution:
@@ -9029,6 +9262,21 @@ packages:
       eslint-plugin-import: ^2.20.1
     resolution:
       integrity: sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==
+  /eslint-config-airbnb-base/14.2.0_b0107ac66144325cec64acec0bc152ec:
+    dependencies:
+      confusing-browser-globals: 1.0.9
+      eslint: 7.11.0
+      eslint-plugin-import: 2.22.1_eslint@7.11.0
+      object.assign: 4.1.0
+      object.entries: 1.1.2
+    dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.21.2
+    resolution:
+      integrity: sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==
   /eslint-config-airbnb/18.1.0_7221e9efc3e1df952f9031babfc371af:
     dependencies:
       eslint: 6.8.0
@@ -9108,6 +9356,27 @@ packages:
       eslint-plugin-react-hooks: ^2.5.0 || ^1.7.0
     resolution:
       integrity: sha512-kZFuQC/MPnH7KJp6v95xsLBf63G/w7YqdPfQ0MUanxQ7zcKUNG8j+sSY860g3NwCBOa62apw16J6pRN+AOgXzw==
+  /eslint-config-airbnb/18.2.0_74bcc3ac45f6a99aa08aa67ef2092323:
+    dependencies:
+      eslint: 7.11.0
+      eslint-config-airbnb-base: 14.2.0_b0107ac66144325cec64acec0bc152ec
+      eslint-plugin-import: 2.22.1_eslint@7.11.0
+      eslint-plugin-jsx-a11y: 6.3.1_eslint@7.11.0
+      eslint-plugin-react: 7.21.4_eslint@7.11.0
+      eslint-plugin-react-hooks: 4.1.2_eslint@7.11.0
+      object.assign: 4.1.0
+      object.entries: 1.1.2
+    dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.21.2
+      eslint-plugin-jsx-a11y: ^6.3.0
+      eslint-plugin-react: ^7.20.0
+      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
+    resolution:
+      integrity: sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==
   /eslint-config-prettier/6.10.1_eslint@6.8.0:
     dependencies:
       eslint: 6.8.0
@@ -9118,6 +9387,16 @@ packages:
       eslint: '>=3.14.1'
     resolution:
       integrity: sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
+  /eslint-config-prettier/6.12.0_eslint@7.11.0:
+    dependencies:
+      eslint: 7.11.0
+      get-stdin: 6.0.0
+    dev: true
+    hasBin: true
+    peerDependencies:
+      eslint: '>=3.14.1'
+    resolution:
+      integrity: sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==
   /eslint-config-react-app/5.2.1_c14ecc97ba42c4e073f7e6502a3f179f:
     dependencies:
       '@typescript-eslint/eslint-plugin': 2.27.0_9e31f0f459c1656d0a7ef30429cc70f8
@@ -9150,6 +9429,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+  /eslint-import-resolver-node/0.3.4:
+    dependencies:
+      debug: 2.6.9
+      resolve: 1.17.0
+    dev: true
+    resolution:
+      integrity: sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   /eslint-loader/3.0.3_eslint@6.8.0+webpack@4.42.0:
     dependencies:
       eslint: 6.8.0
@@ -9240,6 +9526,29 @@ packages:
       eslint: 2.x - 6.x
     resolution:
       integrity: sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==
+  /eslint-plugin-import/2.22.1_eslint@7.11.0:
+    dependencies:
+      array-includes: 3.1.1
+      array.prototype.flat: 1.2.3
+      contains-path: 0.1.0
+      debug: 2.6.9
+      doctrine: 1.5.0
+      eslint: 7.11.0
+      eslint-import-resolver-node: 0.3.4
+      eslint-module-utils: 2.6.0
+      has: 1.0.3
+      minimatch: 3.0.4
+      object.values: 1.1.1
+      read-pkg-up: 2.0.0
+      resolve: 1.17.0
+      tsconfig-paths: 3.9.0
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
+    resolution:
+      integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
   /eslint-plugin-jest/22.21.0_eslint@6.8.0:
     dependencies:
       '@typescript-eslint/experimental-utils': 1.13.0_eslint@6.8.0
@@ -9251,6 +9560,17 @@ packages:
       eslint: '>=5'
     resolution:
       integrity: sha512-OaqnSS7uBgcGiqXUiEnjoqxPNKvR4JWG5mSRkzVoR6+vDwlqqp11beeql1hYs0HTbdhiwrxWLxbX0Vx7roG3Ew==
+  /eslint-plugin-jest/23.20.0_eslint@7.11.0:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.27.0_eslint@7.11.0
+      eslint: 7.11.0
+    dev: true
+    engines:
+      node: '>=8'
+    peerDependencies:
+      eslint: '>=5'
+    resolution:
+      integrity: sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
   /eslint-plugin-jest/23.8.2_eslint@6.8.0:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.27.0_eslint@6.8.0
@@ -9281,6 +9601,27 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6
     resolution:
       integrity: sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==
+  /eslint-plugin-jsx-a11y/6.3.1_eslint@7.11.0:
+    dependencies:
+      '@babel/runtime': 7.10.3
+      aria-query: 4.2.2
+      array-includes: 3.1.1
+      ast-types-flow: 0.0.7
+      axe-core: 3.5.5
+      axobject-query: 2.1.2
+      damerau-levenshtein: 1.0.6
+      emoji-regex: 9.1.1
+      eslint: 7.11.0
+      has: 1.0.3
+      jsx-ast-utils: 2.4.1
+      language-tags: 1.0.5
+    dev: true
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7
+    resolution:
+      integrity: sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==
   /eslint-plugin-prettier/3.1.2_eslint@6.8.0+prettier@1.19.1:
     dependencies:
       eslint: 6.8.0
@@ -9294,6 +9635,18 @@ packages:
       prettier: '>= 1.13.0'
     resolution:
       integrity: sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  /eslint-plugin-prettier/3.1.4_eslint@7.11.0:
+    dependencies:
+      eslint: 7.11.0
+      prettier-linter-helpers: 1.0.0
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    peerDependencies:
+      eslint: '>=5.0.0'
+      prettier: '>=1.13.0'
+    resolution:
+      integrity: sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
   /eslint-plugin-react-hooks/1.7.0_eslint@6.8.0:
     dependencies:
       eslint: 6.8.0
@@ -9314,6 +9667,16 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
+  /eslint-plugin-react-hooks/4.1.2_eslint@7.11.0:
+    dependencies:
+      eslint: 7.11.0
+    dev: true
+    engines:
+      node: '>=10'
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+    resolution:
+      integrity: sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
   /eslint-plugin-react/7.19.0_eslint@6.8.0:
     dependencies:
       array-includes: 3.1.1
@@ -9336,6 +9699,27 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==
+  /eslint-plugin-react/7.21.4_eslint@7.11.0:
+    dependencies:
+      array-includes: 3.1.1
+      array.prototype.flatmap: 1.2.3
+      doctrine: 2.1.0
+      eslint: 7.11.0
+      has: 1.0.3
+      jsx-ast-utils: 3.1.0
+      object.entries: 1.1.2
+      object.fromentries: 2.0.2
+      object.values: 1.1.1
+      prop-types: 15.7.2
+      resolve: 1.17.0
+      string.prototype.matchall: 4.0.2
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7
+    resolution:
+      integrity: sha512-uHeQ8A0hg0ltNDXFu3qSfFqTNPXm1XithH6/SY318UX76CMj7Q599qWpgmMhVQyvhq36pm7qvoN3pb6/3jsTFg==
   /eslint-scope/4.0.3:
     dependencies:
       esrecurse: 4.2.1
@@ -9345,15 +9729,6 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
-  /eslint-scope/5.0.0:
-    dependencies:
-      esrecurse: 4.2.1
-      estraverse: 4.3.0
-    dev: true
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
   /eslint-scope/5.1.0:
     dependencies:
       esrecurse: 4.2.1
@@ -9363,6 +9738,15 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  /eslint-scope/5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   /eslint-utils/1.4.3:
     dependencies:
       eslint-visitor-keys: 1.3.0
@@ -9371,14 +9755,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
-  /eslint-utils/2.0.0:
+  /eslint-utils/2.1.0:
     dependencies:
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.3.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+      integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   /eslint-visitor-keys/1.1.0:
     dev: true
     engines:
@@ -9391,6 +9775,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+  /eslint-visitor-keys/2.0.0:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
   /eslint/6.8.0:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -9436,6 +9826,51 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+  /eslint/7.11.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@eslint/eslintrc': 0.1.3
+      ajv: 6.12.2
+      chalk: 4.1.0
+      cross-spawn: 7.0.2
+      debug: 4.1.1
+      doctrine: 3.0.0
+      enquirer: 2.3.6
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+      eslint-visitor-keys: 2.0.0
+      espree: 7.3.0
+      esquery: 1.3.1
+      esutils: 2.0.3
+      file-entry-cache: 5.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.1.1
+      globals: 12.4.0
+      ignore: 4.0.6
+      import-fresh: 3.2.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.1
+      js-yaml: 3.14.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash: 4.17.20
+      minimatch: 3.0.4
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      progress: 2.0.3
+      regexpp: 3.1.0
+      semver: 7.3.2
+      strip-ansi: 6.0.0
+      strip-json-comments: 3.1.0
+      table: 5.4.6
+      text-table: 0.2.0
+      v8-compile-cache: 2.1.1
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    hasBin: true
+    resolution:
+      integrity: sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
   /esniff/1.1.0:
     dependencies:
       d: 1.0.1
@@ -9445,14 +9880,24 @@ packages:
       integrity: sha1-xmhJIp+RRk3t4uDUAgHtar9l8qw=
   /espree/6.2.1:
     dependencies:
-      acorn: 7.3.1
-      acorn-jsx: 5.2.0_acorn@7.3.1
+      acorn: 7.4.1
+      acorn-jsx: 5.2.0_acorn@7.4.1
       eslint-visitor-keys: 1.3.0
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  /espree/7.3.0:
+    dependencies:
+      acorn: 7.4.1
+      acorn-jsx: 5.2.0_acorn@7.4.1
+      eslint-visitor-keys: 1.3.0
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    resolution:
+      integrity: sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
   /esprima/4.0.1:
     engines:
       node: '>=4'
@@ -9475,6 +9920,14 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+  /esrecurse/4.3.0:
+    dependencies:
+      estraverse: 5.2.0
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   /essentials/1.1.1:
     dev: true
     resolution:
@@ -9491,6 +9944,12 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+  /estraverse/5.2.0:
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
   /esutils/2.0.3:
     dev: true
     engines:
@@ -10888,6 +11347,7 @@ packages:
     resolution:
       integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
   /has-flag/4.0.0:
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -11661,6 +12121,11 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+  /is-callable/1.2.2:
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
   /is-ci/1.2.1:
     dependencies:
       ci-info: 1.6.0
@@ -11844,6 +12309,11 @@ packages:
     dev: true
     resolution:
       integrity: sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
+  /is-negative-zero/2.0.0:
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
   /is-npm/1.0.0:
     dev: true
     engines:
@@ -11975,6 +12445,13 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  /is-regex/1.1.1:
+    dependencies:
+      has-symbols: 1.0.1
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   /is-regexp/1.0.0:
     dev: true
     engines:
@@ -13344,6 +13821,24 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
+  /jsx-ast-utils/2.4.1:
+    dependencies:
+      array-includes: 3.1.1
+      object.assign: 4.1.1
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
+  /jsx-ast-utils/3.1.0:
+    dependencies:
+      array-includes: 3.1.1
+      object.assign: 4.1.1
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==
   /jszip/3.3.0:
     dependencies:
       lie: 3.3.0
@@ -13354,6 +13849,7 @@ packages:
     resolution:
       integrity: sha512-EJ9k766htB1ZWnsV5ZMDkKLgA+201r/ouFF8R2OigVjVdcm2rurcBrrdXaeqBJbqnUVMko512PYmlncBKE1Huw==
   /just-extend/4.1.0:
+    dev: true
     resolution:
       integrity: sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
   /jwa/1.4.1:
@@ -13454,6 +13950,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==
+  /language-subtag-registry/0.3.20:
+    dev: true
+    resolution:
+      integrity: sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==
+  /language-tags/1.0.5:
+    dependencies:
+      language-subtag-registry: 0.3.20
+    dev: true
+    resolution:
+      integrity: sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
   /last-call-webpack-plugin/3.0.0:
     dependencies:
       lodash: 4.17.15
@@ -13539,6 +14045,15 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  /levn/0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
+    engines:
+      node: '>= 0.8.0'
+    resolution:
+      integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   /lie/3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -13706,6 +14221,7 @@ packages:
     resolution:
       integrity: sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
   /lodash.get/4.4.2:
+    dev: true
     resolution:
       integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
   /lodash.includes/4.3.0:
@@ -13734,6 +14250,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+  /lodash.merge/4.6.2:
+    dev: true
+    resolution:
+      integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
   /lodash.once/4.1.1:
     resolution:
       integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
@@ -13819,6 +14339,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==
+  /loglevel-colored-level-prefix/1.0.0:
+    dependencies:
+      chalk: 1.1.3
+      loglevel: 1.6.7
+    dev: true
+    resolution:
+      integrity: sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=
   /loglevel/1.6.7:
     dev: true
     engines:
@@ -14496,6 +15023,7 @@ packages:
       '@sinonjs/text-encoding': 0.7.1
       just-extend: 4.1.0
       path-to-regexp: 1.8.0
+    dev: true
     resolution:
       integrity: sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
   /no-case/3.0.3:
@@ -14802,10 +15330,21 @@ packages:
       function-bind: 1.1.1
       has-symbols: 1.0.1
       object-keys: 1.1.1
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  /object.assign/4.1.1:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.18.0-next.1
+      has-symbols: 1.0.1
+      object-keys: 1.1.1
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   /object.entries/1.1.1:
     dependencies:
       define-properties: 1.1.3
@@ -14958,6 +15497,19 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  /optionator/0.9.1:
+    dependencies:
+      deep-is: 0.1.3
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.3
+    dev: true
+    engines:
+      node: '>= 0.8.0'
+    resolution:
+      integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   /original/1.0.2:
     dependencies:
       url-parse: 1.4.7
@@ -16276,6 +16828,12 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+  /prelude-ls/1.2.1:
+    dev: true
+    engines:
+      node: '>= 0.8.0'
+    resolution:
+      integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
   /prepend-http/1.0.4:
     dev: true
     engines:
@@ -16288,6 +16846,25 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+  /prettier-eslint/11.0.0:
+    dependencies:
+      '@typescript-eslint/parser': 3.10.1_eslint@6.8.0+typescript@3.9.7
+      common-tags: 1.8.0
+      dlv: 1.1.3
+      eslint: 6.8.0
+      indent-string: 4.0.0
+      lodash.merge: 4.6.2
+      loglevel-colored-level-prefix: 1.0.0
+      prettier: 2.1.2
+      pretty-format: 23.6.0
+      require-relative: 0.8.7
+      typescript: 3.9.7
+      vue-eslint-parser: 7.1.1_eslint@6.8.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-ACjL7T8m10HCO7DwYdXwhNWuZzQv86JkZAhVpzFV9brTMWi3i6LhqoELFaXf6RetDngujz89tnbDmGyvDl+rzA==
   /prettier-linter-helpers/1.0.0:
     dependencies:
       fast-diff: 1.2.0
@@ -16303,6 +16880,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+  /prettier/2.1.2:
+    dev: true
+    engines:
+      node: '>=10.13.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
   /pretty-bytes/5.3.0:
     engines:
       node: '>=6'
@@ -16315,6 +16899,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+  /pretty-format/23.6.0:
+    dependencies:
+      ansi-regex: 3.0.0
+      ansi-styles: 3.2.1
+    dev: true
+    resolution:
+      integrity: sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
   /pretty-format/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -17445,6 +18036,10 @@ packages:
   /require-main-filename/2.0.0:
     resolution:
       integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+  /require-relative/0.8.7:
+    dev: true
+    resolution:
+      integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
   /require-resolve/0.0.2:
     dependencies:
       x-path: 0.0.2
@@ -17914,6 +18509,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+  /semver/7.3.2:
+    dev: true
+    engines:
+      node: '>=10'
+    hasBin: true
+    resolution:
+      integrity: sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
   /send/0.17.1:
     dependencies:
       debug: 2.6.9
@@ -18260,6 +18862,7 @@ packages:
       diff: 4.0.2
       nise: 4.0.4
       supports-color: 7.1.0
+    dev: true
     resolution:
       integrity: sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
   /sisteransi/1.0.5:
@@ -18891,6 +19494,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+  /strip-json-comments/3.1.1:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
   /strip-outer/1.0.1:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -18969,6 +19578,7 @@ packages:
   /supports-color/7.1.0:
     dependencies:
       has-flag: 4.0.0
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -19018,8 +19628,8 @@ packages:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
   /table/5.4.6:
     dependencies:
-      ajv: 6.12.2
-      lodash: 4.17.15
+      ajv: 6.12.6
+      lodash: 4.17.20
       slice-ansi: 2.1.0
       string-width: 3.1.0
     dev: true
@@ -19460,6 +20070,15 @@ packages:
         optional: true
     resolution:
       integrity: sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
+  /tsconfig-paths/3.9.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.1
+      minimist: 1.2.5
+      strip-bom: 3.0.0
+    dev: true
+    resolution:
+      integrity: sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
   /tsconfig/6.0.0:
     dependencies:
       strip-bom: 3.0.0
@@ -19476,7 +20095,7 @@ packages:
       integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
   /tsutils/3.17.1:
     dependencies:
-      tslib: 1.11.1
+      tslib: 1.13.0
     dev: true
     engines:
       node: '>= 6'
@@ -19486,8 +20105,19 @@ packages:
       integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tsutils/3.17.1_typescript@3.8.3:
     dependencies:
-      tslib: 1.11.1
+      tslib: 1.13.0
       typescript: 3.8.3
+    dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  /tsutils/3.17.1_typescript@3.9.7:
+    dependencies:
+      tslib: 1.13.0
+      typescript: 3.9.7
     dev: true
     engines:
       node: '>= 6'
@@ -19515,7 +20145,16 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  /type-check/0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+    dev: true
+    engines:
+      node: '>= 0.8.0'
+    resolution:
+      integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   /type-detect/4.0.8:
+    dev: true
     engines:
       node: '>=4'
     resolution:
@@ -19585,6 +20224,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+  /typescript/3.9.7:
+    dev: true
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
   /un-eval/1.2.0:
     dev: true
     resolution:
@@ -19992,6 +20638,22 @@ packages:
     dev: true
     resolution:
       integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+  /vue-eslint-parser/7.1.1_eslint@6.8.0:
+    dependencies:
+      debug: 4.1.1
+      eslint: 6.8.0
+      eslint-scope: 5.1.1
+      eslint-visitor-keys: 1.3.0
+      espree: 6.2.1
+      esquery: 1.3.1
+      lodash: 4.17.20
+    dev: true
+    engines:
+      node: '>=8.10'
+    peerDependencies:
+      eslint: '>=5.0.0'
+    resolution:
+      integrity: sha512-8FdXi0gieEwh1IprIBafpiJWcApwrU+l2FEj8c1HtHFdNXMd0+2jUSjBVmcQYohf/E72irwAXEXLga6TQcB3FA==
   /w3c-hr-time/1.0.2:
     dependencies:
       browser-process-hrtime: 1.0.0


### PR DESCRIPTION
Issue #, if available: GALI-436

Description of changes:

Added a workflow which does the following:
1. Provision EC2 instance, VPC, Subnet, Volume and Elastic IP using CloudFormation
2. Activate Storage Gateway
3. Add Volume to Storage Gateway
4. Persist the results to DynamoDB

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
