### PR TITLE
fix: domain name clashing issue

### DIFF
--- a/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
+++ b/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
@@ -30,6 +30,7 @@ const settingKeys = {
   fedIdpMetadatas: 'fedIdpMetadatas',
   defaultAuthNProviderTitle: 'defaultAuthNProviderTitle',
   cognitoAuthNProviderTitle: 'cognitoAuthNProviderTitle',
+  cognitoUserPoolDomainPrefix: 'cognitoUserPoolDomainPrefix',
 };
 
 class AddAuthProviders extends Service {
@@ -81,6 +82,7 @@ class AddAuthProviders extends Service {
     // Get settings
     const envName = this.settings.get(settingKeys.envName);
     const solutionName = this.settings.get(settingKeys.solutionName);
+    const cognitoUserPoolDomainPrefix = this.settings.get(settingKeys.cognitoUserPoolDomainPrefix);
 
     const enableNativeUserPoolUsers = this.settings.getBoolean(settingKeys.enableNativeUserPoolUsers);
 
@@ -110,12 +112,12 @@ class AddAuthProviders extends Service {
       }),
     );
 
-    const userPoolName = `${envName}-${solutionName}-userPool`;
+    const userPoolName = `${envName}-${solutionName}`;
     const cognitoAuthProviderConfig = {
       title: this.settings.get(settingKeys.cognitoAuthNProviderTitle),
       userPoolName,
       clientName: `${envName}-${solutionName}-client`,
-      userPoolDomain: `${envName}-${solutionName}`,
+      userPoolDomain: cognitoUserPoolDomainPrefix,
       enableNativeUserPoolUsers,
       federatedIdentityProviders,
     };
@@ -141,6 +143,12 @@ class AddAuthProviders extends Service {
     if (userPool) {
       // If pool exists, set its ID in the config so it can be updated
       cognitoAuthProviderConfig.userPoolId = userPool.Id;
+
+      // If pool exists, set userPoolDomain to existing value
+      const userPoolDetailResult = await cognitoIdentityServiceProvider
+        .describeUserPool({ UserPoolId: userPool.Id })
+        .promise();
+      cognitoAuthProviderConfig.userPoolDomain = userPoolDetailResult.UserPool.Domain;
 
       // Verify that the stored auth provider config also exists
       const awsRegion = this.settings.get(settingKeys.awsRegion);

--- a/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
+++ b/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
@@ -112,7 +112,7 @@ class AddAuthProviders extends Service {
       }),
     );
 
-    const userPoolName = `${envName}-${solutionName}`;
+    const userPoolName = `${envName}-${solutionName}-userPool`;
     const cognitoAuthProviderConfig = {
       title: this.settings.get(settingKeys.cognitoAuthNProviderTitle),
       userPoolName,

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/__tests__/provisioner-service.test.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/__tests__/provisioner-service.test.js
@@ -1,0 +1,147 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const Aws = require('@aws-ee/base-services/lib/aws/aws-service');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+const AWSMock = require('aws-sdk-mock');
+const Logger = require('@aws-ee/base-services/lib/logger/logger-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/s3-service');
+const S3ServiceMock = require('@aws-ee/base-services/lib/s3-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+jest.mock('../../../authentication-provider-config-service');
+const AuthenticationProviderConfigServiceMock = require('../../../authentication-provider-config-service');
+
+const ProvisionerService = require('../provisioner-service');
+
+describe('ProvisionerService', () => {
+  let service;
+  beforeAll(async () => {
+    // Initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('aws', new Aws());
+    container.register('log', new Logger());
+    container.register('settings', new SettingsServiceMock());
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('authenticationProviderConfigService', new AuthenticationProviderConfigServiceMock());
+    container.register('s3Service', new S3ServiceMock());
+    container.register('provisionerService', new ProvisionerService());
+
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('provisionerService');
+
+    // Mock return for settings get
+    const settings = await container.find('settings');
+    settings.get = jest.fn(input => input);
+  });
+
+  beforeEach(async () => {
+    const aws = await service.service('aws');
+    AWSMock.setSDKInstance(aws.sdk);
+  });
+
+  afterEach(() => {
+    AWSMock.restore();
+  });
+
+  describe('configureUserPoolDomain', () => {
+    const providerConfig = {
+      userPoolDomain: 'swb-dev',
+      userPoolId: 'some-user-pool-id',
+    };
+    it('should configure user pool domain with passed in domain', async () => {
+      // BUILD
+      AWSMock.mock('CognitoIdentityServiceProvider', 'createUserPoolDomain', (params, callback) => {
+        expect(params).toMatchObject({ Domain: 'swb-dev', UserPoolId: 'some-user-pool-id' });
+        callback(null, {});
+      });
+      // OPERATE
+      await service.configureUserPoolDomain(providerConfig);
+    });
+
+    it('should configure user pool domain with default value if domain is not passed in', async () => {
+      // BUILD
+      AWSMock.mock('CognitoIdentityServiceProvider', 'createUserPoolDomain', (params, callback) => {
+        expect(params).toMatchObject({ Domain: 'envName-envType-solutionName', UserPoolId: 'some-user-pool-id' });
+        callback(null, {});
+      });
+      // OPERATE
+      await service.configureUserPoolDomain({ userPoolId: 'some-user-pool-id' });
+    });
+
+    it('should stop retry when retry count is reached', async () => {
+      // BUILD
+      AWSMock.mock('CognitoIdentityServiceProvider', 'createUserPoolDomain', (params, callback) => {
+        const error = {
+          code: 'InvalidParameterException',
+          message: 'Domain already associated with another user pool',
+        };
+        callback(error, {});
+      });
+      // OPERATE
+      try {
+        await service.configureUserPoolDomain(providerConfig);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('Domain already associated with another user pool');
+      }
+    });
+
+    it('should not retry if an unrecognized error is thrown', async () => {
+      // BUILD
+      AWSMock.mock('CognitoIdentityServiceProvider', 'createUserPoolDomain', (params, callback) => {
+        const error = {
+          code: 'InvalidParameterException',
+          message: 'some other validation error',
+        };
+        callback(error, {});
+      });
+      service.retryCreateDomain = jest.fn();
+      // OPERATE
+      try {
+        await service.configureUserPoolDomain(providerConfig);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual('some other validation error');
+        expect(service.retryCreateDomain).not.toHaveBeenCalled();
+      }
+    });
+
+    it('should retry if "already associated with another user pool" error is thrown', async () => {
+      // BUILD
+      AWSMock.mock('CognitoIdentityServiceProvider', 'createUserPoolDomain', (params, callback) => {
+        const error = {
+          code: 'InvalidParameterException',
+          message: 'Domain already associated with another user pool',
+        };
+        callback(error, {});
+      });
+      service.retryCreateDomain = jest.fn();
+      // OPERATE
+      await service.configureUserPoolDomain(providerConfig);
+      // CHECK
+      expect(service.retryCreateDomain).toHaveBeenCalled();
+    });
+  });
+});

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/provisioner-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/provisioner-service.js
@@ -427,7 +427,9 @@ class ProvisionerService extends Service {
         this.log.info(`The Cognito User Pool Domain with Prefix "${userPoolDomain}" already exists. Nothing to do.`);
       } else if (
         err.code === 'InvalidParameterException' &&
-        err.message.indexOf('already associated with another user pool') >= 0
+        err.message.indexOf('already associated with another user pool') >= 0 &&
+        // Cognito user pool domain prefix hard limit is 63, we keep it at less then 62 so the retry logic has a decent chance to succeed
+        userPoolDomain.length < 62
       ) {
         await this.retryCreateDomain(cognitoIdentityServiceProvider, params, userPoolDomain, 10);
       } else {

--- a/addons/addon-base-rest-api/packages/services/package.json
+++ b/addons/addon-base-rest-api/packages/services/package.json
@@ -30,6 +30,7 @@
     "husky": "^3.1.0",
     "jest": "^24.9.0",
     "jest-junit": "^10.0.0",
+    "aws-sdk-mock": "^5.1.0",
     "prettier": "^1.19.1",
     "source-map-support": "^0.5.16"
   },

--- a/main/solution/post-deployment/config/infra/functions.yml
+++ b/main/solution/post-deployment/config/infra/functions.yml
@@ -14,6 +14,7 @@ postDeployment:
     APP_PARAM_STORE_JWT_SECRET: ${self:custom.settings.paramStoreJwtSecret}
     APP_JWT_OPTIONS: ${self:custom.settings.jwtOptions}
     APP_ENABLE_NATIVE_USER_POOL_USERS: ${self:custom.settings.enableNativeUserPoolUsers}
+    APP_COGNITO_USER_POOL_DOMAIN_PREFIX: ${self:custom.settings.cognitoUserPoolDomainPrefix}
     APP_FED_IDP_IDS: ${self:custom.settings.fedIdpIds}
     APP_FED_IDP_NAMES: ${self:custom.settings.fedIdpNames}
     APP_FED_IDP_DISPLAY_NAMES: ${self:custom.settings.fedIdpDisplayNames}

--- a/main/solution/post-deployment/config/settings/.defaults.yml
+++ b/main/solution/post-deployment/config/settings/.defaults.yml
@@ -20,6 +20,9 @@ websiteUrl: ${cf:${self:custom.settings.infrastructureStackName}.WebsiteUrl}
 # other identity providers
 enableNativeUserPoolUsers: false
 
+# Cognito domain prefix. Note random string will be padded at the end if specified domain is not available
+cognitoUserPoolDomainPrefix: ${self:custom.settings.envName}-${self:custom.settings.solutionName}
+
 # Title of the default (internal) authentication provider. This shows up in the login dropdown.
 defaultAuthNProviderTitle: 'Default Login'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,6 +637,7 @@ importers:
       uuid: 3.4.0
       validatorjs: 3.18.1
     devDependencies:
+      aws-sdk-mock: 5.1.0
       eslint: 6.8.0
       eslint-config-airbnb-base: 14.1.0_8cdb6d8c18c3319a1365bd5afa0063a3
       eslint-config-prettier: 6.10.1_eslint@6.8.0
@@ -654,6 +655,7 @@ importers:
       '@aws-ee/base-services-container': 'workspace:*'
       ajv: ^6.11.0
       aws-sdk: ^2.647.0
+      aws-sdk-mock: ^5.1.0
       eslint: ^6.8.0
       eslint-config-airbnb-base: ^14.0.0
       eslint-config-prettier: ^6.10.0
@@ -10425,6 +10427,7 @@ packages:
     resolution:
       integrity: sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==
   /fsevents/2.1.2:
+    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -16756,7 +16759,6 @@ packages:
       prop-types: 15.7.2
       react: 16.13.1
       scheduler: 0.19.1
-    dev: false
     peerDependencies:
       react: ^16.13.1
     resolution:
@@ -17091,7 +17093,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-    dev: false
     engines:
       node: '>=0.10.0'
     resolution:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Add new settings key cognitoUserPoolDomainPrefix with default value envName-solutionName
* Allow customized cognitoUserPoolDomainPrefix
* Pad random string if domain is not available 
* Retry another random string if padded domain is not available, till an availability is found
* Unit test - WIP 

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
