### PR TITLE
fix: UI fixes and permissions for bucket policy

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -1274,4 +1274,106 @@ describe('EnvironmentMountService', () => {
     );
     expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
   });
+
+  it('should ensure permission updates when admins are removed are as expected', async () => {
+    // BUILD
+    const updateRequest = {
+      usersToAdd: [{ uid: 'User1-UID', permissionLevel: 'readwrite' }],
+      usersToRemove: [{ uid: 'User1-UID', permissionLevel: 'admin' }],
+    };
+    const studyId = 'StudyA';
+    const envsForUser = [{ studyIds: ['StudyA'] }];
+    environmentScService.getActiveEnvsForUser = jest.fn().mockResolvedValue(envsForUser);
+    iamService.putRolePolicy = jest.fn();
+    const studyBucket = 'arn:aws:s3:::xxxxxxxx-namespace-studydata';
+    const studyPrefix = 'studies/Organization/SampleStudy/*';
+    const inputPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    const IamUpdateParams = {
+      iamClient: 'sampleIamClient',
+      studyPathArn: `${studyBucket}/${studyPrefix}`,
+      policyDoc: inputPolicy,
+      roleName: 'sampleRoleName',
+      studyDataPolicyName: 'sampleStudyDataPolicy',
+    };
+    const expectedPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'studyKMSAccess',
+          Action: ['Permission1', 'Permission2'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:kms:region:xxxxxxxx:key/someRandomString',
+        },
+        {
+          Sid: 'studyListS3AccessN',
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+          Resource: studyBucket,
+          Condition: {
+            StringLike: {
+              's3:prefix': ['AnotherStudyPrefixForThisBucket', studyPrefix],
+            },
+          },
+        },
+        {
+          Sid: 'S3StudyReadAccess',
+          Effect: 'Allow',
+          Action: ['s3:GetObject'],
+          Resource: ['AnotherStudyBucketPath'],
+        },
+        {
+          Sid: 'S3StudyReadWriteAccess',
+          Effect: 'Allow',
+          Action: [
+            's3:GetObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+            's3:PutObject',
+            's3:PutObjectAcl',
+          ],
+          Resource: [`${studyBucket}/${studyPrefix}`],
+        },
+      ],
+    };
+    service._getIamUpdateParams = jest.fn().mockResolvedValue(IamUpdateParams);
+
+    // OPERATE
+    await service.applyWorkspacePermissions(studyId, updateRequest);
+
+    // CHECK
+    expect(iamService.putRolePolicy).toHaveBeenCalledWith(
+      IamUpdateParams.roleName,
+      IamUpdateParams.studyDataPolicyName,
+      JSON.stringify(IamUpdateParams.policyDoc),
+      IamUpdateParams.iamClient,
+    );
+    expect(IamUpdateParams.policyDoc).toMatchObject(expectedPolicy);
+  });
 });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -634,7 +634,13 @@ describe('EnvironmentMountService', () => {
           {
             Sid: 'S3StudyReadWriteAccess',
             Effect: 'Allow',
-            Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+            Action: [
+              's3:GetObject',
+              's3:AbortMultipartUpload',
+              's3:ListMultipartUploadParts',
+              's3:PutObject',
+              's3:PutObjectAcl',
+            ],
             Resource: [`${studyBucket}/${studyPrefix}`],
           },
         ],
@@ -695,7 +701,13 @@ describe('EnvironmentMountService', () => {
           {
             Sid: 'S3StudyReadWriteAccess',
             Effect: 'Allow',
-            Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+            Action: [
+              's3:GetObject',
+              's3:AbortMultipartUpload',
+              's3:ListMultipartUploadParts',
+              's3:PutObject',
+              's3:PutObjectAcl',
+            ],
             Resource: ['StudyBucketPath_XYZ'],
           },
         ],
@@ -736,7 +748,13 @@ describe('EnvironmentMountService', () => {
           {
             Sid: 'S3StudyReadWriteAccess',
             Effect: 'Allow',
-            Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+            Action: [
+              's3:GetObject',
+              's3:AbortMultipartUpload',
+              's3:ListMultipartUploadParts',
+              's3:PutObject',
+              's3:PutObjectAcl',
+            ],
             Resource: ['StudyBucketPath_XYZ', `${studyBucket}/${studyPrefix}`],
           },
         ],
@@ -882,7 +900,13 @@ describe('EnvironmentMountService', () => {
         {
           Sid: 'S3StudyReadWriteAccess',
           Effect: 'Allow',
-          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Action: [
+            's3:GetObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+            's3:PutObject',
+            's3:PutObjectAcl',
+          ],
           Resource: ['AnotherStudyBucketPath', `${studyBucket}/${studyPrefix}`],
         },
       ],
@@ -917,7 +941,13 @@ describe('EnvironmentMountService', () => {
         {
           Sid: 'S3StudyReadWriteAccess',
           Effect: 'Allow',
-          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Action: [
+            's3:GetObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+            's3:PutObject',
+            's3:PutObjectAcl',
+          ],
           Resource: ['AnotherStudyBucketPath'],
         },
         {
@@ -1022,7 +1052,13 @@ describe('EnvironmentMountService', () => {
         {
           Sid: 'S3StudyReadWriteAccess',
           Effect: 'Allow',
-          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Action: [
+            's3:GetObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+            's3:PutObject',
+            's3:PutObjectAcl',
+          ],
           Resource: [`${studyBucket}/${studyPrefix}`],
         },
       ],
@@ -1172,7 +1208,13 @@ describe('EnvironmentMountService', () => {
         {
           Sid: 'S3StudyReadWriteAccess',
           Effect: 'Allow',
-          Action: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+          Action: [
+            's3:GetObject',
+            's3:AbortMultipartUpload',
+            's3:ListMultipartUploadParts',
+            's3:PutObject',
+            's3:PutObjectAcl',
+          ],
           Resource: [`${studyBucket}/${studyPrefix}`],
         },
         {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -264,11 +264,14 @@ class StudyService extends Service {
 
             // Filter by category and inject requestor's access level
             const studyAccessMap = {};
-            ['admin', 'readwrite', 'readonly'].forEach(level =>
-              permissions[`${level}Access`].forEach(studyId => {
-                studyAccessMap[studyId] = level;
-              }),
-            );
+            ['admin', 'readwrite', 'readonly'].forEach(level => {
+              const studiesWithPermission = permissions[`${level}Access`];
+              if (studiesWithPermission && studiesWithPermission.length > 0)
+                studiesWithPermission.forEach(studyId => {
+                  studyAccessMap[studyId] = level;
+                });
+            });
+
             result = rawResult
               .filter(study => study.category === category)
               .map(study => ({


### PR DESCRIPTION
Issue #, if available:
GALI-455 (partial)

Description of changes:
Adding fixes affecting the UI for handling R/W permission level access.
Adding required permissions for multipart upload and putObjectAcl for study bucket policy.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
