### PR TITLE
fix: Creating empty XML file for no test config

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -37,5 +37,6 @@ if [ "$TEST_CONFIG_EXISTS" == true ]; then
 else
     # Create empty report file
     mkdir -p main/integration-tests/.build/test
-    echo 'No integration tests were run. Please provide your test config file to run integration tests' > "main/integration-tests/.build/test/junit.xml"
+    echo '<?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="Integration tests were skipped!" tests="0" failures="0" time="0"><testsuite></testsuite></testsuites>' > "main/integration-tests/.build/test/junit.xml"
 fi


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Integration test script to create empty XML result file when test config not found.

Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes? 
* [x] Have you linted your code locally prior to submission?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran unit tests and manual tests with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
