### PR TITLE
fix: code comment update

### DIFF
--- a/main/integration-tests/support/resources/studies/studies.js
+++ b/main/integration-tests/support/resources/studies/studies.js
@@ -38,7 +38,7 @@ class Studies extends CollectionResource {
   }
 
   // When creating a child resource, this method provides default values. This method is used by the
-  // CollectionResource class when we use get() method on this resource operations helper.
+  // CollectionResource class when we use create() method on this resource operations helper.
   defaults(study = {}) {
     const id = study.id || this.setup.gen.string({ prefix: 'study-test' });
     return {

--- a/main/integration-tests/support/resources/users/users.js
+++ b/main/integration-tests/support/resources/users/users.js
@@ -36,7 +36,7 @@ class Users extends CollectionResource {
   }
 
   // When creating a child resource, this method provides default values. This method is used by the
-  // CollectionResource class when we use get() method on this resource operations helper.
+  // CollectionResource class when we use create() method on this resource operations helper.
   defaults(user = {}) {
     const gen = this.setup.gen;
     const username = user.username || gen.username();


### PR DESCRIPTION
Change the comment from 'get()' to 'create()' in the comments for studies and users resource operations helpers
Checklist: 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
