### PR TITLE
feat: Change mount scripts for EC2 linux and windows to make mounting work for BYOB

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -264,6 +264,30 @@ Resources:
 
           diskpart /s diskpart.txt
 
+          # script to create credentials file with all the roleArns for each study
+          $createCredentialsFile = @'
+          $credentialsFolder = -join ($env:USERPROFILE, "\.aws")
+          md -Force $credentialsFolder
+          $credentialsFileName = "credentials"
+          $credentialsFile = -join ($credentialsFolder, "\", $credentialsFileName)
+          if (!(Test-Path $credentialsFile)) {
+              New-Item -itemType File -Path $credentialsFolder -Name $credentialsFileName
+          }
+          $studyJson = convertfrom-json '${S3Mounts}'
+          $studyJson | ForEach {
+              $studyId = $_.id
+              $roleArn = $_.roleArn
+              # if roleArn is present and the study isn't added yet to the credentials file, then add it
+              If ( ( $roleArn.length -GT 0 ) -AND  -NOT ( Select-String -Path $credentialsFile -Pattern "\[$studyId\]" -Quiet ) ) {
+                  Add-Content $credentialsFile "[$studyId]"
+                  Add-Content $credentialsFile "role_arn = $roleArn"
+                  Add-Content $credentialsFile "credential_source = Ec2InstanceMetadata"
+              }
+          }
+          '@
+          Set-Content -Path c:\workdir\create-credentials-file.ps1 -Value $createCredentialsFile
+          ."C:\workdir\create-credentials-file.ps1"
+
           # Create script to download the s3 synchronizer
           $downloadS3Synchronizer = @'
           # Download s3-synchronizer Windows executable
@@ -278,6 +302,8 @@ Resources:
 
           # Create script to start the s3 synchronizer process
           $startS3SyncScriptContent = @'
+          # enable AWS_SDK_LOAD_CONFIG to 1. This will allow S3 session to use .aws/profile and .aws/credentials file
+          $env:AWS_SDK_LOAD_CONFIG = 1
           $defaultS3Mounts = '${S3Mounts}' | ConvertTo-Json
 
           $arguments = "-defaultS3Mounts=$defaultS3Mounts -destination=d:\ -region=${AWS::Region} -recurringDownloads=${RecurringDownloads} -downloadInterval=${DownloadInterval} -stopRecurringDownloadsAfter=${StopRecurringDownloadsAfter}"

--- a/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-default-mounts.go
+++ b/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-default-mounts.go
@@ -18,9 +18,13 @@ func getDefaultMounts(defaultS3Mounts string) (*[]s3Mount, error) {
 		if mount.Writeable == nil {
 			mounts[i].Writeable = Bool(false)
 		}
-		if mount.KmsKeyId == nil {
+		if mount.KmsArn == nil {
 			emptyString := ""
-			mounts[i].KmsKeyId = &emptyString
+			mounts[i].KmsArn = &emptyString
+		}
+		if mount.RoleArn == nil {
+		    emptyString := ""
+		    mounts[i].RoleArn = &emptyString
 		}
 	}
 	return &mounts, err

--- a/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-download.go
+++ b/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-download.go
@@ -43,15 +43,17 @@ type mountConfiguration struct {
 	destination string
 	writeable   bool
 	kmsKeyId    string
+	roleArn     string
 }
 
-func newMountConfiguration(bucket string, prefix string, destination string, writeable bool, kmsKeyId string) *mountConfiguration {
+func newMountConfiguration(bucket string, prefix string, destination string, writeable bool, kmsKeyId string, roleArn string) *mountConfiguration {
 	config := mountConfiguration{
 		bucket:      bucket,
 		prefix:      prefix,
 		destination: destination,
 		writeable:   writeable,
 		kmsKeyId:    kmsKeyId,
+		roleArn:     roleArn,
 	}
 	return &config
 }

--- a/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-mounts.go
+++ b/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-mounts.go
@@ -11,7 +11,8 @@ type s3Mount struct {
 	Bucket    *string `json:"bucket,omitempty"`
 	Prefix    *string `json:"prefix,omitempty"`
 	Writeable *bool   `json:"writeable,omitempty"`
-	KmsKeyId  *string `json:"kmsKeyId,omitempty"`
+	KmsArn    *string `json:"kmsArn,omitempty"`
+	RoleArn   *string `json:"roleArn,omitempty"`
 }
 
 func mountToString(mount *s3Mount) string {

--- a/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-synchronizer_test.go
+++ b/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-synchronizer_test.go
@@ -65,7 +65,7 @@ func TestMainImplForInitialDownloadSingleMount(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase)
+	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err != nil {
 		// Fail test in case of any errors
 		t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -109,7 +109,7 @@ func TestMainImplForInitialDownloadMultipleMounts(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase)
+	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err != nil {
 		// Fail test in case of any errors
 		t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -141,7 +141,7 @@ func TestMainImplForInitialDownloadEmptyMounts(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase)
+	err = mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err != nil {
 		// Fail test in case of any errors
 		t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -158,7 +158,7 @@ func TestMainImplForInitialDownloadInvalidMounts(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err := mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase)
+	err := mainImpl(testAwsSession, debug, false, -1, 60, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err == nil {
 		// Fail test in case of no errors since we are expecting errors when passing invalid json for mounting
 		t.Logf("Expecting error when running the main s3-synchronizer with invalid testMountsJson but it ran fine")
@@ -200,7 +200,7 @@ func TestMainImplForSyncSingleMount(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		// ---- Run code under test ----
-		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, -1, concurrency, testMountsJson, destinationBase)
+		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, -1, concurrency, testMountsJson, destinationBase, testRegion)
 		if err != nil {
 			// Fail test in case of any errors
 			t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -307,7 +307,7 @@ func TestMainImplForSyncMultipleMounts(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		// ---- Run code under test ----
-		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, -1, concurrency, testMountsJson, destinationBase)
+		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, -1, concurrency, testMountsJson, destinationBase, testRegion)
 		if err != nil {
 			// Fail test in case of any errors
 			t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -401,7 +401,7 @@ func TestMainImplForRecurringDownloadEmptyMounts(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err = mainImpl(testAwsSession, debug, true, 5, 1, -1, concurrency, testMountsJson, destinationBase)
+	err = mainImpl(testAwsSession, debug, true, 5, 1, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err != nil {
 		// Fail test in case of any errors
 		t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -418,7 +418,7 @@ func TestMainImplForRecurringDownloadInvalidMounts(t *testing.T) {
 	fmt.Printf("Input: \n\n%s\n\n", testMountsJson)
 
 	// ---- Run code under test ----
-	err := mainImpl(testAwsSession, debug, true, 5, 1, -1, concurrency, testMountsJson, destinationBase)
+	err := mainImpl(testAwsSession, debug, true, 5, 1, -1, concurrency, testMountsJson, destinationBase, testRegion)
 	if err == nil {
 		// Fail test in case of no errors since we are expecting errors when passing invalid json for mounting
 		t.Logf("Expecting error when running the main s3-synchronizer with invalid testMountsJson but it ran fine")
@@ -469,7 +469,7 @@ func TestMainImplForBiDirectionalSyncSingleMount(t *testing.T) {
 	go func() {
 
 		// ---- Run code under test ----
-		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, stopUploadWatchersAfter, concurrency, testMountsJson, destinationBase)
+		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, stopUploadWatchersAfter, concurrency, testMountsJson, destinationBase, testRegion)
 		if err != nil {
 			// Fail test in case of any errors
 			t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -702,7 +702,7 @@ func TestMainImplForBiDirectionalSyncMultipleMounts(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		// ---- Run code under test ----
-		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, stopUploadWatchersAfter, concurrency, testMountsJson, destinationBase)
+		err = mainImpl(testAwsSession, debug, recurringDownloads, stopRecurringDownloadsAfter, downloadInterval, stopUploadWatchersAfter, concurrency, testMountsJson, destinationBase, testRegion)
 		if err != nil {
 			// Fail test in case of any errors
 			t.Logf("Error running the main s3-synchronizer with testMountsJson %s", testMountsJson)
@@ -950,7 +950,7 @@ func putTestMountFiles(t *testing.T, bucketName string, testMountId string, noOf
 		}
 	}
 	kmsKeyId := ""
-	return &s3Mount{Id: &testMountId, Bucket: &bucketName, Prefix: &mountPrefix, Writeable: &writeable, KmsKeyId: &kmsKeyId}
+	return &s3Mount{Id: &testMountId, Bucket: &bucketName, Prefix: &mountPrefix, Writeable: &writeable, KmsArn: &kmsKeyId}
 }
 
 func createTestFilesLocally(t *testing.T, testMountId string, noOfFiles int) {

--- a/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
+++ b/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
@@ -12,6 +12,7 @@
 # }, ...]
 CONFIG="/usr/local/etc/s3-mounts.json"
 MOUNT_DIR="${HOME}/studies"
+AWS_CONFIG_DIR="${HOME}/.aws"
 
 # Exit if CONFIG doesn't exist or is 0 bytes
 [ ! -s "$CONFIG" ] && exit 0
@@ -32,6 +33,21 @@ env_type() {
     fi
 }
 
+# Add roleArn for a study to credentials file if not present already
+append_role_to_credentials() {
+    study_id=$1
+    role_arn=$2
+    credentials_file=$AWS_CONFIG_DIR/credentials
+    if ! grep -q "\[$study_id\]" $AWS_CONFIG_DIR/credentials
+    then
+      # append role for this study since it doesn't already exist in the file
+      echo "[$study_id]" >> $credentials_file
+      echo "role_arn = $role_arn" >> $credentials_file
+      echo "credential_source = Ec2InstanceMetadata" >> $credentials_file
+      echo "" >> $credentials_file
+    fi
+}
+
 # Mount S3 buckets
 mounts="$(cat "$CONFIG")"
 num_mounts=$(printf "%s" "$mounts" | jq ". | length" -)
@@ -41,15 +57,28 @@ do
     study_id="$(printf "%s" "$mounts" | jq -r ".[$study_idx].id" -)"
     s3_bucket="$(printf "%s" "$mounts" | jq -r ".[$study_idx].bucket" -)"
     s3_prefix="$(printf "%s" "$mounts" | jq -r ".[$study_idx].prefix" -)"
+    s3_role_arn="$(printf "%s" "$mounts" | jq -r ".[$study_idx].roleArn" -)"
+    kms_arn = "$(printf "%s" "$mounts" | jq -r ".[$study_idx].kmsArn" -)"
 
     # Mount S3 location if not already mounted
     study_dir="${MOUNT_DIR}/${study_id}"
     ps -U "$LOGNAME" -o "command" | egrep -q "goofys .* ${study_dir}$"
     if [ $? -ne 0 ]
     then
-        printf 'Mounting study "%s" at "%s"\n' "$study_id" "$study_dir"
         mkdir -p "$study_dir"
-        goofys --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
+        if [ "$s3_role_arn" == "null" ]
+        then
+            printf 'Mounting internal study "%s" at "%s"\n' "$study_id" "$study_dir"
+            goofys --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
+        else
+            # make .aws dir if it doesn't already exist and add credentials
+            mkdir -p $AWS_CONFIG_DIR
+            append_role_to_credentials $study_id $s3_role_arn
+            printf 'Mounting external study "%s" at "%s" using role "%s" and kms arn "%s" \n' "$study_id" "$study_dir" \
+            "$s3_role_arn" "$kms_arn"
+            goofys --profile $study_id --sse-kms $kms_arn --acl "bucket-owner-full-control" \
+            "${s3_bucket}:${s3_prefix}" "$study_dir"
+        fi
     fi
 done
 


### PR DESCRIPTION
Issue #, if available: GALI-605

Description of changes:

* For EC2 linux the script which mounts using Goofys has been changed to write a credentials file and Goofys mount command has been reflected to use it correctly
* For EC2 windows the powershell script has been modified to write a credentials file as a bootstrap step. 
* I have tested the changes in my member account for both EC2 Windows and Linux by mounting two external studies using assume role approach
* Unfortunately, there isn't any unit testing for the scripts since they are in bash/powershell. This is something that needs to be tackled as part of integ tests or when we can move the scripts to JS.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
