### PR TITLE
fix: Manage S3 bucket policy for Study Access

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
@@ -45,6 +45,7 @@ const JwtService = require('@aws-ee/base-api-services/lib/jwt-service');
 const EnvironmentScService = require('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-service');
 const EnvironmentConfigVarsService = require('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-config-vars-service');
 const EnvironmentScKeypairService = require('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-keypair-service');
+const EnvResourceUsageTrackerService = require('@aws-ee/base-raas-services/lib/environment/env-resource-usage-tracker-service');
 
 const settingKeys = {
   tablePrefix: 'dbPrefix',
@@ -88,6 +89,7 @@ async function registerServices(container, pluginRegistry) {
   container.register('computePlatformService', new ComputePlatformService());
   container.register('computePriceService', new ComputePriceService());
   container.register('environmentScService', new EnvironmentScService());
+  container.register('envResourceUsageTrackerService', new EnvResourceUsageTrackerService());
   container.register('environmentConfigVarsService', new EnvironmentConfigVarsService());
   container.register('environmentScKeypairService', new EnvironmentScKeypairService());
   container.register('pluginRegistryService', new PluginRegistryService(pluginRegistry), { lazy: false });
@@ -120,6 +122,7 @@ function getStaticSettings(existingStaticSettings, settings, pluginRegistry) {
   table('dbStudies', 'Studies');
   table('dbEnvironments', 'Environments');
   table('dbEnvironmentsSc', 'EnvironmentsSc');
+  table('dbEnvironmentResourceUsages', 'EnvironmentResourceUsages');
   table('dbUserRoles', 'UserRoles');
   table('dbAwsAccounts', 'AwsAccounts');
   table('dbIndexes', 'Indexes');

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -12,7 +12,6 @@
  *  express or implied. See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-/* eslint-disable max-classes-per-file */
 const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
 
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-mount-service.test.js
@@ -42,6 +42,9 @@ const StudyPermissionServiceMock = require('../../study/study-permission-service
 jest.mock('../service-catalog/environment-sc-service');
 const EnvironmentScServiceMock = require('../service-catalog/environment-sc-service');
 
+jest.mock('../env-resource-usage-tracker-service');
+const EnvResourceUsageTrackerServiceMock = require('../env-resource-usage-tracker-service');
+
 const EnvironmentMountService = require('../environment-mount-service');
 
 describe('EnvironmentMountService', () => {
@@ -53,6 +56,7 @@ describe('EnvironmentMountService', () => {
     // Initialize services container and register dependencies
     const container = new ServicesContainer();
     container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('envResourceUsageTrackerService', new EnvResourceUsageTrackerServiceMock());
     container.register('environmentScService', new EnvironmentScServiceMock());
     container.register('environmentMountService', new EnvironmentMountService());
     container.register('studyService', new StudyServiceMock());

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/built-in/environment-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/built-in/environment-service.js
@@ -434,6 +434,8 @@ class EnvironmentService extends Service {
         const environmentMountService = await this.service('environmentMountService');
 
         await environmentMountService.addRoleArnToLocalResourcePolicies(
+          requestContext,
+          environment.id,
           environment.instanceInfo.WorkspaceInstanceRoleArn,
           existingEnvironment.instanceInfo.s3Prefixes,
         );
@@ -500,6 +502,8 @@ class EnvironmentService extends Service {
         const environmentMountService = await this.service('environmentMountService');
 
         await environmentMountService.removeRoleArnFromLocalResourcePolicies(
+          requestContext,
+          id,
           existingEnvironment.instanceInfo.WorkspaceInstanceRoleArn,
           existingEnvironment.instanceInfo.s3Prefixes,
         );

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/env-resource-usage-tracker-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/env-resource-usage-tracker-service.js
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const Service = require('@aws-ee/base-services-container/lib/service');
+
+const getResourceCountKey = principal => `resourceCount|${principal}`;
+
+const settingKeys = {
+  tableName: 'dbEnvironmentResourceUsages',
+};
+
+/**
+ * A service to track usage of a specific resource by the specific environment.
+ *
+ * The service is only used for tracking AWS resources that need cross account provisioning
+ * (such as S3 bucket policy update or KMS resource policy updates etc).
+ * The service is not used for tracking all AWS resource usages by environments (workspaces)
+ */
+class EnvResourceUsageTrackerService extends Service {
+  constructor() {
+    super();
+    this.dependency(['dbService', 'auditWriterService']);
+  }
+
+  async init() {
+    await super.init();
+    const [dbService] = await this.service(['dbService']);
+    const table = this.settings.get(settingKeys.tableName);
+
+    this._updater = () => dbService.helper.updater().table(table);
+  }
+
+  async addEnvironmentResourceUse(requestContext, { resource, principal, envId }) {
+    const updater = this._updater();
+    const result = await updater
+      .key({ id: resource, type: getResourceCountKey(principal) })
+      .add('envIds :envId')
+      .values({ ':envId': updater.client.createSet([envId], { validate: true }) })
+      .update();
+
+    // Write audit event
+    await this.audit(requestContext, { action: 'increment-resource-count', body: { resource, principal, envId } });
+
+    return { ...result, count: 'envIds' in result ? result.envIds.length : 0 };
+  }
+
+  async deleteEnvironmentResourceUse(requestContext, { resource, principal, envId }) {
+    const updater = this._updater();
+    const result = await updater
+      .key({ id: resource, type: getResourceCountKey(principal) })
+      .delete('envIds :envId')
+      .values({ ':envId': updater.client.createSet([envId], { validate: true }) })
+      .update();
+
+    // Write audit event
+    await this.audit(requestContext, { action: 'decrement-resource-count', body: { resource, principal, envId } });
+
+    if (result) {
+      return { ...result, count: 'envIds' in result ? result.envIds.length : 0 };
+    }
+
+    // If result is undefined then we can't determine the usage count. Return -1 in that case.
+    // This is for backwards compatibility. This can happen when an existing env is being terminated that was created
+    // before this EnvResourceUsageTrackerService existed.
+    return { count: -1 };
+  }
+
+  async audit(requestContext, auditEvent) {
+    const auditWriterService = await this.service('auditWriterService');
+    // Calling "writeAndForget" instead of "write" to allow main call to continue without waiting for audit logging
+    // and not fail main call if audit writing fails for some reason
+    // If the main call also needs to fail in case writing to any audit destination fails then switch to "write" method as follows
+    // return auditWriterService.write(requestContext, auditEvent);
+    return auditWriterService.writeAndForget(requestContext, auditEvent);
+  }
+}
+
+module.exports = EnvResourceUsageTrackerService;

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/env-resource-usage-tracker-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/env-resource-usage-tracker-service.js
@@ -36,7 +36,7 @@ class EnvResourceUsageTrackerService extends Service {
 
   async init() {
     await super.init();
-    const [dbService] = await this.service(['dbService']);
+    const dbService = await this.service('dbService');
     const table = this.settings.get(settingKeys.tableName);
 
     this._updater = () => dbService.helper.updater().table(table);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -229,17 +229,17 @@ class EnvironmentMountService extends Service {
           listStatement.Principal.AWS = updateAwsPrincipals(
             listStatement.Principal.AWS,
             workspaceRoleArn,
-            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+            `${s3BucketName}/${prefix}`,
           );
           getStatement.Principal.AWS = updateAwsPrincipals(
             getStatement.Principal.AWS,
             workspaceRoleArn,
-            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+            `${s3BucketName}/${prefix}`,
           );
           putStatement.Principal.AWS = updateAwsPrincipals(
             putStatement.Principal.AWS,
             workspaceRoleArn,
-            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+            `${s3BucketName}/${prefix}`,
           );
 
           s3Policy.Statement = s3Policy.Statement.filter(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -703,11 +703,14 @@ class EnvironmentMountService extends Service {
   }
 
   async _getWorkspacePolicy(iamClient, env) {
-    if (!env.outputs) {
-      throw new Error('Environment outputs are not ready yet. Please make sure environment is in Completed status');
+    const workspaceRoleObject = _.find(env.outputs, { OutputKey: 'WorkspaceInstanceRoleArn' });
+    if (!workspaceRoleObject) {
+      throw new Error(
+        'Workspace IAM Role is not ready yet. Please make sure environment is in Completed status and retry the operation',
+      );
     }
     const iamService = await this.service('iamService');
-    const workspaceRoleArn = _.find(env.outputs, { OutputKey: 'WorkspaceInstanceRoleArn' }).OutputValue;
+    const workspaceRoleArn = workspaceRoleObject.OutputValue;
     const roleName = workspaceRoleArn.split('role/')[1];
     const studyDataPolicyName = `analysis-${workspaceRoleArn.split('-')[1]}-s3-studydata-policy`;
     const { PolicyDocument: policyDocStr } = await iamService.getRolePolicy(roleName, studyDataPolicyName, iamClient);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -106,7 +106,7 @@ class EnvironmentMountService extends Service {
     };
 
     return this._updateResourcePolicies({
-      updateAwsPrincipals: maybeUpdateAwsPrincipals,
+      updateAwsPrincipals: await maybeUpdateAwsPrincipals,
       workspaceRoleArn,
       s3Prefixes,
     });
@@ -138,7 +138,7 @@ class EnvironmentMountService extends Service {
     };
 
     return this._updateResourcePolicies({
-      updateAwsPrincipals: maybeUpdateAwsPrincipals,
+      updateAwsPrincipals: await maybeUpdateAwsPrincipals,
       workspaceRoleArn,
       s3Prefixes,
     });
@@ -281,7 +281,11 @@ class EnvironmentMountService extends Service {
 
         // Update policy
         // NOTE: The S3 API *should* remove duplicate principals, if any
-        environmentStatement.Principal.AWS = updateAwsPrincipals(environmentStatement.Principal.AWS, workspaceRoleArn);
+        environmentStatement.Principal.AWS = updateAwsPrincipals(
+          environmentStatement.Principal.AWS,
+          workspaceRoleArn,
+          `kmsKeyAliasId/${keyId}`,
+        );
 
         kmsPolicy.Statement = kmsPolicy.Statement.filter(statement => statement.Sid !== sid);
         if (environmentStatement.Principal.AWS.length > 0) {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -317,6 +317,7 @@ class EnvironmentMountService extends Service {
     if (total > limit) {
       this.boom.internalError(
         `This requires system to update ${total} workspace permissions at a time. Please reduce this to within ${limit} workspaces owned by selected users`,
+        true,
       );
     }
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -226,9 +226,21 @@ class EnvironmentMountService extends Service {
 
           // Update statement and policy
           // NOTE: The S3 API *should* remove duplicate principals, if any
-          listStatement.Principal.AWS = updateAwsPrincipals(listStatement.Principal.AWS, workspaceRoleArn);
-          getStatement.Principal.AWS = updateAwsPrincipals(getStatement.Principal.AWS, workspaceRoleArn);
-          putStatement.Principal.AWS = updateAwsPrincipals(putStatement.Principal.AWS, workspaceRoleArn);
+          listStatement.Principal.AWS = updateAwsPrincipals(
+            listStatement.Principal.AWS,
+            workspaceRoleArn,
+            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+          );
+          getStatement.Principal.AWS = updateAwsPrincipals(
+            getStatement.Principal.AWS,
+            workspaceRoleArn,
+            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+          );
+          putStatement.Principal.AWS = updateAwsPrincipals(
+            putStatement.Principal.AWS,
+            workspaceRoleArn,
+            `arn:aws:s3:::${s3BucketName}/${prefix}`,
+          );
 
           s3Policy.Statement = s3Policy.Statement.filter(
             statement => ![listSid, getSid, putSid].includes(statement.Sid),

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/environment-mount-service.js
@@ -106,7 +106,7 @@ class EnvironmentMountService extends Service {
     };
 
     return this._updateResourcePolicies({
-      updateAwsPrincipals: await maybeUpdateAwsPrincipals,
+      updateAwsPrincipals: maybeUpdateAwsPrincipals,
       workspaceRoleArn,
       s3Prefixes,
     });
@@ -138,7 +138,7 @@ class EnvironmentMountService extends Service {
     };
 
     return this._updateResourcePolicies({
-      updateAwsPrincipals: await maybeUpdateAwsPrincipals,
+      updateAwsPrincipals: maybeUpdateAwsPrincipals,
       workspaceRoleArn,
       s3Prefixes,
     });
@@ -281,10 +281,11 @@ class EnvironmentMountService extends Service {
 
         // Update policy
         // NOTE: The S3 API *should* remove duplicate principals, if any
+        const studyDataKmsAliasArn = this.settings.get(settingKeys.studyDataKmsKeyArn);
         environmentStatement.Principal.AWS = updateAwsPrincipals(
           environmentStatement.Principal.AWS,
           workspaceRoleArn,
-          `kmsKeyAliasId/${keyId}`,
+          studyDataKmsAliasArn,
         );
 
         kmsPolicy.Statement = kmsPolicy.Statement.filter(statement => statement.Sid !== sid);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
@@ -205,7 +205,12 @@ class EnvironmentConfigVarsService extends Service {
     // case we have to trust that the member account hasn't altered the role's assume role policy to allow other
     // principals assume it
     if (s3Prefixes.length > 0) {
-      await environmentMountService.addRoleArnToLocalResourcePolicies(`arn:aws:iam::${accountId}:root`, s3Prefixes);
+      await environmentMountService.addRoleArnToLocalResourcePolicies(
+        requestContext,
+        environment.id,
+        `arn:aws:iam::${accountId}:root`,
+        s3Prefixes,
+      );
     }
 
     // Check if the environment being launched needs an admin key-pair to be created in the target account

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -221,10 +221,12 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
   await rstudioCleanup(requestContext, updatedEnvironment, container);
 
   const indexesService = await container.find('indexesService');
+  const awsAccountsService = await container.find('awsAccountsService');
   const { awsAccountId } = await indexesService.mustFind(requestContext, { id: updatedEnvironment.indexId });
+  const { accountId } = await awsAccountsService.mustFind(requestContext, { id: awsAccountId });
   const environmentMountService = await container.find('environmentMountService');
 
-  const { s3Prefixes, databases } = await environmentMountService.getStudyAccessInfo(
+  const { s3Prefixes } = await environmentMountService.getStudyAccessInfo(
     requestContext,
     updatedEnvironment.studyIds,
     updatedEnvironment.createdAt,
@@ -234,9 +236,8 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
     await environmentMountService.removeRoleArnFromLocalResourcePolicies(
       requestContext,
       updatedEnvironment.id,
-      `arn:aws:iam::${awsAccountId}:root`,
+      `arn:aws:iam::${accountId}:root`,
       s3Prefixes,
-      databases,
     );
   }
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -232,6 +232,8 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
 
   if (s3Prefixes.length > 0) {
     await environmentMountService.removeRoleArnFromLocalResourcePolicies(
+      requestContext,
+      updatedEnvironment.id,
       `arn:aws:iam::${awsAccountId}:root`,
       s3Prefixes,
       databases,

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/delete-environment/delete-environment.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/delete-environment/delete-environment.js
@@ -62,6 +62,8 @@ class DeleteEnvironment extends StepBase {
     // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
     // under IAM Roles
     await environmentMountService.removeRoleArnFromLocalResourcePolicies(
+      requestContext,
+      environmentId,
       environment.instanceInfo.WorkspaceInstanceRoleArn,
       environment.instanceInfo.s3Prefixes,
     );

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -1252,20 +1252,20 @@ Resources:
       BillingMode: PAY_PER_REQUEST
 
   EnvironmentResourceUsagesDb:
-  Type: AWS::DynamoDB::Table
-  Properties:
-    TableName: ${self:custom.settings.dbEnvironmentResourceUsages}
-    AttributeDefinitions:
-      - AttributeName: 'id'
-        AttributeType: 'S'
-      - AttributeName: 'type'
-        AttributeType: 'S'
-    KeySchema:
-      - AttributeName: 'id'
-        KeyType: 'HASH'
-      - AttributeName: 'type'
-        KeyType: 'RANGE'
-    BillingMode: PAY_PER_REQUEST
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: ${self:custom.settings.dbEnvironmentResourceUsages}
+      AttributeDefinitions:
+        - AttributeName: 'id'
+          AttributeType: 'S'
+        - AttributeName: 'type'
+          AttributeType: 'S'
+      KeySchema:
+        - AttributeName: 'id'
+          KeyType: 'HASH'
+        - AttributeName: 'type'
+          KeyType: 'RANGE'
+      BillingMode: PAY_PER_REQUEST
 
   EnvironmentsTypesDb:
     Type: AWS::DynamoDB::Table

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -1251,6 +1251,22 @@ Resources:
             ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
 
+  EnvironmentResourceUsagesDb:
+  Type: AWS::DynamoDB::Table
+  Properties:
+    TableName: ${self:custom.settings.dbEnvironmentResourceUsages}
+    AttributeDefinitions:
+      - AttributeName: 'id'
+        AttributeType: 'S'
+      - AttributeName: 'type'
+        AttributeType: 'S'
+    KeySchema:
+      - AttributeName: 'id'
+        KeyType: 'HASH'
+      - AttributeName: 'type'
+        KeyType: 'RANGE'
+    BillingMode: PAY_PER_REQUEST
+
   EnvironmentsTypesDb:
     Type: AWS::DynamoDB::Table
     DependsOn: UserRolesDb

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -558,6 +558,7 @@ Resources:
                 - !GetAtt [EnvironmentsScDb, Arn]
                 - !Join ['', [!GetAtt [EnvironmentsScDb, Arn], '/index/*']]
                 - !GetAtt [EnvironmentsTypesDb, Arn]
+                - !GetAtt [EnvironmentResourceUsagesDb, Arn]
                 - !GetAtt [StudiesDb, Arn]
                 - !GetAtt [ProjectsDb, Arn]
                 - !GetAtt [StudyPermissionsDb, Arn]

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -144,6 +144,12 @@ dbEnvironments: ${self:custom.settings.dbPrefix}-Environments
 # DynamoDB table name for Environments created using AWS Service Catalog
 dbEnvironmentsSc: ${self:custom.settings.dbPrefix}-EnvironmentsSc
 
+# DynamoDB table name for tracking AWS resources used by the environment
+# The table is only used for tracking AWS resources that need cross account provisioning
+# (such as S3 bucket policy update or KMS resource policy updates etc).
+# The table is not used for tracking all AWS resource usages by environments (workspaces)
+dbEnvironmentResourceUsages: ${self:custom.settings.dbPrefix}-EnvironmentResourceUsages
+
 # DynamoDB table name for Environment Types
 dbEnvironmentTypes: ${self:custom.settings.dbPrefix}-EnvironmentTypes
 

--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -94,6 +94,7 @@ Resources:
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbAwsAccounts}'
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbCostApiCaches}'
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbEnvironmentsSc}'
+                - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbEnvironmentResourceUsages}'
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbIndexes}'
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbEnvironmentTypes}'
                 - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:custom.settings.dbEnvironments}'

--- a/main/solution/post-deployment/config/settings/.defaults.yml
+++ b/main/solution/post-deployment/config/settings/.defaults.yml
@@ -158,6 +158,12 @@ dbEnvironments: ${self:custom.settings.dbPrefix}-Environments
 # DynamoDB table name for Environments created using AWS Service Catalog
 dbEnvironmentsSc: ${self:custom.settings.dbPrefix}-EnvironmentsSc
 
+# DynamoDB table name for tracking AWS resources used by the environment
+# The table is only used for tracking AWS resources that need cross account provisioning
+# (such as S3 bucket policy update or KMS resource policy updates etc).
+# The table is not used for tracking all AWS resource usages by environments (workspaces)
+dbEnvironmentResourceUsages: ${self:custom.settings.dbPrefix}-EnvironmentResourceUsages
+
 # DynamoDB table name for Environment Types
 dbEnvironmentTypes: ${self:custom.settings.dbPrefix}-EnvironmentTypes
 


### PR DESCRIPTION
Issue #, if available:
GALI-461

Description of changes:
_Bug synopsis:_
If you launch one workspace in project 1 with study 1
then you launch another workspace in same project (project 1) with same study (study 1)
then terminate one of the workspaces
the other workspace will also loose its access to the study

This PR prevents the above by managing the studies being used by various workspaces within each member account in a new DB table "EnvironmentResourceUsages". When the first workspace of a member account is mounted with a particular study, it creates a row for that study-account combination, and adds the permission to access the study in the S3 bucket policy. When the last workspace to use a given study within a member account is terminated, the permission is removed from the S3 bucket policy.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
