### PR TITLE
fix: handling policy names for windows envs

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -673,7 +673,7 @@ class EnvironmentMountService extends Service {
    * with a matching name from the "possibleInlinePolicyNames".
    * If no inline policy is found with any of the names from the "possibleInlinePolicyNames", the method returns undefined.
    *
-   * @param {Object} possibleInlinePolicyNames - Known possible policy role names we have used for out of the box CfN templates
+   * @param {Object} possibleInlinePolicyNames - Known policy names we have used in out-of-the-box SC product templates
    * * @param {Object} roleName - Name of the IAM role for the given workspace
    * * @param {Object} iamClient
    * @returns {Object} - Returns policyDocStr and studyDataPolicyName that was found on this role

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -676,7 +676,7 @@ class EnvironmentMountService extends Service {
    * @param {Object} possibleInlinePolicyNames - Known policy names we have used in out-of-the-box SC product templates
    * * @param {Object} roleName - Name of the IAM role for the given workspace
    * * @param {Object} iamClient
-   * @returns {Object} - Returns policyDocStr and studyDataPolicyName that was found on this role
+   * @returns {Object} - Returns policy object
    */
   async _getPolicy(possibleInlinePolicyNames, roleName, iamClient) {
     const iamService = await this.service('iamService');

--- a/addons/addon-base/packages/services/lib/iam/iam-service.js
+++ b/addons/addon-base/packages/services/lib/iam/iam-service.js
@@ -138,7 +138,7 @@ class IamService extends Service {
       .promise()
       .catch(emptyObjectIfDoesNotExist);
 
-    const policy = {};
+    const policy = { PolicyName: policyName };
     if (policyDocument) {
       // The "PolicyDocument" is URL encoded JSON string
       const policyDocumentSrc = decodeURIComponent(policyDocument);


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Added logic to handle EC2 Windows permission propagation scenarios, with known S3 permission policy names.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
