### PR TITLE
fix: Made external researcher used UserOnboarding template less permissive

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UserOnboarding.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UserOnboarding.js
@@ -73,26 +73,73 @@ const generateDefaultIAMPolicy = accountId =>
     {
       "Sid": "ec2",
       "Effect": "Allow",
-      "Action": "ec2:*",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateKeyPair",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteKeyPair",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeDhcpOptions",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances"
+      ],
       "Resource": "*"
     },
     {
       "Sid": "cloudformation",
       "Effect": "Allow",
-      "Action": "cloudformation:*",
-      "Resource": "*"
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": "arn:aws:cloudformation:*:${accountId}:stack/analysis*/*"
     },
     {
       "Sid": "emr",
       "Effect": "Allow",
-      "Action": "elasticmapreduce:*",
+      "Action": [
+        "elasticmapreduce:CreateSecurityConfiguration",
+        "elasticmapreduce:DeleteSecurityConfiguration",
+        "elasticmapreduce:DescribeCluster",
+        "elasticmapreduce:RunJobFlow",
+        "elasticmapreduce:TerminateJobFlows"
+      ],
       "Resource": "*"
     },
     {
       "Sid": "sagemaker",
       "Effect": "Allow",
-      "Action": "sagemaker:*",
-      "Resource": "*"
+      "Action": [
+        "sagemaker:CreateNotebookInstance",
+        "sagemaker:CreateNotebookInstanceLifecycleConfig",
+        "sagemaker:CreatePresignedNotebookInstanceUrl",
+        "sagemaker:DeleteNotebookInstance",
+        "sagemaker:DeleteNotebookInstanceLifecycleConfig",
+        "sagemaker:DescribeNotebookInstance",
+        "sagemaker:DescribeNotebookInstanceLifecycleConfig",
+        "sagemaker:StopNotebookInstance"
+      ],
+      "Resource": [
+        "arn:aws:sagemaker:*:${accountId}:notebook-instance-lifecycle-config/*",
+        "arn:aws:sagemaker:*:${accountId}:notebook-instance/*"
+      ]
     },
     {
       "Sid": "iamRoleAccess",
@@ -155,19 +202,48 @@ const generateDefaultIAMPolicy = accountId =>
     {
       "Sid": "s3",
       "Effect": "Allow",
-      "Action": "s3:*",
-      "Resource": "*"
+      "Action": [
+        "s3:CreateBucket",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutBucketTagging"
+      ],
+      "Resource": "arn:aws:s3:::analysis*"
     },
     {
       "Sid": "ssm",
       "Effect": "Allow",
-      "Action": "ssm:*",
+      "Action": [
+        "ssm:DeleteParameter",
+        "ssm:GetParameter",
+        "ssm:PutParameter"
+      ],
       "Resource": "*"
     },
     {
       "Sid": "kms",
       "Effect": "Allow",
-      "Action": "kms:*",
+      "Action": [
+        "kms:CreateGrant",
+        "kms:CreateKey",
+        "kms:DeleteAlias",
+        "kms:DescribeKey",
+        "kms:EnableKeyRotation",
+        "kms:Encrypt",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:GetKeyPolicy",
+        "kms:GetKeyRotationStatus",
+        "kms:GetParametersForImport",
+        "kms:ListAliases",
+        "kms:ListGrants",
+        "kms:ListKeyPolicies",
+        "kms:ListKeys",
+        "kms:ListResourceTags",
+        "kms:ListRetirableGrants",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion",
+        "kms:TagResource",
+        "kms:UntagResource"
+      ],
       "Resource": "*"
     }
   ]


### PR DESCRIPTION


Issue #, if available: GALI-20

Description of changes:
* Note that the change is only applicable for external-researchers, so in order to test the change I had to enable built-in and external-researcher config
* Verified that I was able to create/connect/terminate SageMaker instance
* Verified that I was able to create/terminate EMR
* RStudio/Windows/Linux EC2 are not supported for external-researchers, and they don't show up as an option for provisioning

Out of scope but broken
* Stopping SageMaker and connecting with EMR is broken currently, and I will create a separate issue about this
* Also note that we have permissions to createRole with permissions boundary. That is also overly permissive but the change would be more involved. I will create a separate issue in our backlog for this too.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
