### PR TITLE
fix: Add tables back for postmortem analysis

### DIFF
--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
@@ -174,43 +174,16 @@ class ApiKeyService extends Service {
     return redactIfNotForCurrentUser(requestContext, apiKey, uid);
   }
 
+  /**
+   * Api Key feature is DEPRECATED
+   * All existing Api Keys should be denined
+   * @param signedApiKey
+   */
   async validateApiKey(signedApiKey) {
-    // Make sure the key is specified
     if (_.isEmpty(signedApiKey)) {
       throw this.boom.forbidden('no api key was provided', true);
     }
-
-    // Make sure the key is a valid non-expired JWT token and has correct signature
-    const jwtService = await this.service('jwtService');
-    const verifiedApiKeyJwtToken = await jwtService.verify(signedApiKey);
-    const { sub: uid } = verifiedApiKeyJwtToken;
-    if (_.isEmpty(uid)) {
-      throw this.boom.invalidToken('No "sub" is provided in the api key', true);
-    }
-
-    // Make sure the key is an API key (and not the regular JWT token)
-    if (!this.isApiKeyToken(verifiedApiKeyJwtToken)) {
-      throw this.boom.invalidToken('The given key is not valid for API access', true);
-    }
-
-    // Make sure the key is an active key (by checking it against the DB)
-    const apiKeyId = _.get(verifiedApiKeyJwtToken, 'custom:apiKeyId');
-    const dbService = await this.service('dbService');
-    const table = this.settings.get(settingKeys.tableName);
-    const apiKey = await dbService.helper
-      .getter()
-      .table(table)
-      .key({ id: apiKeyId })
-      .get();
-
-    if (!apiKey) {
-      throw this.boom.invalidToken('The given key is not valid for API access', true);
-    }
-    if (apiKey.status !== 'active') {
-      throw this.boom.invalidToken('The given API key is not active', true);
-    }
-    // If code reached here then this is a valid key
-    return { verifiedToken: verifiedApiKeyJwtToken, uid };
+    throw this.boom.invalidToken('The given key is not valid for API access', true);
   }
 
   async getApiKeys(requestContext, { uid }) {

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
@@ -184,7 +184,7 @@ class ApiKeyService extends Service {
       throw this.boom.forbidden('no api key was provided', true);
     }
     throw this.boom.invalidToken(
-      'Existing internally generated APIs keys cannot be used for access. Contact your system admin about it.',
+      'Existing internally generated API keys cannot be used for access. Contact your system admin about it.',
       true,
     );
   }

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/internal/api-key-service.js
@@ -183,7 +183,10 @@ class ApiKeyService extends Service {
     if (_.isEmpty(signedApiKey)) {
       throw this.boom.forbidden('no api key was provided', true);
     }
-    throw this.boom.invalidToken('The given key is not valid for API access', true);
+    throw this.boom.invalidToken(
+      'Existing internally generated APIs keys cannot be used for access. Contact your system admin about it.',
+      true,
+    );
   }
 
   async getApiKeys(requestContext, { uid }) {

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -937,6 +937,27 @@ Resources:
           KeyType: 'HASH'
       BillingMode: PAY_PER_REQUEST
 
+  UserApiKeysDb:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: ${self:custom.settings.dbUserApiKeys}
+      AttributeDefinitions:
+        - AttributeName: 'id'
+          AttributeType: 'S'
+        - AttributeName: 'uid'
+          AttributeType: 'S'
+      KeySchema:
+        - AttributeName: 'id'
+          KeyType: 'HASH'
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: ByUID
+          KeySchema:
+            - AttributeName: 'uid'
+              KeyType: 'HASH'
+          Projection:
+            ProjectionType: ALL
+
   UsersDb:
     Type: AWS::DynamoDB::Table
     DependsOn: PasswordsDb
@@ -1377,6 +1398,22 @@ Resources:
       KeySchema:
         - AttributeName: 'username'
           KeyType: 'HASH'
+      BillingMode: PAY_PER_REQUEST
+
+  DbUserApiKeys:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: ${self:custom.settings.dbTableUserApiKeys}
+      AttributeDefinitions:
+        - AttributeName: 'unameWithNs' # Username with Namespace (ns)
+          AttributeType: 'S'
+        - AttributeName: 'id'
+          AttributeType: 'S'
+      KeySchema:
+        - AttributeName: 'unameWithNs'
+          KeyType: 'HASH'
+        - AttributeName: 'id'
+          KeyType: 'RANGE'
       BillingMode: PAY_PER_REQUEST
 
   DbUsers:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Add two ApiKeys table back
* Update validateKey method to throw error on all calls 
* Deployed to environments with or without the previous patch, both deployed successfully  
* Validated both environments for log in, log out, create new user
* Validated using key in the ApiKeys table throw Unauthorized error
* Validated triggering /api-keys throw Not Found error

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
