### PR TITLE
fix: remove the POST workflow status query endpoint

### DIFF
--- a/addons/addon-base-workflow-api/packages/base-worklfow-api/lib/controllers/workflow-controller.js
+++ b/addons/addon-base-workflow-api/packages/base-worklfow-api/lib/controllers/workflow-controller.js
@@ -76,23 +76,6 @@ async function configure(context) {
   );
 
   // ===============================================================
-  //  POST /instances/status (mounted to /api/workflows)
-  // ===============================================================
-  router.post(
-    '/instances/status/:status',
-    wrap(async (req, res) => {
-      const status = req.params.status;
-      const { startTime, endTime } = req.body;
-      const result = await workflowInstanceService.listByStatus({
-        status,
-        startTime,
-        endTime,
-      });
-      res.status(200).json(result);
-    }),
-  );
-
-  // ===============================================================
   //  GET /:id/assignments (mounted to /api/workflows)
   // ===============================================================
   router.get(

--- a/addons/addon-base-workflow-ui/packages/base-workflow-ui/src/helpers/api.js
+++ b/addons/addon-base-workflow-ui/packages/base-workflow-ui/src/helpers/api.js
@@ -90,10 +90,6 @@ async function getWorkflow(id) {
   return httpApiGet(`api/workflows/${encodeURIComponent(id)}`);
 }
 
-async function listWorkflowInstancesByStatus({ status, data }) {
-  return httpApiPost(`api/workflows/instances/status/${status}`, { data });
-}
-
 async function getWorkflowInstances(id, ver) {
   return httpApiGet(`api/workflows/${encodeURIComponent(id)}/v/${ver}/instances`);
 }
@@ -128,7 +124,6 @@ export {
   publishWorkflowDraft,
   deleteWorkflowDraft,
   getWorkflow,
-  listWorkflowInstancesByStatus,
   getWorkflowInstances,
   getWorkflowInstance,
   triggerWorkflow,

--- a/addons/addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-instance-service.js
+++ b/addons/addon-base-workflow/packages/base-workflow-core/lib/workflow/workflow-instance-service.js
@@ -30,7 +30,6 @@ const settingKeys = {
 };
 
 const workflowIndexName = 'WorkflowIndex';
-const workflowStatusIndexName = 'InstanceStatusCreatedIndex';
 
 class WorkflowInstanceService extends Service {
   constructor() {
@@ -262,25 +261,6 @@ class WorkflowInstanceService extends Service {
         throw this.boom.badRequest(`Workflow instance "${instanceId}" does not exist`, true);
       },
     );
-
-    return result;
-  }
-
-  // List the all workflow instances by status for a specified time period
-  // startTime and endTime must be in ISO format
-  async listByStatus({ startTime, endTime, status, fields = [] } = {}) {
-    const dbService = await this.service('dbService');
-    const table = this.tableName;
-
-    const result = await dbService.helper
-      .query()
-      .table(table)
-      .index(workflowStatusIndexName)
-      .key('wfStatus', status)
-      .sortKey('createdAt')
-      .between(startTime, endTime)
-      .projection(fields)
-      .query();
 
     return result;
   }


### PR DESCRIPTION
The current POST /api/workflows/instances/status/{status}  API is not used and the underlying database index is missing from the beginning.  No services or other APIs depend on this API.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [X] Have you successfully deployed to an AWS account with your changes?
- [X] Have you successfully tested with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
