### PR TITLE
fix: Allow study admins to update study and its permissions

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-permission-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-permission-service.js
@@ -326,10 +326,14 @@ class StudyPermissionService extends Service {
     const lockId = `study-${studyEntity.id}`;
     const entity = await lockService.tryWriteLockAndRun({ id: lockId }, async () => {
       const studyPermissionsEntity = await this.findStudyPermissions(requestContext, studyEntity);
-      await this.assertAuthorized(requestContext, {
-        action: 'update-study-permissions',
-        conditions: [allowIfActive, this.allowUpdate],
-      });
+      await this.assertAuthorized(
+        requestContext,
+        {
+          action: 'update-study-permissions',
+          conditions: [allowIfActive, this.allowUpdate],
+        },
+        { studyEntity, studyPermissionsEntity },
+      );
 
       applyUpdateRequest(studyPermissionsEntity, updateRequest);
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -392,11 +392,12 @@ class StudyService extends Service {
     // Validate input
     await validationService.ensureValid(rawData, updateSchema);
     const { id } = rawData;
+    const by = _.get(requestContext, 'principalIdentifier.uid');
 
     // Ensure the principal has update permission. This is done by getting the study permissions entity
     // and checking if the principal has a study admin permissions
     const studyEntity = await this.getStudyPermissions(requestContext, id);
-    if (!isStudyAdmin(studyEntity.permissions) && !isAdmin(requestContext)) {
+    if (!isStudyAdmin(studyEntity.permissions, by) && !isAdmin(requestContext)) {
       throw this.boom.forbidden("You don't have permissions to update this study", true);
     }
 
@@ -407,8 +408,6 @@ class StudyService extends Service {
     if (!isOpenData(studyEntity) && !_.isEmpty(rawData.resources)) {
       throw this.boom.badRequest('Resources can only be updated for Open Data study category', true);
     }
-
-    const by = _.get(requestContext, 'principalIdentifier.uid');
 
     // Prepare the db object
     const dbObject = _.omit(toDbEntity(rawData, { updatedBy: by }), ['rev']);

--- a/main/integration-tests/__test__/api-tests/studies/create-study.test.js
+++ b/main/integration-tests/__test__/api-tests/studies/create-study.test.js
@@ -41,7 +41,7 @@ describe('Create study scenarios', () => {
       await expect(
         researcherSession.resources.studies.create({ id: studyId, category: 'Open Data' }),
       ).rejects.toMatchObject({
-        code: errorCode.http.code.badRequest,
+        code: errorCode.http.code.forbidden,
       });
     });
 
@@ -58,7 +58,7 @@ describe('Create study scenarios', () => {
             category: studyCategory,
           }),
         ).rejects.toMatchObject({
-          code: errorCode.http.code.badRequest,
+          code: errorCode.http.code.forbidden,
         });
       },
     );

--- a/main/integration-tests/__test__/api-tests/studies/get-study-permissions.test.js
+++ b/main/integration-tests/__test__/api-tests/studies/get-study-permissions.test.js
@@ -65,7 +65,7 @@ describe('Get study permissions scenarios', () => {
           .permissions()
           .get(),
       ).rejects.toMatchObject({
-        code: errorCode.http.code.notFound,
+        code: errorCode.http.code.forbidden,
       });
     });
 

--- a/main/integration-tests/__test__/api-tests/studies/get-study.test.js
+++ b/main/integration-tests/__test__/api-tests/studies/get-study.test.js
@@ -52,7 +52,7 @@ describe('Get study scenarios', () => {
       await researcher1session.resources.studies.create({ id: studyId, category: studyCategory });
       const researcher2session = await setup.createResearcherSession();
       await expect(researcher2session.resources.studies.study(studyId).get()).rejects.toMatchObject({
-        code: errorCode.http.code.notFound,
+        code: errorCode.http.code.forbidden,
       });
     });
 

--- a/main/integration-tests/__test__/api-tests/studies/update-study-permissions.test.js
+++ b/main/integration-tests/__test__/api-tests/studies/update-study-permissions.test.js
@@ -69,7 +69,7 @@ describe('Update study permissions scenarios', () => {
             .permissions()
             .update(),
         ).rejects.toMatchObject({
-          code: errorCode.http.code.notFound,
+          code: errorCode.http.code.forbidden,
         });
       },
     );


### PR DESCRIPTION
Issue #, if available:

Description of changes:

1. Allow study admins to update study and its permissions
2. Fix study APIs integration tests to throw `forbidden` error instead of `unauthorized` when access is not granted

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id: GALI-672

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
