### PR TITLE
fix: Query string parameters were getting duplicated in the url

### DIFF
--- a/addons/addon-base-ui/packages/base-ui/src/helpers/api.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/api.js
@@ -89,6 +89,16 @@ function fetchJson(url, options = {}, retryCount = 0) {
       key => `${encodeURIComponent(key)}=${encodeURIComponent(_.get(merged.params, key))}`,
     ).join('&');
     url = query ? `${url}?${query}` : url;
+
+    // Delete merged.params after they are added to the url as query string params
+    // This is required otherwise, if the call fails for some reason (e.g., time out) the same query string params
+    // will be added once again to the URL causing duplicate params being passed in.
+    // For example, if the merge.params = { param1: 'value1', param2: 'value2' }
+    // The url will become something like `https://some-host/some-path?param1=value1&param2=value2`
+    // If we do not delete "merged.params" here and if the call is retried (with a recursive call to "fetchJson") due
+    // to timeout or any other issue, the url will then become
+    // `https://some-host/some-path?param1=value1&param2=value2?param1=value1&param2=value2`
+    delete merged.params;
   }
 
   return Promise.resolve()


### PR DESCRIPTION
Query string parameters were getting duplicated in the url upon retries. This was causing intermittent failures on the Workspace Types page.

Issue #, if available:

Description of changes:
- Delete merged.params after they are added to the url to stop them from getting duplicated upon recursive retry calls
- This fixes an issue where the `Workspace Types` screen intermittently shows `Invalid version specified for filter. Valid values for version are *,latest` error under `AWS Service Catalog Products` section. That error happens when the initial call times out (because fetching Service Catalog Products is relatively slow operation) and the call is retried. 
![image](https://user-images.githubusercontent.com/1855846/96649235-bace2f80-12fe-11eb-956d-661a31472df7.png)


Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
