### PR TITLE
fix: removing region from mount_s3 script

### DIFF
--- a/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
+++ b/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
@@ -41,7 +41,6 @@ do
     study_id="$(printf "%s" "$mounts" | jq -r ".[$study_idx].id" -)"
     s3_bucket="$(printf "%s" "$mounts" | jq -r ".[$study_idx].bucket" -)"
     s3_prefix="$(printf "%s" "$mounts" | jq -r ".[$study_idx].prefix" -)"
-    region="$(curl http://169.254.169.254/latest/meta-data/placement/region)"
 
     # Mount S3 location if not already mounted
     study_dir="${MOUNT_DIR}/${study_id}"
@@ -50,7 +49,7 @@ do
     then
         printf 'Mounting study "%s" at "%s"\n' "$study_id" "$study_dir"
         mkdir -p "$study_dir"
-        goofys --region "${region}" --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
+        goofys --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
     fi
 done
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Removing dependency on region while mounting S3 studies on workspaces. This allows studies in a different region to be mounted on workspaces.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
