### PR TITLE
feat: enable API Gateway access logs

### DIFF
--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -22,6 +22,10 @@ provider:
   # See https://forum.serverless.com/t/getting-handle-accountid-in-serverless-config/946/11 and
   # See https://github.com/serverless/serverless/issues/5011
   variableSyntax: '\$\{((((self|opt|deep|cf):)|file)((?!\$\{).)+?)}'
+  logs:
+    restApi:
+      format: '{"authorizer.principalId":"$context.authorizer.principalId","error.message":"$context.error.message","extendedRequestId":"$context.extendedRequestId","httpMethod":"$context.httpMethod","identity.sourceIp":"$context.identity.sourceIp","integration.error":"$context.integration.error","integration.integrationStatus":"$context.integration.integrationStatus","integration.latency":"$context.integration.latency","integration.requestId":"$context.integration.requestId","integration.status":"$context.integration.status","path":"$context.path","requestId":"$context.requestId","responseLatency":"$context.responseLatency","responseLength":"$context.responseLength","stage":"$context.stage","status":"$context.status"}'
+      executionLogging: false
   environment:
     APP_ENV_TYPE: ${self:custom.settings.envType}
     APP_ENV_NAME: ${self:custom.settings.envName}


### PR DESCRIPTION
Description of changes:

Enable ApiGW access logs. The values that are logged were handpicked from the [ApiGW List of Log Variables](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference%3Fcmpid=docs_apigateway_console)

example log entry:
```json
{
    "authorizer.principalId": "u-PvFZgnw5fl5nwqIia4F0P",
    "error.message": "-",
    "extendedRequestId": "ZuT4rGDNoAMFxXw=",
    "httpMethod": "GET",
    "identity.sourceIp": "72.21.196.66",
    "integration.error": "-",
    "integration.integrationStatus": "200",
    "integration.latency": "79",
    "integration.requestId": "67394741-90ae-4c6c-94fb-df8bf7be33ec",
    "integration.status": "200",
    "path": "/nesdev/api/user-roles",
    "requestId": "468a1b4d-3015-4901-b749-37e4e0551029",
    "responseLatency": "83",
    "responseLength": "819",
    "stage": "nesdev",
    "status": "200"
}
```

Execution logging is explicitly disabled since its features are not-so-great for the average customer:
- It is very verbose, thus expensive.
- There's no way to mask sensitive data from the logs
- Large payloads/responses may be truncated so it's not a surefire way to log all relevant request data

Checklist: 

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [n/a] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [n/a] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
