### PR TITLE
feat: Remove APIs for built-in workspaces and clarify documentation on the enableBuiltInWorkspaces flag

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/compute-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/compute-controller.js
@@ -17,38 +17,38 @@
 
 async function configure(context) {
   const router = context.router();
-  const wrap = context.wrap;
+  // const wrap = context.wrap;
 
-  const computePlatformService = await context.service('computePlatformService');
+  // const computePlatformService = await context.service('computePlatformService');
 
   // ===============================================================
   //  GET /platforms (mounted to /api/compute)
   // ===============================================================
-  router.get(
-    '/platforms',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-
-      const platforms = await computePlatformService.listPlatforms(requestContext);
-      res.status(200).json(platforms);
-    }),
-  );
-
-  // ===============================================================
-  //  GET /platforms/:id/configurations (mounted to /api/compute)
-  // ===============================================================
-  router.get(
-    '/platforms/:id/configurations',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-      const platforms = await computePlatformService.listConfigurations(requestContext, {
-        platformId: id,
-        includePrice: true,
-      });
-      res.status(200).json(platforms);
-    }),
-  );
+  // router.get(
+  //   '/platforms',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //
+  //     const platforms = await computePlatformService.listPlatforms(requestContext);
+  //     res.status(200).json(platforms);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /platforms/:id/configurations (mounted to /api/compute)
+  // // ===============================================================
+  // router.get(
+  //   '/platforms/:id/configurations',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //     const platforms = await computePlatformService.listConfigurations(requestContext, {
+  //       platformId: id,
+  //       includePrice: true,
+  //     });
+  //     res.status(200).json(platforms);
+  //   }),
+  // );
 
   return router;
 }

--- a/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/environment-controller.js
+++ b/addons/addon-base-raas/packages/base-raas-rest-api/lib/controllers/environment-controller.js
@@ -18,178 +18,178 @@
 
 async function configure(context) {
   const router = context.router();
-  const wrap = context.wrap;
-
-  const [
-    environmentService,
-    environmentKeypairService,
-    environmentUrlService,
-    environmentSpotPriceHistoryService,
-  ] = await context.service([
-    'environmentService',
-    'environmentKeypairService',
-    'environmentUrlService',
-    'environmentSpotPriceHistoryService',
-  ]);
-
-  // ===============================================================
-  //  GET / (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-
-      const result = await environmentService.list(requestContext);
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  GET /:id (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/:id',
-    wrap(async (req, res) => {
-      const id = req.params.id;
-      const requestContext = res.locals.requestContext;
-
-      const result = await environmentService.mustFind(requestContext, { id });
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  POST / (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.post(
-    '/',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const possibleBody = req.body;
-      const result = requestContext.principal.isExternalUser
-        ? await environmentService.createExternal(requestContext, possibleBody)
-        : await environmentService.create(requestContext, possibleBody);
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  PUT / (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.put(
-    '/',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const possibleBody = req.body;
-      const result = await environmentService.update(requestContext, possibleBody);
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  PUT / (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.put(
-    '/:id/start',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-      const operation = 'start';
-      const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  PUT / (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.put(
-    '/:id/stop',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-      const operation = 'stop';
-      const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  DELETE /:id (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.delete(
-    '/:id',
-    wrap(async (req, res) => {
-      const id = req.params.id;
-      const requestContext = res.locals.requestContext;
-
-      await environmentService.delete(requestContext, { id });
-      res.status(200).json({});
-    }),
-  );
-
-  // ===============================================================
-  //  GET /:id/keypair (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/:id/keypair',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-
-      const result = await environmentKeypairService.mustFind(requestContext, id);
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  GET /:id/password (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/:id/password',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-
-      const result = await environmentService.getWindowsPasswordData(requestContext, { id });
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  GET /:id/url (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/:id/url',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const id = req.params.id;
-      const result = await environmentUrlService.get(requestContext, id);
-
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
-  //  GET /pricing/:type (mounted to /api/workspaces/built-in)
-  // ===============================================================
-  router.get(
-    '/pricing/:type',
-    wrap(async (req, res) => {
-      const requestContext = res.locals.requestContext;
-      const type = req.params.type;
-      const result = await environmentSpotPriceHistoryService.getPriceHistory(requestContext, type);
-
-      res.status(200).json(result);
-    }),
-  );
+  // const wrap = context.wrap;
+  //
+  // const [
+  //   environmentService,
+  //   environmentKeypairService,
+  //   environmentUrlService,
+  //   environmentSpotPriceHistoryService,
+  // ] = await context.service([
+  //   'environmentService',
+  //   'environmentKeypairService',
+  //   'environmentUrlService',
+  //   'environmentSpotPriceHistoryService',
+  // ]);
+  //
+  // // ===============================================================
+  // //  GET / (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //
+  //     const result = await environmentService.list(requestContext);
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /:id (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/:id',
+  //   wrap(async (req, res) => {
+  //     const id = req.params.id;
+  //     const requestContext = res.locals.requestContext;
+  //
+  //     const result = await environmentService.mustFind(requestContext, { id });
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  POST / (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.post(
+  //   '/',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const possibleBody = req.body;
+  //     const result = requestContext.principal.isExternalUser
+  //       ? await environmentService.createExternal(requestContext, possibleBody)
+  //       : await environmentService.create(requestContext, possibleBody);
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  PUT / (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.put(
+  //   '/',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const possibleBody = req.body;
+  //     const result = await environmentService.update(requestContext, possibleBody);
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  PUT / (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.put(
+  //   '/:id/start',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //     const operation = 'start';
+  //     const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  PUT / (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.put(
+  //   '/:id/stop',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //     const operation = 'stop';
+  //     const result = await environmentService.changeWorkspaceRunState(requestContext, { id, operation });
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  DELETE /:id (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.delete(
+  //   '/:id',
+  //   wrap(async (req, res) => {
+  //     const id = req.params.id;
+  //     const requestContext = res.locals.requestContext;
+  //
+  //     await environmentService.delete(requestContext, { id });
+  //     res.status(200).json({});
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /:id/keypair (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/:id/keypair',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //
+  //     const result = await environmentKeypairService.mustFind(requestContext, id);
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /:id/password (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/:id/password',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //
+  //     const result = await environmentService.getWindowsPasswordData(requestContext, { id });
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /:id/url (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/:id/url',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const id = req.params.id;
+  //     const result = await environmentUrlService.get(requestContext, id);
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
+  //
+  // // ===============================================================
+  // //  GET /pricing/:type (mounted to /api/workspaces/built-in)
+  // // ===============================================================
+  // router.get(
+  //   '/pricing/:type',
+  //   wrap(async (req, res) => {
+  //     const requestContext = res.locals.requestContext;
+  //     const type = req.params.type;
+  //     const result = await environmentSpotPriceHistoryService.getPriceHistory(requestContext, type);
+  //
+  //     res.status(200).json(result);
+  //   }),
+  // );
 
   return router;
 }

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -157,10 +157,11 @@ launchConstraintRoleName: '${self:custom.settings.namespace}-LaunchConstraint'
 # Specify wild-card ( i.e., '*') here to allow any prefix pattern
 launchConstraintPolicyPrefix: '*'
 
-# Enable/disable support for built-in workspaces and built-in workspace types.
-# If enableBuiltInWorkspaces = true then built in workspaces/workspace types are used.
-# If enableBuiltInWorkspaces = false then support for importing new workspace types based on
-#  AWS Service Catalog Products/Versions is enabled and the built-in workspaces feature is disabled
+# Disable support for built-in workspaces and built-in workspace types.
+# AWS Service Catalog Products/Versions is enabled and the built-in workspaces feature is disabled
+# Note that setting enableBuiltInWorkspaces = true won't be enough to get the built-in workspace support. In order to
+# get built-in workspaces support please open a new issue with Service Workbench
+# https://github.com/awslabs/service-workbench-on-aws/issues/new
 enableBuiltInWorkspaces: false
 
 # Name of the audit QLDB. This is the name of the QLDB ledger that will keep the audit logs.


### PR DESCRIPTION
Issue #, if available:  GALI-684

Description of changes:

Disabling built-in related APIs since the feature isn't being used by any known customers. I have updated the documentation on the flag to reflect that. We will bring the feature back based on customer interest and re-evaluating it on our side.

I tested by calling the APIs from postman and get an expected Error. Did this by deploying the code locally and via APIGateway endpoint both.

Paths I tested: {{baseUrl}}/api/compute/platforms/ and {{baseUrl}}/api/workspaces/built-in

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
