### PR TITLE
chore: Enable SSE-S3 when registering buckets in BYOB

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/data-sources/register/operations/RegisterBucket.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/data-sources/register/operations/RegisterBucket.js
@@ -25,11 +25,14 @@ class RegisterBucketOperation extends Operation {
     this.bucket = bucket;
     this.name = `Registering bucket ${bucket.name}`;
     this.accountsStore = accountsStore;
+    if (this.bucket.kmsArn === '') {
+      delete this.bucket.kmsArn;
+    }
   }
 
   async doRun() {
     const { name } = this.bucket;
-    this.setMessage(`Registering bucket${name}`);
+    this.setMessage(`Registering bucket ${name}`);
     try {
       await this.accountsStore.registerBucket(this.accountId, this.bucket);
       this.setMessage(`Successfully registered bucket ${name}`);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
@@ -156,7 +156,7 @@ describe('DataSourceBucketService', () => {
       );
     });
 
-    it('fails because kmsArn is empty', async () => {
+    it('fails because kmsArn is empty with kms as sse', async () => {
       const uid = 'u-currentUserId';
       const requestContext = { principalIdentifier: { uid }, principal: { isAdmin: true, status: 'active' } };
       const id = '123456789012';
@@ -167,6 +167,24 @@ describe('DataSourceBucketService', () => {
         kmsArn: '',
         access: 'roles',
         sse: 'kms',
+      };
+
+      await expect(service.register(requestContext, { id }, rawData)).rejects.toThrow(
+        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
+      );
+    });
+
+    it('fails because kmsArn is empty with s3 as sse', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid }, principal: { isAdmin: true, status: 'active' } };
+      const id = '123456789012';
+      const rawData = {
+        name: 'bucket-1',
+        region: 'us-east-1',
+        awsPartition: 'aws',
+        kmsArn: '',
+        access: 'roles',
+        sse: 's3',
       };
 
       await expect(service.register(requestContext, { id }, rawData)).rejects.toThrow(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
@@ -156,6 +156,24 @@ describe('DataSourceBucketService', () => {
       );
     });
 
+    it('fails because kmsArn is empty', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid }, principal: { isAdmin: true, status: 'active' } };
+      const id = '123456789012';
+      const rawData = {
+        name: 'bucket-1',
+        region: 'us-east-1',
+        awsPartition: 'aws',
+        kmsArn: '',
+        access: 'roles',
+        sse: 'kms',
+      };
+
+      await expect(service.register(requestContext, { id }, rawData)).rejects.toThrow(
+        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
+      );
+    });
+
     it('fails because name is long', async () => {
       const uid = 'u-currentUserId';
       const requestContext = { principalIdentifier: { uid }, principal: { isAdmin: true, status: 'active' } };

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/data-source-bucket-service.test.js
@@ -82,6 +82,31 @@ describe('DataSourceBucketService', () => {
       );
     });
 
+    it('should call DBService when sse is s3', async () => {
+      const uid = 'u-currentUserId';
+      const requestContext = { principalIdentifier: { uid }, principal: { isAdmin: true, status: 'active' } };
+      const id = '123456789012';
+      const rawData = {
+        name: 'bucket-1',
+        region: 'us-east-1',
+        awsPartition: 'aws',
+        access: 'roles',
+        sse: 's3',
+      };
+
+      await service.register(requestContext, { id }, rawData);
+
+      expect(dbService.table.key).toHaveBeenCalledWith({ pk: `ACT#${id}`, sk: `BUK#${rawData.name}` });
+      expect(dbService.table.item).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ..._.omit(rawData, ['name']),
+          updatedBy: uid,
+          createdBy: uid,
+          rev: 0,
+        }),
+      );
+    });
+
     it('only admins are allowed to create data source bucket', async () => {
       const uid = 'u-currentUserId';
       const requestContext = { principalIdentifier: { uid } };

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-bucket-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-bucket-service.js
@@ -103,11 +103,6 @@ class DataSourceBucketService extends Service {
         true,
       );
 
-    // SSE (server side encryption) using S3 and not KMS is not supported
-    if (rawBucketEntity.sse === 's3') {
-      throw this.boom.notSupported('SSE S3 is not supported', true);
-    }
-
     // kmsArn can only be provide if sse = kms
     if (!_.isEmpty(rawBucketEntity.kmsArn) && rawBucketEntity.sse !== 'kms') {
       throw this.boom.badRequest('KMS arn can only be provided if sse = kms', true);


### PR DESCRIPTION
Issue #, if available: CHAM-77

Description of changes:
* Removed `SSE S3` check from backend
* Remove `kmsArn` from request when it is empty. The field is empty when user selects SSE as `S3` or encryption is disabled
* Verified that `SSE S3` works as expected on both Linux and Windows instances. Tested both read only and read/write scenarios

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.