### PR TITLE
fix: added region parameter reference to elasticmapreduce bucket references

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -151,7 +151,7 @@ Resources:
               - Effect: 'Allow'
                 Action: 's3:GetObject'
                 Resource:
-                  - 'arn:aws:s3:::us-east-1.elasticmapreduce/bootstrap-actions/run-if'
+                  - !Sub 'arn:aws:s3:::${AWS::Region}.elasticmapreduce/bootstrap-actions/run-if'
                   - !Sub
                     - 'arn:aws:s3:::${S3Location}/*'
                     # Remove "s3://" prefix from EnvironmentInstanceFiles
@@ -218,7 +218,7 @@ Resources:
       BootstrapActions:
         - Name: Run-Python-Jupyter
           ScriptBootstrapAction:
-            Path: s3://us-east-1.elasticmapreduce/bootstrap-actions/run-if
+            Path: !Sub 's3://${AWS::Region}.elasticmapreduce/bootstrap-actions/run-if'
             Args:
               - 'instance.isMaster=true'
               - '/opt/hail-on-AWS-spot-instances/src/jupyter_run.sh'


### PR DESCRIPTION
Issue #, if available:
* https://github.com/awslabs/service-workbench-on-aws/pull/278
* https://github.com/awslabs/service-workbench-on-aws/issues/123

Description of changes:
* Without this change, provisioning of EMR cluster doesn't work in certain regions. EMR provisioning failed for me in ap-northeast-2 (Seoul) region
* Specifying the region in S3 arn and url ensures that cluster was provisioned successfully

![image](https://user-images.githubusercontent.com/68876606/111535002-3ad1b780-872e-11eb-917a-edad3ff87213.png)


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.