### PR TITLE
fix: changed RStudio CSP headers to allow uploads from same-origin

### DIFF
--- a/main/solution/machine-images/config/infra/files/rstudio/nginx.conf
+++ b/main/solution/machine-images/config/infra/files/rstudio/nginx.conf
@@ -51,11 +51,11 @@ http {
     ssl_trusted_certificate cert.pem;
 
     add_header Referrer-Policy same-origin always;
-    add_header X-Frame-Options DENY always;
+    add_header X-Frame-Options SAMEORIGIN always;
     add_header X-Content-Type-Options nosniff always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self';" always;
 
     proxy_http_version 1.1;
     proxy_read_timeout 20d;


### PR DESCRIPTION
**Object of this PR**
This PR aims to fix an error in the default RStudio workspaces. This error prevents users to upload data from their computer to the RStudio server.

**Description of the error :**
When a user clicks on the "upload" button available on the RStudio interface, the following error is raised.  
The "upload" pop-up frizzes the whole page, and no upload is performed.  
It concerns too-restrictive CSP headers that prevent uploads from any domain name.  
![image](https://user-images.githubusercontent.com/33128425/100239596-e06bdb80-2f31-11eb-8a00-8297a9b24dd1.png)

**Description of changes:**
I modified the CSP headers and the X-Frame-Options headers of the nginx server to allow uploads from the same own domain name (via the HTTPS RStudio interface).
I tried those changes. It erases the error, and allows to upload data as expected without errors.

**Checklist:** 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
