### PR TITLE
docs:  add specific info to enable cost breakdowns

### DIFF
--- a/docs/docs/deployment/pre_deployment/prerequisites.md
+++ b/docs/docs/deployment/pre_deployment/prerequisites.md
@@ -17,4 +17,4 @@ During the installation, we will require access to the billing account (Created 
 ## Cost Explorer
 
 In order to see any actual cost in dashboards and workspaces, the master account must have Cost Explorer set up. 
-
+Service Workbench has the ability to provide detailed cost breakdowns based on cost allocation tags. In order to benefit from this feature, you should activate the following list of cost allocation tags in the [Billing](https://console.aws.amazon.com/billing/home?#/tags) service of the AWS accounts that will host workspaces : `CreatedBy`, `Env`, `Proj`.


### PR DESCRIPTION
**Issue** : Cost breakdowns were always empty in a version of SWB deployed in a test account.

**Description of changes:**
Cost allocation tags need to be activated in order to get actual cost reports.
We figured that this information was not included in the documentation yet. 
Feel free to correct it if you think of more exact formulations.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._