### PR TITLE
feat: bring your own bucket - role allocation implementation

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/plugins/services-plugin.js
@@ -49,6 +49,7 @@ const DataSourceRegistrationService = require('@aws-ee/base-raas-services/lib/da
 const DataSourceAccountService = require('@aws-ee/base-raas-services/lib/data-source/data-source-account-service');
 const DataSourceBucketService = require('@aws-ee/base-raas-services/lib/data-source/data-source-bucket-service');
 const ApplicationRoleService = require('@aws-ee/base-raas-services/lib/data-source/access-strategy/roles-only/application-role-service');
+const FilesystemRoleService = require('@aws-ee/base-raas-services/lib/data-source/access-strategy/roles-only/filesystem-role-service');
 const LegacyEnvironmentResourceService = require('@aws-ee/base-raas-services/lib/data-source/access-strategy/legacy/environment-resource-service');
 const ResourceUsageService = require('@aws-ee/base-raas-services/lib/usage/resource-usage-service');
 
@@ -102,6 +103,7 @@ async function registerServices(container, pluginRegistry) {
   container.register('dataSourceAccountService', new DataSourceAccountService());
   container.register('dataSourceBucketService', new DataSourceBucketService());
   container.register('roles-only/applicationRoleService', new ApplicationRoleService());
+  container.register('roles-only/filesystemRoleService', new FilesystemRoleService());
   container.register('legacy/environmentResourceService', new LegacyEnvironmentResourceService());
   container.register('resourceUsageService', new ResourceUsageService());
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
@@ -32,7 +32,7 @@ const AuditService = require('@aws-ee/base-services/lib/audit/audit-writer-servi
 const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
 const ApplicationRoleService = require('../application-role-service');
 const ResourceUsageService = require('../../../../usage/resource-usage-service');
-const FileSystemRoleService = require('../filesystem-role-service');
+const FilesystemRoleService = require('../filesystem-role-service');
 
 const createStudy = ({
   id = 'study-1',
@@ -119,10 +119,10 @@ describe('DataSourceBucketService', () => {
     container.register('auditWriterService', new AuditService());
     container.register('roles-only/applicationRoleService', new ApplicationRoleService());
     container.register('resourceUsageService', new ResourceUsageService());
-    container.register('roles-only/fileSystemRoleService', new FileSystemRoleService());
+    container.register('roles-only/filesystemRoleService', new FilesystemRoleService());
     await container.initServices();
 
-    service = await container.find('roles-only/fileSystemRoleService');
+    service = await container.find('roles-only/filesystemRoleService');
     appRoleService = await container.find('roles-only/applicationRoleService');
     usageService = await container.find('resourceUsageService');
   });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
@@ -1,0 +1,366 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+
+// Mocked services
+jest.mock('@aws-ee/base-services/lib/db-service');
+jest.mock('@aws-ee/base-services/lib/logger/logger-service');
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+jest.mock('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
+jest.mock('../application-role-service');
+
+const Aws = require('@aws-ee/base-services/lib/aws/aws-service');
+const Logger = require('@aws-ee/base-services/lib/logger/logger-service');
+const DbService = require('@aws-ee/base-services/lib/db-service');
+const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+const SettingsService = require('@aws-ee/base-services/lib/settings/env-settings-service');
+const AuthService = require('@aws-ee/base-services/lib/authorization/authorization-service');
+const AuditService = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+const JsonSchemaValidationService = require('@aws-ee/base-services/lib/json-schema-validation-service');
+const ApplicationRoleService = require('../application-role-service');
+const ResourceUsageService = require('../../../../usage/resource-usage-service');
+const FileSystemRoleService = require('../filesystem-role-service');
+
+const createStudy = ({
+  id = 'study-1',
+  category = 'Organization',
+  accountId = '1122334455',
+  awsPartition = 'aws',
+  bucketAccess = 'roles',
+  bucket = 'bucket-1',
+  qualifier = 'swb-IhsKhN8GsLneiis11ujlb8',
+  appRoleArn = 'arn:aws:iam::684277579687:role/swb-IhsKhN8GsLneiis11ujlb8-app-1607537845811',
+  accessType = 'readwrite',
+  envPermission = { read: true, write: true },
+  folder = '/',
+  kmsScope = 'none',
+} = {}) => ({
+  id,
+  category,
+  accountId,
+  awsPartition,
+  bucketAccess,
+  bucket,
+  qualifier,
+  appRoleArn,
+  accessType,
+  envPermission,
+  folder,
+  kmsScope,
+});
+
+const createAppRole = ({
+  arn = 'arn:aws:iam::684277579687:role/swb-IhsKhN8GsLneiis11ujlb8-app-1607537845811',
+  accountId = '1122334455',
+  mainRegion = 'us-east-1',
+  awsPartition = 'aws',
+  bucket = 'bucket-1',
+  bucketRegion = 'us-east-1',
+  status = 'pending',
+  name = 'swb-IhsKhN8GsLneiis11ujlb8-app-1607537845811',
+  qualifier = 'swb-IhsKhN8GsLneiis11ujlb8',
+  boundaryPolicyArn = 'arn:aws:iam::684277579687:policy/swb-IhsKhN8GsLneiis11ujlb8-app-1607537845811',
+  studies = {
+    'study-1': {
+      accessType: 'readonly',
+      kmsScope: 'none',
+      folder: '/',
+    },
+  },
+} = {}) => ({
+  accountId,
+  arn,
+  name,
+  mainRegion,
+  awsPartition,
+  bucket,
+  bucketRegion,
+  status,
+  qualifier,
+  boundaryPolicyArn,
+  studies,
+});
+
+const createAdminContext = ({ uid = 'uid-admin' } = {}) => ({
+  principalIdentifier: { uid },
+  principal: { isAdmin: true, userRole: 'admin', status: 'active' },
+});
+
+describe('DataSourceBucketService', () => {
+  let container;
+  let service;
+  let appRoleService;
+  let usageService;
+
+  beforeEach(async () => {
+    // Initialize services container and register dependencies
+    container = new ServicesContainer();
+
+    container.register('dbService', new DbService());
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('settings', new SettingsService());
+    container.register('aws', new Aws());
+    container.register('log', new Logger());
+    container.register('pluginRegistryService', new PluginRegistryService());
+    container.register('authorizationService', new AuthService());
+    container.register('auditWriterService', new AuditService());
+    container.register('roles-only/applicationRoleService', new ApplicationRoleService());
+    container.register('resourceUsageService', new ResourceUsageService());
+    container.register('roles-only/fileSystemRoleService', new FileSystemRoleService());
+    await container.initServices();
+
+    service = await container.find('roles-only/fileSystemRoleService');
+    appRoleService = await container.find('roles-only/applicationRoleService');
+    usageService = await container.find('resourceUsageService');
+  });
+
+  describe('when allocating a role', () => {
+    it('skip if study bucket access is not roles', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const study = { bucketAccess: 'something else' };
+      const env = {};
+      const accountId = '1234456789012';
+
+      usageService.getResourceUsage = jest.fn(() => {
+        throw new Error('I got here');
+      });
+      await expect(service.allocateRole(requestContext, study, env, accountId)).resolves.toBeUndefined();
+    });
+
+    it('only admins are allowed', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const study = { bucketAccess: 'roles' };
+      const env = {};
+      const accountId = '1234456789012';
+
+      await expect(service.allocateRole(requestContext, study, env, accountId)).rejects.toThrow(
+        expect.objectContaining({ boom: true, code: 'forbidden', safe: true }),
+      );
+    });
+
+    it('create a new role if one is not found', async () => {
+      const requestContext = createAdminContext();
+      const study = createStudy();
+      const appRole = createAppRole();
+      const env = {};
+      const memberAcct = '1234456789012';
+      let fsRoleEntity = {};
+
+      appRoleService.mustFind = jest.fn((_rq, { arn }) => {
+        if (arn === appRole.arn) return Promise.resolve(appRole);
+        return Promise.resolve();
+      });
+
+      usageService.getResourceUsage = jest.fn((_rq, { setName }) => {
+        return Promise.resolve({ [setName]: [] });
+      });
+
+      service.provisionRole = jest.fn();
+      service.saveEntity = jest.fn((_rq, entity) => {
+        fsRoleEntity = entity;
+        return Promise.resolve(entity);
+      });
+      usageService.addUsage = jest.fn();
+
+      await expect(service.allocateRole(requestContext, study, env, memberAcct)).resolves.toStrictEqual(
+        expect.objectContaining({
+          studies: {
+            'study-1': {
+              accessType: 'readwrite',
+              envPermission: { read: true, write: true },
+              folder: '/',
+              kmsArn: undefined,
+              kmsScope: 'none',
+            },
+          },
+          trust: [memberAcct],
+        }),
+      );
+      expect(service.provisionRole).toHaveBeenCalledWith(expect.objectContaining(fsRoleEntity));
+    });
+
+    it('return a role if there was a match', async () => {
+      const requestContext = createAdminContext();
+      const study = createStudy();
+      const appRole = createAppRole();
+      const env = {};
+      const memberAcct = '1234456789012';
+      const fsRoleEntity = {
+        arn: 'fs-role-arn',
+        studies: {
+          'study-1': {
+            accessType: 'readwrite',
+            envPermission: { read: true, write: true },
+            folder: '/',
+            kmsArn: undefined,
+            kmsScope: 'none',
+          },
+        },
+        trust: [memberAcct],
+      };
+
+      appRoleService.mustFind = jest.fn((_rq, { arn }) => {
+        if (arn === appRole.arn) return Promise.resolve(appRole);
+        return Promise.resolve();
+      });
+
+      usageService.getResourceUsage = jest.fn((_rq, { setName }) => {
+        return Promise.resolve({ [setName]: [fsRoleEntity.arn] });
+      });
+      usageService.addUsage = jest.fn();
+
+      service.provisionRole = jest.fn();
+      service.saveEntity = jest.fn((_rq, entity) => {
+        return Promise.resolve(entity);
+      });
+      service.find = jest.fn((_rq, { arn }) => {
+        if (arn === fsRoleEntity.arn) return Promise.resolve(fsRoleEntity);
+        return Promise.resolve();
+      });
+
+      await expect(service.allocateRole(requestContext, study, env, memberAcct)).resolves.toStrictEqual(
+        expect.objectContaining(fsRoleEntity),
+      );
+      expect(service.provisionRole).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when de-allocating a role', () => {
+    it('skip if study bucket access is not roles', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const study = { bucketAccess: 'something else' };
+      const env = {};
+      const accountId = '1234456789012';
+
+      usageService.getResourceUsage = jest.fn(() => {
+        throw new Error('I got here');
+      });
+      await expect(service.deallocateRole(requestContext, study, env, accountId)).resolves.toBeUndefined();
+    });
+
+    it('only admins are allowed', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const study = createStudy();
+      const env = {};
+      const accountId = '1234456789012';
+
+      await expect(service.deallocateRole(requestContext, 'fs-role-arn', study, env, accountId)).rejects.toThrow(
+        expect.objectContaining({ boom: true, code: 'forbidden', safe: true }),
+      );
+    });
+
+    it('delete role if orphan', async () => {
+      const requestContext = createAdminContext();
+      const study = createStudy();
+      const env = { id: 'env-1' };
+      const memberAcct = '1234456789012';
+      const arn = 'fs-role-arn';
+      const fsRoleEntity = {
+        arn,
+        studies: {
+          'study-1': {
+            accessType: 'readwrite',
+            envPermission: { read: true, write: true },
+            folder: '/',
+            kmsArn: undefined,
+            kmsScope: 'none',
+          },
+        },
+        trust: [memberAcct],
+      };
+
+      usageService.removeUsage = jest.fn(_rq => {
+        return Promise.resolve({ items: [], removed: true });
+      });
+
+      service.provisionRole = jest.fn();
+      service.deprovisionRole = jest.fn();
+      service.saveEntity = jest.fn((_rq, entity) => {
+        return Promise.resolve(entity);
+      });
+      // eslint-disable-next-line no-shadow
+      service.find = jest.fn((_rq, { arn }) => {
+        if (arn === fsRoleEntity.arn) return Promise.resolve(fsRoleEntity);
+        return Promise.resolve();
+      });
+
+      const deleteObj = {
+        key: () => {
+          return deleteObj;
+        },
+        delete: jest.fn(),
+      };
+      service._deleter = jest.fn().mockReturnValue(deleteObj);
+
+      await expect(service.deallocateRole(requestContext, arn, study, env, memberAcct)).resolves.toBeUndefined();
+      expect(service.provisionRole).not.toHaveBeenCalled();
+      expect(service.deprovisionRole).toHaveBeenCalled();
+      expect(deleteObj.delete).toHaveBeenCalled();
+    });
+
+    it('do not delete role if being used by other accounts', async () => {
+      const requestContext = createAdminContext();
+      const study = createStudy();
+      const env = { id: 'env-1' };
+      const memberAcct = '1234456789012';
+      const arn = 'fs-role-arn';
+      const fsRoleEntity = {
+        arn,
+        studies: {
+          'study-1': {
+            accessType: 'readwrite',
+            envPermission: { read: true, write: true },
+            folder: '/',
+            kmsArn: undefined,
+            kmsScope: 'none',
+          },
+        },
+        trust: [memberAcct],
+      };
+
+      usageService.removeUsage = jest.fn(_rq => {
+        return Promise.resolve({ items: ['333333333'], removed: true });
+      });
+
+      service.provisionRole = jest.fn();
+      service.deprovisionRole = jest.fn();
+      service.saveEntity = jest.fn((_rq, entity) => {
+        return Promise.resolve(entity);
+      });
+      // eslint-disable-next-line no-shadow
+      service.find = jest.fn((_rq, { arn }) => {
+        if (arn === fsRoleEntity.arn) return Promise.resolve(fsRoleEntity);
+        return Promise.resolve();
+      });
+      const deleteObj = {
+        key: () => {
+          return deleteObj;
+        },
+        delete: jest.fn(),
+      };
+      service._deleter = jest.fn().mockReturnValue(deleteObj);
+
+      await expect(service.deallocateRole(requestContext, arn, study, env, memberAcct)).resolves.toBeUndefined();
+      expect(service.provisionRole).not.toHaveBeenCalled();
+      expect(service.deprovisionRole).not.toHaveBeenCalled();
+      expect(deleteObj.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/filesystem-role-service.test.js
@@ -135,9 +135,6 @@ describe('DataSourceBucketService', () => {
       const env = {};
       const accountId = '1234456789012';
 
-      usageService.getResourceUsage = jest.fn(() => {
-        throw new Error('I got here');
-      });
       await expect(service.allocateRole(requestContext, study, env, accountId)).resolves.toBeUndefined();
     });
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/application-role-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/application-role-service.js
@@ -18,8 +18,6 @@ const Service = require('@aws-ee/base-services-container/lib/service');
 const { runAndCatch } = require('@aws-ee/base-services/lib/helpers/utils');
 const { allowIfActive, allowIfAdmin } = require('@aws-ee/base-services/lib/authorization/authorization-utils');
 
-// const registerSchema = require('../schema/register-data-source-account');
-// const updateSchema = require('../schema/update-data-source-account');
 const { appRoleIdCompositeKey } = require('./helpers/composite-keys');
 const {
   toDbEntity,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/filesystem-role-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/filesystem-role-service.js
@@ -129,7 +129,7 @@ class FilesystemRoleService extends Service {
    * { read: true/false, write: true/false }
    * @param environmentEntity The environment entity that will use the filesystem role
    */
-  async allocateRole(requestContext, studyEntity = {}, environmentEntity = {}, memberAccountId) {
+  async allocateRole(requestContext, studyEntity = {}, environmentEntity = {}, memberAccountId = '') {
     // Allocating a filesystem role is only applicable for bucket with access = 'roles'
     if (studyEntity.bucketAccess !== 'roles') return undefined;
 
@@ -280,7 +280,7 @@ class FilesystemRoleService extends Service {
    * { read: true/false, write: true/false }
    * @param environmentEntity The environment entity that was using the filesystem role
    */
-  async deallocateRole(requestContext, fsRoleArn, studyEntity = {}, environmentEntity = {}, memberAccountId) {
+  async deallocateRole(requestContext, fsRoleArn, studyEntity = {}, environmentEntity = {}, memberAccountId = '') {
     // Allocating a filesystem role is only applicable for bucket with access = 'roles'
     if (studyEntity.bucketAccess !== 'roles') return;
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/filesystem-role-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/filesystem-role-service.js
@@ -1,0 +1,386 @@
+/* eslint-disable no-await-in-loop */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+const Service = require('@aws-ee/base-services-container/lib/service');
+const { sleep, retry } = require('@aws-ee/base-services/lib/helpers/utils');
+const { allowIfActive, allowIfAdmin } = require('@aws-ee/base-services/lib/authorization/authorization-utils');
+
+const { fsRoleIdCompositeKey } = require('./helpers/composite-keys');
+const {
+  toDbEntity,
+  toFsRoleEntity,
+  newFsRoleEntity,
+  addMemberAccount,
+  hasMemberAccount,
+  maxReached,
+  toTrustPolicyDoc,
+  toInlinePolicyDoc,
+  addStudy,
+} = require('./helpers/entities/filesystem-role-methods');
+
+const settingKeys = {
+  tableName: 'dbRoleAllocations',
+  swbMainAccount: 'mainAcct',
+};
+
+/**
+ * This service is responsible for managing the filesystem role entity.
+ */
+class FilesystemRoleService extends Service {
+  constructor() {
+    super();
+    this.dependency([
+      'aws',
+      'jsonSchemaValidationService',
+      'authorizationService',
+      'dbService',
+      'auditWriterService',
+      'roles-only/applicationRoleService',
+      'resourceUsageService',
+    ]);
+  }
+
+  async init() {
+    await super.init();
+    const [dbService] = await this.service(['dbService']);
+    const table = this.settings.get(settingKeys.tableName);
+
+    this._getter = () => dbService.helper.getter().table(table);
+    this._updater = () => dbService.helper.updater().table(table);
+    this._query = () => dbService.helper.query().table(table);
+    this._deleter = () => dbService.helper.deleter().table(table);
+    this._scanner = () => dbService.helper.scanner().table(table);
+  }
+
+  /**
+   * This method returns the filesystem role entity.
+   *
+   * @param requestContext The standard requestContext
+   * @param accountId The data source account id that the filesystem role belongs to
+   * @param bucket The name of the bucket
+   * @param arn The filesystem role arn
+   * @param fields An array of the attribute names to return, default to all the attributes of the filesystem entity
+   */
+  async find(requestContext, { accountId, bucket, arn, fields = [] }) {
+    // Perform default condition checks to make sure the user is active
+    await this.assertAuthorized(
+      requestContext,
+      { action: 'read', conditions: [allowIfActive, allowIfAdmin] },
+      { accountId, arn },
+    );
+
+    const dbEntity = await this._getter()
+      .key(fsRoleIdCompositeKey.encode({ accountId, bucket, arn }))
+      .projection(fields)
+      .get();
+
+    return toFsRoleEntity(dbEntity);
+  }
+
+  /**
+   * This method is similar to the 'find' method but it throws an exception if the filesystem role is not found.
+   *
+   * @param requestContext The standard requestContext
+   * @param accountId The data source account id that the filesystem role belongs to
+   * @param bucket The name of the bucket
+   * @param arn The filesystem role arn
+   * @param fields An array of the attribute names to return, default to all the attributes of the
+   * filesystem role entity.
+   */
+  async mustFind(requestContext, { accountId, bucket, arn, fields = [] }) {
+    const result = await this.find(requestContext, { accountId, bucket, arn, fields });
+    if (!result) throw this.boom.notFound(`Filesystem role with arn "${arn}" does not exist`, true);
+    return result;
+  }
+
+  /**
+   * Call this method to allocate a filesystem role entity for the given study. This method is smart
+   * enough to reuse an existing filesystem role entity if there is one already for the same study.
+   *
+   * Note: this method creates an IAM role resource in an AWS account, if needed.
+   *
+   * @param requestContext The standard requestContext
+   * @param studyEntity The study entity. IMPORTANT, it is expected that this study entity will have
+   * an additional property named 'envPermission', it is an object with the following shape:
+   * { read: true/false, write: true/false }
+   * @param environmentEntity The environment entity that will use the filesystem role
+   */
+  async allocateRole(requestContext, studyEntity = {}, environmentEntity = {}, memberAccountId) {
+    // Allocating a filesystem role is only applicable for bucket with access = 'roles'
+    if (studyEntity.bucketAccess !== 'roles') return undefined;
+
+    // Perform default condition checks to make sure the user is active
+    await this.assertAuthorized(
+      requestContext,
+      { action: 'allocate', conditions: [allowIfActive, allowIfAdmin] },
+      studyEntity,
+    );
+
+    const { id: envId } = environmentEntity;
+    const { accountId, id: studyId, bucket, appRoleArn } = studyEntity;
+    const studyResource = `roles-only-access-study-${studyId}`;
+    const fsUsageSetName = `fs-roles-study-${studyId}`;
+
+    // Primer
+    // We capture the relations between four items: fs role, study, member account and environment.
+    // We keep the relationship information in three database items across two tables.
+    // 1. Study to fs roles, this is a one-to-many relationship (but we need to make it many-to-many in the future
+    //    if we introduce storage gateway). This relationship is captured in the ResourceUsages table.
+    //    Database item => resource: <studyId>, setName: <studyId>, items: [<fs arn>, ...]
+    // 2. Study to member account to environment using the study. This relationship is also captured in the
+    //    ResourceUsages table.
+    //    Database item => resource: <studyId>, setName: <memberAccountId>, items: [<envId>, ...]
+    // 3. fs role to member account ids. This relationship is captured in the RoleAllocations table.
+    //    Database item => composite key: <accountId, fs role arn>, trust: [<memberAccountId>, ...]
+
+    // The logic
+    // - Get the application role entity from the study.appRoleArn
+    // - Using the resource usage service, get all existing usages of fs roles with the study, see item #1 above.
+    // - For each found fs role arn, load its fs role entity,
+    //   - Does the entity include the member account in its trust, if so, then we don't need to create an fs role
+    //   - If not, can we fit the member account in the trust policy, if so then update the actual trust document
+    //     in the data source account for the fs role, then update the database, see item #3 above.
+    // - If no fs role entity is found, or the existing on has its trust property full, we need to create a new
+    //   fs role as follows:
+    //   - Create the fs role entity and add the member account to the trust property, see item #3 above.
+    //     - At this point, we don't store the entity in the data base until after we are able to create
+    //       it in the data source account
+    //   - Assume the app role and create the fs role in the data source account
+    //   - Store the entity in the database
+    //   - Add usage of the study by this role, see item #1 above.
+
+    const [appRoleService, resourceUsageService] = await this.service([
+      'roles-only/applicationRoleService',
+      'resourceUsageService',
+    ]);
+
+    // Get app role entity
+    const appRoleEntity = await appRoleService.mustFind(requestContext, { accountId, bucket, arn: appRoleArn });
+
+    // Get all existing usages by fs roles for this study
+    const fsRoleUsages = await resourceUsageService.getResourceUsage(requestContext, {
+      resource: studyResource,
+      setName: fsUsageSetName,
+    });
+    const fsRoleEntities = _.get(fsRoleUsages, fsUsageSetName, []);
+
+    // Start a loop to see if existing fs roles for the study have the member account already
+    // or can take it without exceeding the trust doc limit?
+    let fsRoleEntity;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const fsRoleArn of fsRoleEntities) {
+      const entity = await this.find(requestContext, { accountId, bucket, arn: fsRoleArn });
+      // eslint-disable-next-line no-continue
+      if (!entity) continue;
+
+      if (hasMemberAccount(entity, memberAccountId)) {
+        // We found an existing fs role entity that already has the member account
+        fsRoleEntity = entity;
+
+        // Add environment usage
+        await resourceUsageService.addUsage(requestContext, {
+          resource: studyResource,
+          setName: memberAccountId,
+          item: envId,
+        });
+
+        break;
+      }
+
+      if (!maxReached(addMemberAccount(entity, memberAccountId))) {
+        // We found an existing fs role entity and we can fit the member account in its trust doc
+
+        // Update the fs role policy in the data source account
+        await this.updateAssumeRolePolicy(entity);
+
+        // Add environment usage
+        await resourceUsageService.addUsage(requestContext, {
+          resource: studyResource,
+          setName: memberAccountId,
+          item: envId,
+        });
+
+        // We need to save the fsRoleEntity (even though it is already in the database), because
+        // we added the member account id to the trust doc.
+        fsRoleEntity = await this.saveEntity(requestContext, entity);
+        break;
+      }
+    }
+
+    // We have one, we are done and we can return it
+    if (fsRoleEntity) return fsRoleEntity;
+
+    // Create a new fs role entity
+    fsRoleEntity = newFsRoleEntity(appRoleEntity);
+    addStudy(fsRoleEntity, studyEntity);
+    addMemberAccount(fsRoleEntity, memberAccountId);
+
+    // Create in the fs role in the data source account
+    await this.provisionRole(fsRoleEntity);
+
+    // Add environment usage
+    await resourceUsageService.addUsage(requestContext, {
+      resource: studyResource,
+      setName: memberAccountId,
+      item: envId,
+    });
+
+    // Save entity in database
+    fsRoleEntity = await this.saveEntity(requestContext, fsRoleEntity);
+
+    // Add fs role usage
+    await resourceUsageService.addUsage(requestContext, {
+      resource: studyResource,
+      setName: fsUsageSetName,
+      item: fsRoleEntity.arn,
+    });
+
+    return fsRoleEntity;
+  }
+
+  /**
+   * Returns a list of all filesystem roles for the given account.
+   *
+   * @param requestContext The standard requestContext
+   * @param accountId The data source account id that the filesystem roles belong to
+   * @param bucket To filter by the bucket name (optional)
+   * @param fields An array of the attribute names to return, default to all the attributes of
+   * the filesystem role entity.
+   */
+  async list(requestContext, accountId, { bucket, fields = [] } = {}) {
+    await this.assertAuthorized(requestContext, { action: 'list', conditions: [allowIfActive, allowIfAdmin] });
+    if (_.isEmpty(accountId))
+      throw this.boom.badRequest('Listing filesystem roles, requires an account id, and none is provided', true);
+
+    const dbEntities = await this._query()
+      .key('pk', fsRoleIdCompositeKey.pk(accountId))
+      .sortKey('sk')
+      .begins(_.isEmpty(bucket) ? fsRoleIdCompositeKey.skPrefix : `${fsRoleIdCompositeKey.skPrefix}${bucket}#`)
+      .limit(1000)
+      .projection(fields)
+      .query();
+
+    const entities = _.map(dbEntities, toFsRoleEntity);
+    return entities;
+  }
+
+  // @private
+  async saveEntity(requestContext, fsRoleEntity) {
+    const by = _.get(requestContext, 'principalIdentifier.uid');
+    const dbEntity = await this._updater()
+      .key(fsRoleIdCompositeKey.encode(fsRoleEntity))
+      .mark(['trust']) // We need to ensure that the 'trust' property is of type set (dynamodb string set)
+      .item(toDbEntity(fsRoleEntity, by))
+      .update();
+
+    return toFsRoleEntity(dbEntity);
+  }
+
+  // @private
+  async provisionRole(fsRoleEntity) {
+    const { name, boundaryPolicyArn } = fsRoleEntity;
+    const iamClient = await this.getIamClient(fsRoleEntity.appRoleArn, _.get(fsRoleEntity.studies, '[0].id', ''));
+    const trustPolicyDoc = toTrustPolicyDoc(fsRoleEntity);
+
+    let params = {
+      AssumeRolePolicyDocument: JSON.stringify(trustPolicyDoc),
+      RoleName: name,
+      Description: 'A filesystem role that allows access to studies',
+      // 12 hours see
+      // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-maxsessionduration
+      MaxSessionDuration: 43200,
+      PermissionsBoundary: boundaryPolicyArn,
+    };
+
+    // Create the fs role
+    await iamClient.createRole(params).promise();
+
+    // Next, we need to add an inline policy that will allow the role to access the appropriate study. However, due to
+    // eventual consistency constraints, we can't assume that the role is immediately available. Therefore, we attempt to
+    // create the role policy using a retry logic.
+
+    // Lets wait for 0.5 second
+    await sleep(500);
+
+    params = {
+      PolicyDocument: JSON.stringify(toInlinePolicyDoc(fsRoleEntity)),
+      PolicyName: 'StudyS3AccessPolicy',
+      RoleName: name,
+    };
+
+    const putPolicy = () => {
+      return iamClient.putRolePolicy(params).promise();
+    };
+
+    // Retry 5 times using an exponential interval
+    await retry(putPolicy, 5);
+  }
+
+  // @private
+  async updateAssumeRolePolicy(fsRoleEntity) {
+    const { name } = fsRoleEntity;
+    const iamClient = await this.getIamClient(fsRoleEntity.appRoleArn, _.get(fsRoleEntity.studies, '[0].id', ''));
+    const trustPolicyDoc = toTrustPolicyDoc(fsRoleEntity);
+
+    const params = {
+      PolicyDocument: JSON.stringify(trustPolicyDoc),
+      RoleName: name,
+    };
+
+    // Create the fs role trust document
+    await iamClient.updateAssumeRolePolicy(params).promise();
+  }
+
+  // @private
+  async getIamClient(appRoleArn, studyId) {
+    const aws = await this.service('aws');
+    try {
+      const iamClient = await aws.getClientSdkForRole({ roleArn: appRoleArn, clientName: 'IAM' });
+      return iamClient;
+    } catch (error) {
+      throw this.boom
+        .forbidden(`Could not assume an application role to create a filesystem role for the study '${studyId}'`, true)
+        .cause(error);
+    }
+  }
+
+  async assertAuthorized(requestContext, { action, conditions }, ...args) {
+    const authorizationService = await this.service('authorizationService');
+
+    // The "authorizationService.assertAuthorized" below will evaluate permissions by calling the "conditions" functions first
+    // It will then give a chance to all registered plugins (if any) to perform their authorization.
+    // The plugins can even override the authorization decision returned by the conditions
+    // See "authorizationService.authorize" method for more details
+    await authorizationService.assertAuthorized(
+      requestContext,
+      { extensionPoint: 'filesystem-role-authz', action, conditions },
+      ...args,
+    );
+  }
+
+  async audit(requestContext, auditEvent) {
+    const auditWriterService = await this.service('auditWriterService');
+    // Calling "writeAndForget" instead of "write" to allow main call to continue without waiting for audit logging
+    // and not fail main call if audit writing fails for some reason
+    // If the main call also needs to fail in case writing to any audit destination fails then switch to "write" method as follows
+    // return auditWriterService.write(requestContext, auditEvent);
+    return auditWriterService.writeAndForget(requestContext, auditEvent);
+  }
+}
+
+module.exports = FilesystemRoleService;

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/application-role-methods.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/application-role-methods.js
@@ -194,6 +194,7 @@ function toRoleCfnResource(appRoleEntity, swbMainAccountId) {
                     'iam:AttachRolePolicy',
                     'iam:PutRolePolicy',
                     'iam:DeletePolicy',
+                    'iam:DeleteRolePolicy',
                     'iam:DeleteRole',
                     'iam:GetPolicy',
                     'iam:GetRole',

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/application-role-methods.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/application-role-methods.js
@@ -169,6 +169,8 @@ function toRoleCfnResource(appRoleEntity, swbMainAccountId) {
         AssumeRolePolicyDocument: toTrustPolicyDoc(swbMainAccountId),
         Description: 'An application role that allows the SWB application to create roles to access studies',
         ManagedPolicyArns: [{ Ref: getManagedPolicyLogicalId(appRoleEntity) }],
+        // 12 hours see
+        // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-maxsessionduration
         MaxSessionDuration: 43200,
         Policies: [
           {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
@@ -38,6 +38,22 @@ function addStudy(fsRoleEntity = {}, studyEntity = {}) {
   return fsRoleEntity;
 }
 
+function hasStudy(fsRoleEntity = {}, studyEntity = {}) {
+  const foundStudy = _.find(fsRoleEntity.studies, (study, id) => {
+    const sameId = id === studyEntity.id;
+    const sameRead = study.envPermission.read === studyEntity.envPermission.read;
+    const sameWrite = study.envPermission.write === studyEntity.envPermission.write;
+
+    return sameId && sameRead && sameWrite;
+  });
+
+  return !_.isUndefined(foundStudy);
+}
+
+function removeStudy(fsRoleEntity = {}, studyEntity = {}) {
+  delete fsRoleEntity.studies[studyEntity.id];
+}
+
 function addMemberAccount(fsRoleEntity = {}, memberAccountId) {
   if (_.includes(fsRoleEntity.trust, memberAccountId)) return fsRoleEntity;
   fsRoleEntity.trust.push(memberAccountId);
@@ -46,7 +62,11 @@ function addMemberAccount(fsRoleEntity = {}, memberAccountId) {
 }
 
 function hasMemberAccount(fsRoleEntity = {}, memberAccountId) {
-  return _.includes(fsRoleEntity.trues, memberAccountId);
+  return _.includes(fsRoleEntity.trust, memberAccountId);
+}
+
+function removeMemberAccount(fsRoleEntity = {}, memberAccountId) {
+  _.remove(fsRoleEntity.trust, accountId => memberAccountId === accountId);
 }
 
 /**
@@ -169,7 +189,10 @@ module.exports = {
   toDbEntity,
   newFsRoleEntity,
   addStudy,
+  removeStudy,
+  hasStudy,
   addMemberAccount,
+  removeMemberAccount,
   hasMemberAccount,
   maxReached,
   toTrustPolicyDoc,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
@@ -1,0 +1,177 @@
+/* eslint-disable no-await-in-loop */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+/**
+ * This file contains a collection of functions that are used with the
+ * applicationRoleEntity. Think of these functions as derived attributes
+ * or functions that are part of the applicationRoleEntity.
+ */
+
+const _ = require('lodash');
+
+const { StudyPolicy } = require('../../../../../helpers/iam/study-policy');
+const { fsRoleIdCompositeKey } = require('../composite-keys');
+
+function addStudy(fsRoleEntity = {}, studyEntity = {}) {
+  const { id, folder, kmsArn, kmsScope, accessType } = studyEntity;
+  fsRoleEntity.studies[id] = {
+    folder,
+    kmsArn,
+    kmsScope,
+    accessType,
+    envPermission: studyEntity.envPermission,
+  };
+
+  return fsRoleEntity;
+}
+
+function addMemberAccount(fsRoleEntity = {}, memberAccountId) {
+  if (_.includes(fsRoleEntity.trust, memberAccountId)) return fsRoleEntity;
+  fsRoleEntity.trust.push(memberAccountId);
+
+  return fsRoleEntity;
+}
+
+function hasMemberAccount(fsRoleEntity = {}, memberAccountId) {
+  return _.includes(fsRoleEntity.trues, memberAccountId);
+}
+
+/**
+ * Returns filesystem entity given its db entity version.
+ *
+ * @param dbEntity The db entity (a.k.a db record) to use to create the filesystem entity from
+ */
+function toFsRoleEntity(dbEntity) {
+  if (!_.isObject(dbEntity)) return dbEntity;
+
+  const entity = { ...dbEntity };
+  const { accountId, arn } = fsRoleIdCompositeKey.decode(entity);
+  entity.accountId = accountId;
+  entity.arn = arn;
+  delete entity.pk;
+  delete entity.sk;
+
+  return entity;
+}
+
+function toDbEntity(fsRoleEntity, by) {
+  const dbEntity = { ...fsRoleEntity };
+  delete dbEntity.accountId;
+
+  if (_.isEmpty(by)) return dbEntity;
+
+  dbEntity.updatedBy = by;
+
+  if (_.isEmpty(dbEntity.createdBy)) {
+    dbEntity.createdBy = by;
+  }
+
+  return dbEntity;
+}
+
+function newFsRoleEntity(appRoleEntity = {}) {
+  const {
+    accountId,
+    boundaryPolicyArn,
+    arn: appRoleArn,
+    bucketKmsArn,
+    mainRegion,
+    bucketRegion,
+    bucket,
+    awsPartition,
+    qualifier,
+  } = appRoleEntity;
+  const now = Date.now();
+  const name = `${qualifier}-fs-${now}`;
+  const arn = `arn:${awsPartition}:iam::${accountId}:role/${name}`;
+
+  return {
+    accountId,
+    arn,
+    name,
+    qualifier,
+    studies: {},
+    appRoleArn,
+    boundaryPolicyArn,
+    bucket,
+    bucketKmsArn,
+    bucketRegion,
+    mainRegion,
+    awsPartition,
+    trust: [], // This is where we store the member account ids. This property should be marked as a dynamodb set
+  };
+}
+
+function toInlinePolicyDoc(fsRoleEntity = {}) {
+  const { bucket, bucketKmsArn, awsPartition } = fsRoleEntity;
+  const studyPolicy = new StudyPolicy();
+  const studies = fsRoleEntity.studies || [];
+
+  _.forEach(studies, study => {
+    const { folder, kmsArn, kmsScope } = study;
+    const item = {
+      bucket,
+      awsPartition,
+      folder,
+      permission: study.envPermission || { read: false, write: false },
+    };
+
+    if (kmsScope === 'bucket') {
+      item.kmsArn = bucketKmsArn;
+    } else if (kmsScope === 'study') {
+      item.kmsArn = kmsArn;
+    }
+
+    studyPolicy.addStudy(item);
+  });
+
+  return studyPolicy.toPolicyDoc();
+}
+
+function toTrustPolicyDoc(fsRoleEntity = {}) {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: {
+          AWS: _.slice(fsRoleEntity.trust || []),
+        },
+        Action: ['sts:AssumeRole'],
+      },
+    ],
+  };
+}
+
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+function maxReached(fsRoleEntity = {}, maxSize = 2 * 1024 - 255) {
+  // The max characters count for a trust policy is 2k, we add some buffer here (255 character).
+
+  const policyDoc = JSON.stringify(toTrustPolicyDoc(fsRoleEntity));
+  return _.size(policyDoc) >= maxSize;
+}
+
+module.exports = {
+  toFsRoleEntity,
+  toDbEntity,
+  newFsRoleEntity,
+  addStudy,
+  addMemberAccount,
+  hasMemberAccount,
+  maxReached,
+  toTrustPolicyDoc,
+  toInlinePolicyDoc,
+};

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/helpers/entities/filesystem-role-methods.js
@@ -54,7 +54,7 @@ function removeStudy(fsRoleEntity = {}, studyEntity = {}) {
   delete fsRoleEntity.studies[studyEntity.id];
 }
 
-function addMemberAccount(fsRoleEntity = {}, memberAccountId) {
+function addMemberAccount(fsRoleEntity = {}, memberAccountId = '') {
   if (_.includes(fsRoleEntity.trust, memberAccountId)) return fsRoleEntity;
   fsRoleEntity.trust.push(memberAccountId);
 
@@ -65,7 +65,7 @@ function hasMemberAccount(fsRoleEntity = {}, memberAccountId) {
   return _.includes(fsRoleEntity.trust, memberAccountId);
 }
 
-function removeMemberAccount(fsRoleEntity = {}, memberAccountId) {
+function removeMemberAccount(fsRoleEntity = {}, memberAccountId = '') {
   _.remove(fsRoleEntity.trust, accountId => memberAccountId === accountId);
 }
 


### PR DESCRIPTION
This PR wraps up the work related to the implementation of the role allocation core logic.  This PR includes the file system service implementation.  Together with the application role service (submitted in a previous PR), these two services are the core pieces for the role allocation logic.  The file system service code is heavily documented to aid with understanding this nontrivial allocation logic.  The following is a primer and a high level logic of how the file system service role works.

**Primer**

- We capture the relations between four items: fs role, study, member account and environment.
- We keep the relationship information in three database items across two tables.
    1. Study to fs roles, this is a one-to-many relationship (but we need to make it many-to-many in the future if we introduce storage gateway). This relationship is captured in the ResourceUsages table.
       `Database item => resource: <studyId>, setName: <studyId>, items: [<fs arn>, ...]`
     2. Study to member account to environment using the study. This relationship is also captured in the ResourceUsages table.
        `Database item => resource: <studyId>, setName: <memberAccountId>, items: [<envId>, ...]`
     3. fs role to member account ids. This relationship is captured in the RoleAllocations table.
         `Database item => composite key: <accountId, fs role arn>, trust: [<memberAccountId>, ...]`

**The logic**
- Get the application role entity from the study.appRoleArn
- Using the resource usage service, get all existing usages of fs roles for the study, see item _i_ above.
- For each found fs role arn, load its fs role entity,
  - Does the entity include the member account in its trust and include the study with the same envPermission,
    if so, then we don't need to create an fs role
  - If not, can we fit the member account in the trust policy, if so then update the actual trust document
    in the data source account for the fs role, then update the database, see item _iii_ above.
- If no fs role entity is found, or the existing on has its trust property full, we need to create a new
  fs role as follows:
  - Create the fs role entity and add the member account to the trust property, see item _iii_ above.
    - At this point, we don't store the entity in the data base until after we are able to create
      it in the data source account
  - Assume the app role and create the fs role in the data source account
  - Store the entity in the database
  - Add usage of the study by this role, see item _i_ above.


Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes? 
* [ ] Have you linted your code locally prior to submission?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
