### PR TITLE
fix: Add 'reachable' and 'error' status to reachability check schema

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-reachability-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-reachability-service.test.js
@@ -73,6 +73,38 @@ describe('DataSourceBucketService', () => {
   });
 
   describe('reach scenarios', () => {
+    it('calls attemptReach for wildcard without any errors if status is reachable', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const params = { id: '*', status: 'reachable' };
+
+      service.bulkReach = jest.fn();
+
+      await service.attemptReach(requestContext, params);
+
+      expect(service.bulkReach).toHaveBeenCalledWith(
+        requestContext,
+        { status: params.status },
+        { forceCheckAll: false },
+      );
+    });
+
+    it('calls attemptReach for wildcard without any errors if status is error', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid } };
+      const params = { id: '*', status: 'error' };
+
+      service.bulkReach = jest.fn();
+
+      await service.attemptReach(requestContext, params);
+
+      expect(service.bulkReach).toHaveBeenCalledWith(
+        requestContext,
+        { status: params.status },
+        { forceCheckAll: false },
+      );
+    });
+
     it('calls attemptReach for wildcard without any errors', async () => {
       const uid = 'u-currentUserId';
       const requestContext = { principalIdentifier: { uid } };

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/attempt-reach-data-source.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/attempt-reach-data-source.json
@@ -15,7 +15,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["active", "inactive", "pending", "*"]
+      "enum": ["active", "inactive", "pending", "error", "reachable", "*"]
     }
   },
   "required": ["id"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3056,6 +3056,13 @@ components:
           example: 'study'
         status:
           type: string
+          enum:
+            - active
+            - inactive
+            - pending
+            - error
+            - reachable
+            - *
           description: id must be * when status is specified
     RegisterStudy:
       type: object


### PR DESCRIPTION
Issue #, if available:

Description of changes:
1. State `error` is valid when studies are [unreachable](https://github.com/awslabs/service-workbench-on-aws/blob/develop/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-reachability-service.js#L204). Our [handler](https://github.com/awslabs/service-workbench-on-aws/blob/4b5928ebbbd837d2e20781a213c2fcb630fbdd95/main/solution/backend/src/lambdas/data-source-reachability/handler.js#L41) also uses discovers unreachable studies using this filter
2. State `reachable` is added for [reachable](https://github.com/awslabs/service-workbench-on-aws/blob/develop/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-reachability-service.js#L200) studies. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.