### PR TITLE
fix: use correct fieldsToMask in the logger

### DIFF
--- a/addons/addon-base/packages/services/lib/logger/__tests__/log-transformer.test.js
+++ b/addons/addon-base/packages/services/lib/logger/__tests__/log-transformer.test.js
@@ -1,0 +1,35 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const LogTransformer = require('../log-transformer');
+
+describe('LogTransformer', () => {
+  it('formats log message and masks sensitive fields', () => {
+    const logTransformer = new LogTransformer({}, ['secret']);
+    expect(logTransformer.transformForLog({ a: '1', secret: 'should not be seen' })).toEqual(
+      // eslint-disable-next-line prettier/prettier
+`{
+  "logLevel": "log",
+  "a": "1",
+  "secret": "****"
+}`,
+    );
+  });
+
+  it('should fail for invalid fieldsToMask', () => {
+    expect(() => new LogTransformer({}, { key: 'val' })).toThrow();
+    expect(() => new LogTransformer({}, ['a', 'b', {}, []])).toThrow();
+  });
+});

--- a/addons/addon-base/packages/services/lib/logger/__tests__/log-transformer.test.js
+++ b/addons/addon-base/packages/services/lib/logger/__tests__/log-transformer.test.js
@@ -19,8 +19,7 @@ describe('LogTransformer', () => {
   it('formats log message and masks sensitive fields', () => {
     const logTransformer = new LogTransformer({}, ['secret']);
     expect(logTransformer.transformForLog({ a: '1', secret: 'should not be seen' })).toEqual(
-      // eslint-disable-next-line prettier/prettier
-`{
+      `{
   "logLevel": "log",
   "a": "1",
   "secret": "****"

--- a/addons/addon-base/packages/services/lib/logger/log-transformer.js
+++ b/addons/addon-base/packages/services/lib/logger/log-transformer.js
@@ -18,6 +18,12 @@ const cycle = require('cycle');
 
 class LogTransformer {
   constructor(loggingContext = {}, fieldsToMask = ['x-amz-security-token', 'user', 'accessKey', 'password']) {
+    if (!Array.isArray(fieldsToMask) || fieldsToMask.some(field => typeof field !== 'string')) {
+      throw new Error(
+        `expected fieldsToMask to be an array of strings, but got instead: ${JSON.stringify(fieldsToMask)}`,
+      );
+    }
+
     this.loggingContext = loggingContext;
     this.fieldsToMask = fieldsToMask;
   }

--- a/main/packages/services/lib/plugins/services-plugin.js
+++ b/main/packages/services/lib/plugins/services-plugin.js
@@ -162,9 +162,7 @@ async function getFieldsToMask(existingFieldsToMask, pluginRegistry) {
   //
 
   // TODO: Register additional fieldsToMask as per your solution requirements here
-  const fieldsToMask = {
-    ...existingFieldsToMask,
-  };
+  const fieldsToMask = [...existingFieldsToMask];
   // DO NOT forget to return fieldsToMask here. If you do not return here no fields will be masked
   return fieldsToMask;
 }

--- a/main/solution/post-deployment/src/lambdas/post-deployment/plugins/services-plugin.js
+++ b/main/solution/post-deployment/src/lambdas/post-deployment/plugins/services-plugin.js
@@ -162,9 +162,7 @@ async function getFieldsToMask(existingFieldsToMask, pluginRegistry) {
   //
 
   // TODO: Register additional fieldsToMask as per your solution requirements here
-  const fieldsToMask = {
-    ...existingFieldsToMask,
-  };
+  const fieldsToMask = [...existingFieldsToMask];
   // DO NOT forget to return fieldsToMask here. If you do not return here no fields will be masked
   return fieldsToMask;
 }


### PR DESCRIPTION
Description of changes:
Some addons were passing an object instead of an array as `fieldsToMask` and that inadvertently lead to the logger not masking anything. This fixes it
Also changed LogTransformer to crash for invalid `fieldsToMask` to prevent this issue in the future.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [n/a] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
