### PR TITLE
Fixed cross-region S3 bucket access for windows

### DIFF
--- a/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-download.go
+++ b/addons/addon-raas-s3-copy/packages/s3-synchronizer/src/s3-download.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"context"
 	"log"
 	"math"
 	"os"
@@ -110,17 +109,7 @@ func syncS3ToLocal(sess *session.Session, config *mountConfiguration, concurrenc
 
 	bucket := config.bucket
 	prefix := config.prefix
-	awsRegion, err := s3manager.GetBucketRegion(context.Background(), sess, bucket, *sess.Config.Region)
-	if debug {
-		log.Println("Bucket", bucket, "region is", awsRegion)
-	}
-
-	sessForTheMount := session.Must(session.NewSession(sess.Config))
-	sessForTheMount.Config.WithRegion(awsRegion)
-	svc := s3.New(sessForTheMount)
-	if err != nil {
-		log.Println("Error getting region of the bucket", bucket, err)
-	}
+	svc := s3.New(sess)
 
 	if debug {
 		log.Println("Listing", bucket, "for prefix", prefix)
@@ -155,7 +144,7 @@ func syncS3ToLocal(sess *session.Session, config *mountConfiguration, concurrenc
 		truncatedListing = *resp.IsTruncated
 	}
 
-	err = deleteLocalFilesNotInS3(listObjectResponses, config, debug)
+	err := deleteLocalFilesNotInS3(listObjectResponses, config, debug)
 	if err != nil {
 		log.Println("Error: ", err)
 	}


### PR DESCRIPTION
Issue #, if available: GALI-645

Description of changes:

If workspace and S3 bucket were in different regions, we would see the files being listed in windows but it won't have any contents. After reading of the code, it seems like we were using the correct region centric AWS session only for file listing and not for file copying, writing or deleting. In this change I have moved the logic of finding the correct region upstream and based on that create the correct S3 session.

I didn't find a good way to unit test this change, so I will be extending our old backlog item to improve the unit testing or better add this as part of integ testing.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
