### PR TITLE
docs: Updated CHANGELOG for 2.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.3] - 2021-03-12
+- chore(deps): bump websocket-extensions from 0.1.3 to 0.1.4
+- test: fix flaky integ tests
+- fix: emr workspace image. Lock jupyterlab to version 2.2.6
+- test: Implemented integration tests for service catalog workspaces
+- feat: verbose integ test log
+
 ## [2.0.2] - 2021-03-03
 
 ### Added 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* docs: Updated CHANGELOG for 2.0.3 release
* CHANGELOG includes EMR bug fix which locks jupyterlab to version 2.2.6 since that is the one we support

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
