### PR TITLE
Study Admin permission handling

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -90,11 +90,8 @@ describe('EnvironmentMountService', () => {
     it('should call add when only adds are requested', async () => {
       // BUILD
       const updateRequest = {
-        usersToAdd: [
-          { uid: 'User1-UID', permissionLevel: 'readwrite' },
-          { uid: 'User1-UID', permissionLevel: 'admin' },
-        ],
-        usersToRemove: [{ uid: 'User2-UID', permissionLevel: 'readonly' }],
+        usersToAdd: [{ uid: 'User1-UID', permissionLevel: 'readonly' }],
+        usersToRemove: [{ uid: 'User2-UID', permissionLevel: 'admin' }],
       };
       const studyId = 'StudyA';
       service.addPermissions = jest.fn();

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -90,8 +90,11 @@ describe('EnvironmentMountService', () => {
     it('should call add when only adds are requested', async () => {
       // BUILD
       const updateRequest = {
-        usersToAdd: [{ uid: 'User1-UID', permissionLevel: 'readonly' }],
-        usersToRemove: [{ uid: 'User2-UID', permissionLevel: 'admin' }],
+        usersToAdd: [
+          { uid: 'User1-UID', permissionLevel: 'readwrite' },
+          { uid: 'User1-UID', permissionLevel: 'admin' },
+        ],
+        usersToRemove: [{ uid: 'User2-UID', permissionLevel: 'readonly' }],
       };
       const studyId = 'StudyA';
       service.addPermissions = jest.fn();

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -102,7 +102,11 @@ describe('EnvironmentMountService', () => {
       await service.applyWorkspacePermissions(studyId, updateRequest);
 
       // CHECK
-      expect(service.addPermissions).toHaveBeenCalledWith([{ uid: 'User1-UID', permissionLevel: 'readonly' }], studyId);
+      expect(service.addPermissions).toHaveBeenCalledWith(
+        [{ uid: 'User1-UID', permissionLevel: 'readonly' }],
+        studyId,
+        updateRequest,
+      );
       expect(service.removePermissions).not.toHaveBeenCalled();
       expect(service.updatePermissions).not.toHaveBeenCalled();
     });
@@ -126,6 +130,7 @@ describe('EnvironmentMountService', () => {
       expect(service.removePermissions).toHaveBeenCalledWith(
         [{ uid: 'User2-UID', permissionLevel: 'readwrite' }],
         studyId,
+        updateRequest,
       );
       expect(service.updatePermissions).not.toHaveBeenCalled();
     });
@@ -729,6 +734,482 @@ describe('EnvironmentMountService', () => {
           Effect: 'Allow',
           Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
           Resource: ['StudyBucketPath_XYZ', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
+
+  it('should ensure study admins have at least R/O access after R/O permission removal', async () => {
+    // BUILD
+    const updateRequest = {
+      usersToRemove: [{ uid: 'User1-UID', permissionLevel: 'readonly' }],
+      usersToAdd: [{ uid: 'User1-UID', permissionLevel: 'admin' }],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
+
+  it('should ensure study admins have at least R/O access after R/W permission removal', async () => {
+    // BUILD
+    const updateRequest = {
+      usersToRemove: [{ uid: 'User1-UID', permissionLevel: 'readwrite' }],
+      usersToAdd: [{ uid: 'User1-UID', permissionLevel: 'admin' }],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadWriteAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadWriteAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Resource: ['AnotherStudyBucketPath'],
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: [`${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
+
+  it('should ensure study admins have only one access level after R/W permission addition', async () => {
+    // BUILD
+
+    const updateRequest = {
+      usersToAdd: [
+        { uid: 'User1-UID', permissionLevel: 'admin' },
+        { uid: 'User1-UID', permissionLevel: 'readwrite' },
+      ],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath'],
+        },
+        {
+          Sid: 'S3StudyReadWriteAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Resource: [`${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
+
+  it('should ensure duplicate resources are not created for admins after R/O permission addition', async () => {
+    // BUILD
+    const updateRequest = {
+      usersToAdd: [
+        { uid: 'User1-UID', permissionLevel: 'admin' },
+        { uid: 'User1-UID', permissionLevel: 'readonly' },
+      ],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
+
+  it('should ensure permission updates for admins are as expected', async () => {
+    // BUILD
+    const updateRequest = {
+      usersToAdd: [
+        { uid: 'User1-UID', permissionLevel: 'admin' },
+        { uid: 'User1-UID', permissionLevel: 'readonly' },
+      ],
+      usersToRemove: [{ uid: 'User1-UID', permissionLevel: 'readwrite' }],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadWriteAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Resource: [`${studyBucket}/${studyPrefix}`],
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath'],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
         },
       ],
     };

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -328,7 +328,6 @@ class EnvironmentMountService extends Service {
               policyDoc.Statement = this._getStatementsAfterAddition(policyDoc, studyPathArn, statementSidToUse);
               policyDoc.Statement = this._ensureListAccess(policyDoc, studyPathArn);
               if (isStudyAdmin && user.permissionLevel === readWritePermissionLevel) {
-                policyDoc.Statement = this._ensureListAccess(policyDoc, studyPathArn);
                 policyDoc.Statement = this._getStatementsAfterRemoval(policyDoc, studyPathArn, readOnlyStatementId);
               }
               await iamService.putRolePolicy(roleName, studyDataPolicyName, JSON.stringify(policyDoc), iamClient);


### PR DESCRIPTION
Issue #, if available:
GALI-455 (Partial)

Description of changes:
These changes ensure that users who are admins of a particular study possess at least R/O access once they provision a workspace with that study mounted on it.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
