### PR TITLE
fix: Added usernameInIdp property to update user schema

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-user.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-user.json
@@ -10,6 +10,12 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
     },
+    "usernameInIdp": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 300,
+      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+    },
     "firstName": {
       "type": "string",
       "maxLength": 500

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
@@ -69,6 +69,56 @@ describe('UserService', () => {
     service.assertAuthorized = jest.fn();
   });
 
+  describe('updateUser', () => {
+    it('should not fail validation when usernameInIdp in schema', async () => {
+      const user = {
+        email: 'example@amazon.com',
+        usernameInIdp: 'example',
+        uid: 'user1',
+        rev: 0,
+      };
+
+      // mocked functions
+      service.toUserType = jest.fn(() => {
+        return { userType: 'root' };
+      });
+      service.getUserByPrincipal = jest.fn(() => {
+        return null;
+      });
+      service.findUser = jest.fn(() => {
+        return user;
+      });
+      await service.updateUser({}, user);
+    });
+
+    it('should fail validation when unknown property in schema', async () => {
+      const user = {
+        email: 'example@amazon.com',
+        usernameInIdp: 'example',
+        uid: 'user1',
+        rev: 0,
+        unknown: 'unknownProperty',
+      };
+
+      // mocked functions
+      service.toUserType = jest.fn(() => {
+        return { userType: 'root' };
+      });
+      service.getUserByPrincipal = jest.fn(() => {
+        return null;
+      });
+      service.findUser = jest.fn(() => {
+        return user;
+      });
+      try {
+        await service.updateUser({}, user);
+        expect.fail('Expected to throw error validation errors');
+      } catch (err) {
+        expect(err.message).toEqual('Input has validation errors');
+      }
+    });
+  });
+
   describe('createUsers', () => {
     it('should try to create a user', async () => {
       const user = {

--- a/addons/addon-base/packages/services/lib/schema/update-user.json
+++ b/addons/addon-base/packages/services/lib/schema/update-user.json
@@ -6,6 +6,12 @@
     "uid": {
       "type": "string"
     },
+    "usernameInIdp": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 300,
+      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+    },
     "email": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"

--- a/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
@@ -243,6 +243,7 @@ describe('UserService', () => {
       // BUILD
       const toUpdate = {
         uid,
+        usernameInIdp: 'user1',
         rev: 2,
       };
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This change fixes authentication of users who are added by admin from ServiceWorkbench UI directly

With userId PR https://github.com/awslabs/service-workbench-on-aws/pull/148 we had broken the above use case since the field `usernameInIdp` was removed from update schema. With users added by admin, this property is tried to be added back to user table[1][2] during authentication but the update fails since the field was removed from schema. Note that when user does self registration via idp the field `usernameInIdp` is already present from idp authentication and since create-user schema supports it, the field is added successfully. I figured that keeping the field around is useful so added it to update schema as well. It seems like removing the field entirely would have worked too.

[1]https://github.com/awslabs/service-workbench-on-aws/blob/37878582af54d2741a1eeb47b4673bdcc295d1b5/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/user-attributes-mapper-service.js
[2]https://github.com/awslabs/service-workbench-on-aws/blob/master/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/provider-service.js#L134-L138

Tested the change under following scenarios:
1. Existing internal login works
2. New internal login works
3. Existing federated login works
4. New federated login registered by admin works
5. Self federated registration also works

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?
* [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
