### PR TITLE
feat: add git preinstallation on Rstudio workspaces

### DIFF
--- a/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -9,6 +9,7 @@ sudo yum install -y "/tmp/rstudio/${rstudio_rpm}"
 sudo systemctl enable rstudio-server
 sudo systemctl restart rstudio-server
 
+sudo yum install -y git
 
 # Create a user for RStudio to use; its password is set at boot time
 sudo useradd -m rstudio-user


### PR DESCRIPTION
**Description of changes:**

RStudio users have no right to install new packages through the terminal.

I added git among the pre-installations of RStudio workspaces so one can bring his/her analysis from a git repository to the workspace. 

Researchers need to pull the code of there analysis in there RStudio workspaces because on many cases they do not start implementation from scratch in Service Workbench.


**Checklist:**

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
