### PR TITLE
fix: change the default expiration of internally generated JWT tokens to one hour

### DIFF
--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -1,5 +1,6 @@
 # Options used when issuing JWT token such as which algorithm to use for hashing and how long to keep the tokens alive etc
-jwtOptions: '{"algorithm":"HS256","expiresIn":"2 days"}'
+# Note that default expiry of access token is set to one hour. This will force the user to logout and login back after an hour
+jwtOptions: '{"algorithm":"HS256","expiresIn":"1 hours"}'
 
 # Name of the parameter in parameter store containing secret key for JWT. This key is used for signing and validating JWT tokens
 # issued by data lake authentication providers


### PR DESCRIPTION
Issue #, if available: GALI-730

Description of changes:

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
