### PR TITLE
feat: install R3.6 and system packages required for research

### DIFF
--- a/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
 
+# Various development packages needed to compile R
+sudo yum install -y gcc gcc-gfortran gcc-c++
+sudo yum install -y java-1.8.0-openjdk-devel
+sudo yum install -y readline-devel zlib-devel bzip2-devel xz-devel pcre-devel
+sudo yum install -y libcurl-devel libpng-devel cairo-devel pango-devel
+sudo yum install -y xorg-x11-server-devel libX11-devel libXt-devel
 
-# Install R and RStudio
-sudo amazon-linux-extras install -y R3.4
+# Install R from source (https://docs.rstudio.com/resources/install-r-source/)
+R_VERSION="3.6.3"
+mkdir -p "/tmp/R/"
+curl -s "https://cran.rstudio.com/src/base/R-3/R-${R_VERSION}.tar.gz" > "/tmp/R/R-${R_VERSION}.tar.gz"
+cd "/tmp/R/"
+tar xvf "R-${R_VERSION}.tar.gz"
+cd "R-${R_VERSION}/"
+./configure --enable-memory-profiling --enable-R-shlib --with-blas --with-lapack
+sudo make
+sudo make install
+cd "../../.."
+
+# Install RStudio
 rstudio_rpm="rstudio-server-rhel-1.3.959-x86_64.rpm"
 curl -s "https://download2.rstudio.org/server/centos6/x86_64/${rstudio_rpm}" > "/tmp/rstudio/${rstudio_rpm}"
 sudo yum install -y "/tmp/rstudio/${rstudio_rpm}"
 sudo systemctl enable rstudio-server
 sudo systemctl restart rstudio-server
 
-sudo yum install -y git
-
 # Create a user for RStudio to use; its password is set at boot time
 sudo useradd -m rstudio-user
-
 
 # Install and configure nginx
 sudo amazon-linux-extras install -y nginx1
@@ -25,7 +39,6 @@ sudo chown -R nginx:nginx "/etc/nginx"
 sudo chmod -R 600 "/etc/nginx"
 sudo systemctl enable nginx
 sudo systemctl restart nginx
-
 
 # Install script that sets the service workbench user password at boot
 sudo mv "/tmp/rstudio/secret.txt" "/root/"
@@ -47,5 +60,31 @@ echo '*/2 * * * * /usr/local/bin/check-idle 2>&1 >> /var/log/check-idle.log' >> 
 sudo crontab "/tmp/crontab"
 
 
+# Install system packages necessary for installing R packages through RStudio CRAN [devtools, tidyverse]
+sudo yum install -y git libcurl-devel openssl-devel libxml2-devel
+libgit2_rpm="libgit2-0.26.6-1.el7.x86_64.rpm"
+libgit2_devel_rpm="libgit2-devel-0.26.6-1.el7.x86_64.rpm"
+mkdir -p "/tmp/libgit2/"
+curl -s "http://mirror.centos.org/centos/7/extras/x86_64/Packages/${libgit2_rpm}" > "/tmp/libgit2/${libgit2_rpm}"
+sudo yum install -y "/tmp/libgit2/${libgit2_rpm}"
+curl -s "http://mirror.centos.org/centos/7/extras/x86_64/Packages/${libgit2_devel_rpm}" > "/tmp/libgit2/${libgit2_devel_rpm}"
+sudo yum install -y "/tmp/libgit2/${libgit2_devel_rpm}"
+
+
+# Other recommended system packages for installing R packages (https://docs.rstudio.com/rsc/post-setup-tool/)
+sudo yum groupinstall -y 'Development Tools'            # Compiling tools 
+sudo yum install -y libssh2-devel                       # Client SSH
+
+sudo yum install -y libpng-devel libjpeg-turbo-devel    # Images
+sudo yum install -y ImageMagick ImageMagick-c++-devel   # Images
+sudo yum install -y cairo-devel libGLU-devel            # Graphs
+sudo yum install freetype-devel harfbuzz-devel          # Font
+
+sudo yum install -y mariadb-devel                       # MariaDB/MySQL client & server packages
+sudo yum install -y unixODBC-devel                      # ODBC API client
+sudo yum install -y gmp-devel                           # GNU MP arbitrary precision library
+
 # Wipe out all traces of provisioning files
-rm -rf "/tmp/rstudio"
+sudo rm -rf "/tmp/rstudio"
+sudo rm -rf "/tmp/libgit2"
+sudo rm -rf "/tmp/R"


### PR DESCRIPTION
**Motivation**
We're currently trying to reproduce a biomedical analyses using RStudio workspaces.
We faced the following blockers when trying to install R libraries :
- the workspace misses system packages required by R to install packages (like 'devtools' or 'tidyverse')
- multiple broadly used R libraries require R>=3.5, whereas only R3.4 was installed through amazon-linux-extras repositories.
For security considerations, users do not have root access to the workspaces, so system packages have to be preinstalled in the AMI of the workspace.

**Description of changes:**
The changes here consist of modifying the provisioning script used to build RStudio AMIs : `main\solution\machine-images\config\infra\provisioners\provision-rstudio.sh`.
The following modifications make them meet the requirements of most analysis using R : 
- Install R3.6.3 from source (version can be changed easily by changing a variable in the script)
- Install system packages necessary to install 'tidyverse' and 'devtools' which are commonly used (deduced from debugging)
- Install additional system packages recommended by [Rstudio](https://docs.rstudio.com/rsc/post-setup-tool)

**Checklist:** 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
