### PR TITLE
refactor: remove lax permissions for cross acct exec

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -177,7 +177,114 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}'
 
-  # TODO lock these permissions down further
+  PolicyCrossAccountExecution:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:CreateStack
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/SC-*'
+          - Effect: Allow
+            Action:
+              - sagemaker:CreatePresignedNotebookInstanceUrl
+              - sagemaker:StartNotebookInstance
+              - sagemaker:StopNotebookInstance
+              - sagemaker:DescribeNotebookInstance
+            Resource: !Sub 'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/basicnotebookinstance-*'
+          - Effect: Allow
+            Action:
+              - iam:GetRole
+              - iam:CreateRole
+              - iam:TagRole
+              - iam:GetRolePolicy
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+              - iam:DeleteRole
+              - iam:PassRole
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
+          - Effect: Allow
+            Action:
+              - iam:AddRoleToInstanceProfile
+              - iam:CreateInstanceProfile
+              - iam:GetInstanceProfile
+              - iam:DeleteInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/SC-*'
+          - Effect: Allow
+            Action:
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
+            Condition:
+              ArnLike:
+                iam:PolicyARN: arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+          - Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+              - iam:PutRolePolicy
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com*/AWSServiceRoleForEMRCleanup*
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - elasticmapreduce.amazonaws.com
+                  - elasticmapreduce.amazonaws.com.cn
+          - Effect: Allow
+            Action:
+              - ce:GetCostAndUsage
+            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+          - Effect: Allow
+            Action:
+              - budgets:ViewBudget
+              - budgets:ModifyBudget
+            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:PutBucketPolicy
+              - s3:DeleteObject
+              - s3:CreateBucket
+            Resource: 'arn:aws:s3:::sc-*'
+          - Effect: Allow
+            Action:
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeInstances
+              - ec2:StartInstances
+              - ec2:StopInstances
+            Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
+          - Effect: Allow
+            Action:
+              - ec2:DescribeSubnets
+              - ec2:DescribeVpcs
+              - ec2:DescribeNetworkInterfaces
+            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource: 
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+          - Effect: Allow
+            Action:
+              - elasticmapreduce:CreateSecurityConfiguration
+              - elasticmapreduce:DeleteSecurityConfiguration
+              - elasticmapreduce:DescribeCluster
+              - elasticmapreduce:RunJobFlow
+              - elasticmapreduce:TerminateJobFlows
+            Resource: 
+              - !Sub 'arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*'
+
   CrossAccountExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -197,120 +304,9 @@ Resources:
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
-      Policies:
-        - PolicyName: cfn-access
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - cloudformation:CreateStack
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeStackEvents
-                Resource: '*'
-        - PolicyName: sagemaker-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - sagemaker:*
-              Resource: '*'
-        - PolicyName: iam-role-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:GetRole
-                - iam:CreateRole
-                - iam:TagRole
-                - iam:GetRolePolicy
-                - iam:PutRolePolicy
-                - iam:DeleteRolePolicy
-                - iam:DeleteRole
-                - iam:PassRole
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-        - PolicyName: iam-instance-profile-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:AddRoleToInstanceProfile
-                - iam:CreateInstanceProfile
-                - iam:GetInstanceProfile
-                - iam:DeleteInstanceProfile
-                - iam:RemoveRoleFromInstanceProfile
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
-        - PolicyName: iam-role-service-policy-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:AttachRolePolicy
-                - iam:DetachRolePolicy
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-              Condition:
-                ArnLike:
-                  iam:PolicyARN: arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-        - PolicyName: iam-service-linked-role-create-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:CreateServiceLinkedRole
-                - iam:PutRolePolicy
-              Resource: arn:aws:iam::*:role/aws-service-role/elasticmapreduce.amazonaws.com*/AWSServiceRoleForEMRCleanup*
-              Condition:
-                StringLike:
-                  iam:AWSServiceName:
-                    - elasticmapreduce.amazonaws.com
-                    - elasticmapreduce.amazonaws.com.cn
-        - PolicyName: cost-explorer-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ce:*
-              Resource: '*'
-        - PolicyName: budget-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - budgets:ViewBudget
-                - budgets:ModifyBudget
-              Resource: '*'
-        - PolicyName: s3-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - s3:*
-              Resource: '*'
-        - PolicyName: ec2-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ec2:*
-              Resource: '*'
-        - PolicyName: ssm-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ssm:*
-              Resource: '*'
-        - PolicyName: emr-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - elasticmapreduce:*
-              Resource: '*'
+      ManagedPolicyArns:
+        - !Ref PolicyCrossAccountExecution
+      PermissionsBoundary: !Ref PolicyCrossAccountExecution
 
   # VPC for launching EMR clusters into
   # Just one AZ as we're aiming for transient low-cost clusters rather than HA
@@ -408,6 +404,110 @@ Resources:
     Properties:
       AliasName: !Join ['', ['alias/', Ref: Namespace, '-encryption-key']]
       TargetKeyId: !Ref EncryptionKey
+
+  CloudTrailBucket: 
+    DeletionPolicy: Retain
+    Type: AWS::S3::Bucket
+    Properties: 
+      BucketName: !Join ['-', ['swb', 'cloudtrail-log-bucket', Ref: AWS::AccountId]]
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  CloudTrailBucketPolicy: 
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket: 
+        Ref: CloudTrailBucket
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - 
+            Sid: "AWSCloudTrailAclCheck"
+            Effect: "Allow"
+            Principal: 
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:GetBucketAcl"
+            Resource: 
+              !Sub |-
+                arn:aws:s3:::${CloudTrailBucket}
+          - 
+            Sid: "AWSCloudTrailWrite"
+            Effect: "Allow"
+            Principal: 
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:PutObject"
+            Resource:
+              !Sub |-
+                arn:aws:s3:::${CloudTrailBucket}/AWSLogs/${AWS::AccountId}/*
+            Condition: 
+              StringEquals:
+                s3:x-amz-acl: "bucket-owner-full-control"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 365
+
+  CloudTrailLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-role']]
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: cloudtrail.amazonaws.com
+        Version: '2012-10-17'
+
+  CloudTrailLogsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Action:
+          - logs:PutLogEvents
+          - logs:CreateLogStream
+          Effect: Allow
+          Resource:
+            Fn::GetAtt:
+            - LogGroup
+            - Arn
+        Version: '2012-10-17'
+      PolicyName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-logs-policy']]
+      Roles:
+      - Ref: CloudTrailLogsRole
+
+  CloudTrail:
+    Type: AWS::CloudTrail::Trail
+    Properties:
+      IsLogging: true
+      EnableLogFileValidation: true
+      TrailName : !Join ['-', ['swb', 'initial-stack', 'default-cloudtrail']]
+      Tags:
+        - Key: Name
+          Value: !Sub Cloudtrail for ${AWS::AccountId}
+      S3BucketName: 
+          Ref: CloudTrailBucket
+      CloudWatchLogsLogGroupArn:
+        Fn::GetAtt:
+        - LogGroup
+        - Arn
+      CloudWatchLogsRoleArn:
+        Fn::GetAtt:
+        - CloudTrailLogsRole
+        - Arn
+    DependsOn:
+    - CloudTrailBucketPolicy
+    - CloudTrailLogsPolicy
+    - CloudTrailLogsRole
 
 Outputs:
   CrossAccountEnvMgmtRoleArn:


### PR DESCRIPTION
Issue #, if available:
GALI-779

Description of changes:
Restrict cross-account role

Restrict actions and resources to cross-account-role using CloudTrail. Note that majorly this role is needed for following features
- cost-service
- budget-service
- environment-service (unused, consider removing all these actions after internal discussion)
- environment-sc-service
- Change state of the environment (EC2 start/stop, SageMaker start/stop)
- Update IAM Role Policy (mainly of EC2 instances based on study permissions)
- study-operations
- environment-mount-service
- Define a permission boundary for this role

Tests performed:
 - Prior to re-onboarding member account
   - Out of the box workspace type instances were provisioned, with and without studies
   - Budget was assigned
   - Personal, BYOB, and Org Studies were created
 - After re-onboarding member account
   - Verified existing and newly provisioned workspaces were still accessible along with their mounted studies (honoring study permissions)
   - Workspaces underwent Start/Stop/Terminate/Auto-stop operations as expected [WIP]
   - Verified budget could be modified
   - New Personal, BYOB, and Org Studies could still be created

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.