### PR TITLE
Refactor cross acct exec

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -68,7 +68,7 @@ Resources:
   # This is the role that code (ApiHandlerLambda and WorkflowLoopRunnerLambda) in central account
   # assumes before performing any AWS Service Catalog interactions in this account (the on-boarded account)
   # for launching environments.
-  # Equivalent role for central account is created by "main/solution/backend/config/infra/cloudformation.yml"
+  # Equivalent role for central account is created by 'main/solution/backend/config/infra/cloudformation.yml'
   CrossAccountRoleEnvMgmt:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -182,7 +182,7 @@ Resources:
     Properties:
       Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -243,12 +243,12 @@ Resources:
           - Effect: Allow
             Action:
               - ce:GetCostAndUsage
-            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - budgets:ViewBudget
               - budgets:ModifyBudget
-            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
+            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated-do-not-update'
           - Effect: Allow
             Action:
               - s3:GetObject
@@ -256,20 +256,25 @@ Resources:
               - s3:PutBucketPolicy
               - s3:DeleteObject
               - s3:CreateBucket
-            Resource: 'arn:aws:s3:::sc-*'
+            Resource: 
+              - 'arn:aws:s3:::sc-*'
+              - !Sub 'arn:aws:s3:::swb-cloudtrail-log-bucket-${AWS::AccountId}'
           - Effect: Allow
             Action:
-              - ec2:DescribeInstanceStatus
-              - ec2:DescribeInstances
               - ec2:StartInstances
               - ec2:StopInstances
             Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
           - Effect: Allow
             Action:
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeInstances
+            Resource:'*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+          - Effect: Allow
+            Action:
               - ec2:DescribeSubnets
               - ec2:DescribeVpcs
               - ec2:DescribeNetworkInterfaces
-            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - ssm:GetParameter
@@ -277,13 +282,17 @@ Resources:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
           - Effect: Allow
             Action:
-              - elasticmapreduce:CreateSecurityConfiguration
-              - elasticmapreduce:DeleteSecurityConfiguration
               - elasticmapreduce:DescribeCluster
-              - elasticmapreduce:RunJobFlow
               - elasticmapreduce:TerminateJobFlows
             Resource: 
               - !Sub 'arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*'
+          - Effect: Allow
+            Action:
+              - elasticmapreduce:CreateSecurityConfiguration
+              - elasticmapreduce:DeleteSecurityConfiguration
+              - elasticmapreduce:RunJobFlow
+            Resource: 
+              - '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
 
   CrossAccountExecutionRole:
     Type: 'AWS::IAM::Role'
@@ -426,39 +435,40 @@ Resources:
       Bucket: 
         Ref: CloudTrailBucket
       PolicyDocument: 
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement: 
           - 
-            Sid: "AWSCloudTrailAclCheck"
-            Effect: "Allow"
+            Sid: 'AWSCloudTrailAclCheck'
+            Effect: 'Allow'
             Principal: 
-              Service: "cloudtrail.amazonaws.com"
-            Action: "s3:GetBucketAcl"
+              Service: 'cloudtrail.amazonaws.com'
+            Action: 's3:GetBucketAcl'
             Resource: 
               !Sub |-
                 arn:aws:s3:::${CloudTrailBucket}
           - 
-            Sid: "AWSCloudTrailWrite"
-            Effect: "Allow"
+            Sid: 'AWSCloudTrailWrite'
+            Effect: 'Allow'
             Principal: 
-              Service: "cloudtrail.amazonaws.com"
-            Action: "s3:PutObject"
+              Service: 'cloudtrail.amazonaws.com'
+            Action: 's3:PutObject'
             Resource:
               !Sub |-
                 arn:aws:s3:::${CloudTrailBucket}/AWSLogs/${AWS::AccountId}/*
             Condition: 
               StringEquals:
-                s3:x-amz-acl: "bucket-owner-full-control"
+                s3:x-amz-acl: 'bucket-owner-full-control'
 
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: 'swb-initial-stack-cloudtrail-log-group'
       RetentionInDays: 365
 
   CloudTrailLogsRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-role']]
+      RoleName: 'swb-initial-stack-cloudtrail-role'
       AssumeRolePolicyDocument:
         Statement:
         - Action: sts:AssumeRole
@@ -466,13 +476,19 @@ Resources:
           Principal:
             Service: cloudtrail.amazonaws.com
         Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Ref: CloudTrailLogsPolicy
+      PermissionsBoundary: !Ref CloudTrailLogsPolicy
 
   CloudTrailLogsPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
+      Description: Allows CloudTrail perform logging operations in member account
       PolicyDocument:
+        Version: '2012-10-17'
         Statement:
-        - Action:
+        - Effect: Allow
+          Action:
           - logs:PutLogEvents
           - logs:CreateLogStream
           Effect: Allow
@@ -480,8 +496,6 @@ Resources:
             Fn::GetAtt:
             - LogGroup
             - Arn
-        Version: '2012-10-17'
-      PolicyName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-logs-policy']]
       Roles:
       - Ref: CloudTrailLogsRole
 
@@ -490,7 +504,7 @@ Resources:
     Properties:
       IsLogging: true
       EnableLogFileValidation: true
-      TrailName : !Join ['-', ['swb', 'initial-stack', 'default-cloudtrail']]
+      TrailName : 'swb-initial-stack-default-cloudtrail'
       Tags:
         - Key: Name
           Value: !Sub Cloudtrail for ${AWS::AccountId}

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -177,7 +177,114 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}'
 
-  # TODO lock these permissions down further
+  PolicyCrossAccountExecution:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:CreateStack
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/SC-*'
+          - Effect: Allow
+            Action:
+              - sagemaker:CreatePresignedNotebookInstanceUrl
+              - sagemaker:StartNotebookInstance
+              - sagemaker:StopNotebookInstance
+              - sagemaker:DescribeNotebookInstance
+            Resource: !Sub 'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/basicnotebookinstance-*'
+          - Effect: Allow
+            Action:
+              - iam:GetRole
+              - iam:CreateRole
+              - iam:TagRole
+              - iam:GetRolePolicy
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+              - iam:DeleteRole
+              - iam:PassRole
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
+          - Effect: Allow
+            Action:
+              - iam:AddRoleToInstanceProfile
+              - iam:CreateInstanceProfile
+              - iam:GetInstanceProfile
+              - iam:DeleteInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/SC-*'
+          - Effect: Allow
+            Action:
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
+            Condition:
+              ArnLike:
+                iam:PolicyARN: arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+          - Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+              - iam:PutRolePolicy
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com*/AWSServiceRoleForEMRCleanup*
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - elasticmapreduce.amazonaws.com
+                  - elasticmapreduce.amazonaws.com.cn
+          - Effect: Allow
+            Action:
+              - ce:GetCostAndUsage
+            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+          - Effect: Allow
+            Action:
+              - budgets:ViewBudget
+              - budgets:ModifyBudget
+            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:PutBucketPolicy
+              - s3:DeleteObject
+              - s3:CreateBucket
+            Resource: 'arn:aws:s3:::sc-*'
+          - Effect: Allow
+            Action:
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeInstances
+              - ec2:StartInstances
+              - ec2:StopInstances
+            Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
+          - Effect: Allow
+            Action:
+              - ec2:DescribeSubnets
+              - ec2:DescribeVpcs
+              - ec2:DescribeNetworkInterfaces
+            Resource: '*' # The actions listed above do not support resource-level permissions and requires all resources to be chosen
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource: 
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+          - Effect: Allow
+            Action:
+              - elasticmapreduce:CreateSecurityConfiguration
+              - elasticmapreduce:DeleteSecurityConfiguration
+              - elasticmapreduce:DescribeCluster
+              - elasticmapreduce:RunJobFlow
+              - elasticmapreduce:TerminateJobFlows
+            Resource: 
+              - !Sub 'arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*'
+
   CrossAccountExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -197,120 +304,9 @@ Resources:
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
-      Policies:
-        - PolicyName: cfn-access
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - cloudformation:CreateStack
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeStackEvents
-                Resource: '*'
-        - PolicyName: sagemaker-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - sagemaker:*
-              Resource: '*'
-        - PolicyName: iam-role-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:GetRole
-                - iam:CreateRole
-                - iam:TagRole
-                - iam:GetRolePolicy
-                - iam:PutRolePolicy
-                - iam:DeleteRolePolicy
-                - iam:DeleteRole
-                - iam:PassRole
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-        - PolicyName: iam-instance-profile-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:AddRoleToInstanceProfile
-                - iam:CreateInstanceProfile
-                - iam:GetInstanceProfile
-                - iam:DeleteInstanceProfile
-                - iam:RemoveRoleFromInstanceProfile
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
-        - PolicyName: iam-role-service-policy-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:AttachRolePolicy
-                - iam:DetachRolePolicy
-              Resource:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-              Condition:
-                ArnLike:
-                  iam:PolicyARN: arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-        - PolicyName: iam-service-linked-role-create-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - iam:CreateServiceLinkedRole
-                - iam:PutRolePolicy
-              Resource: arn:aws:iam::*:role/aws-service-role/elasticmapreduce.amazonaws.com*/AWSServiceRoleForEMRCleanup*
-              Condition:
-                StringLike:
-                  iam:AWSServiceName:
-                    - elasticmapreduce.amazonaws.com
-                    - elasticmapreduce.amazonaws.com.cn
-        - PolicyName: cost-explorer-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ce:*
-              Resource: '*'
-        - PolicyName: budget-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - budgets:ViewBudget
-                - budgets:ModifyBudget
-              Resource: '*'
-        - PolicyName: s3-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - s3:*
-              Resource: '*'
-        - PolicyName: ec2-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ec2:*
-              Resource: '*'
-        - PolicyName: ssm-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - ssm:*
-              Resource: '*'
-        - PolicyName: emr-access
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - elasticmapreduce:*
-              Resource: '*'
+      ManagedPolicyArns:
+        - !Ref PolicyCrossAccountExecution
+      PermissionsBoundary: !Ref PolicyCrossAccountExecution
 
   # VPC for launching EMR clusters into
   # Just one AZ as we're aiming for transient low-cost clusters rather than HA
@@ -408,6 +404,110 @@ Resources:
     Properties:
       AliasName: !Join ['', ['alias/', Ref: Namespace, '-encryption-key']]
       TargetKeyId: !Ref EncryptionKey
+
+  CloudTrailBucket: 
+    DeletionPolicy: Retain
+    Type: AWS::S3::Bucket
+    Properties: 
+      BucketName: !Join ['-', ['swb', 'cloudtrail-log-bucket', Ref: AWS::AccountId]]
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  CloudTrailBucketPolicy: 
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket: 
+        Ref: CloudTrailBucket
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - 
+            Sid: "AWSCloudTrailAclCheck"
+            Effect: "Allow"
+            Principal: 
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:GetBucketAcl"
+            Resource: 
+              !Sub |-
+                arn:aws:s3:::${CloudTrailBucket}
+          - 
+            Sid: "AWSCloudTrailWrite"
+            Effect: "Allow"
+            Principal: 
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:PutObject"
+            Resource:
+              !Sub |-
+                arn:aws:s3:::${CloudTrailBucket}/AWSLogs/${AWS::AccountId}/*
+            Condition: 
+              StringEquals:
+                s3:x-amz-acl: "bucket-owner-full-control"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 365
+
+  CloudTrailLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-role']]
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: cloudtrail.amazonaws.com
+        Version: '2012-10-17'
+
+  CloudTrailLogsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Action:
+          - logs:PutLogEvents
+          - logs:CreateLogStream
+          Effect: Allow
+          Resource:
+            Fn::GetAtt:
+            - LogGroup
+            - Arn
+        Version: '2012-10-17'
+      PolicyName: !Join ['-', ['swb', 'initial-stack', 'cloudtrail-logs-policy']]
+      Roles:
+      - Ref: CloudTrailLogsRole
+
+  CloudTrail:
+    Type: AWS::CloudTrail::Trail
+    Properties:
+      IsLogging: true
+      EnableLogFileValidation: true
+      TrailName : !Join ['-', ['swb', 'initial-stack', 'default-cloudtrail']]
+      Tags:
+        - Key: Name
+          Value: !Sub Cloudtrail for ${AWS::AccountId}
+      S3BucketName: 
+          Ref: CloudTrailBucket
+      CloudWatchLogsLogGroupArn:
+        Fn::GetAtt:
+        - LogGroup
+        - Arn
+      CloudWatchLogsRoleArn:
+        Fn::GetAtt:
+        - CloudTrailLogsRole
+        - Arn
+    DependsOn:
+    - CloudTrailBucketPolicy
+    - CloudTrailLogsPolicy
+    - CloudTrailLogsRole
 
 Outputs:
   CrossAccountEnvMgmtRoleArn:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -207,9 +207,7 @@ Resources:
               - iam:DeleteRole
               - iam:PassRole
               - iam:PutRolePolicy
-            Resource:
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
           - Effect: Allow
             Action:
               - ce:GetCostAndUsage

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -177,52 +177,6 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}'
 
-  PolicyCrossAccountRoleManagement:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Description: Allows main account to perform IAM role management on restricted resources
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - 's3:GetBucketPolicy'
-              - 's3:GetObjectTagging'
-              - 's3:GetObjectTorrent'
-              - 's3:GetObjectVersion'
-              - 's3:GetObjectVersionTagging'
-              - 's3:GetObjectVersionTorrent'
-              - 's3:AbortMultipartUpload'
-              - 's3:ListMultipartUploadParts'
-              - 's3:PutObject'
-              - 's3:PutObjectAcl'
-              - 's3:PutObjectTagging'
-              - 's3:PutObjectVersionTagging'
-              - 's3:DeleteObject'
-              - 's3:DeleteObjectTagging'
-              - 's3:DeleteObjectVersion'
-              - 's3:DeleteObjectVersionTagging'
-            Resource: 
-              - 'arn:aws:s3:::sc-*'
-          - Effect: Allow
-            Action:
-              - 's3:ListBucket'
-              - 's3:ListBucketVersions'
-            Resource: 
-              - 'arn:aws:s3:::sc-*'
-          - Effect: Allow
-            Action:
-              - 'kms:DescribeKey'
-              - 'kms:Encrypt'
-              - 'kms:Decrypt'
-              - 'kms:ReEncrypt*'
-              - 'kms:GenerateDataKey'
-              - 'kms:GenerateDataKeyWithoutPlaintext'
-              - 'kms:CreateGrant'
-              - 'kms:RevokeGrant'
-            Resource: 
-              - !Ref 'arn:aws:kms:{AWS::Region}:{AWS::AccountId}:key/*'
-
   PolicyCrossAccountExecution:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -252,28 +206,10 @@ Resources:
               - iam:DeleteRolePolicy
               - iam:DeleteRole
               - iam:PassRole
-            Resource:
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
-          - Effect: Allow
-            Action:
               - iam:PutRolePolicy
             Resource:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
-            Condition:
-              StringEquals:
-                iam:PermissionsBoundary: PolicyCrossAccountRoleManagement
-          - Effect: Allow
-            Action:
-              - iam:AddRoleToInstanceProfile
-              - iam:CreateInstanceProfile
-              - iam:GetInstanceProfile
-              - iam:DeleteInstanceProfile
-              - iam:RemoveRoleFromInstanceProfile
-            Resource:
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/analysis-*'
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/SC-*'
           - Effect: Allow
             Action:
               - iam:AttachRolePolicy

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -177,6 +177,52 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}'
 
+  PolicyCrossAccountRoleManagement:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows main account to perform IAM role management on restricted resources
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:GetBucketPolicy'
+              - 's3:GetObjectTagging'
+              - 's3:GetObjectTorrent'
+              - 's3:GetObjectVersion'
+              - 's3:GetObjectVersionTagging'
+              - 's3:GetObjectVersionTorrent'
+              - 's3:AbortMultipartUpload'
+              - 's3:ListMultipartUploadParts'
+              - 's3:PutObject'
+              - 's3:PutObjectAcl'
+              - 's3:PutObjectTagging'
+              - 's3:PutObjectVersionTagging'
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectTagging'
+              - 's3:DeleteObjectVersion'
+              - 's3:DeleteObjectVersionTagging'
+            Resource: 
+              - 'arn:aws:s3:::sc-*'
+          - Effect: Allow
+            Action:
+              - 's3:ListBucket'
+              - 's3:ListBucketVersions'
+            Resource: 
+              - 'arn:aws:s3:::sc-*'
+          - Effect: Allow
+            Action:
+              - 'kms:DescribeKey'
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey'
+              - 'kms:GenerateDataKeyWithoutPlaintext'
+              - 'kms:CreateGrant'
+              - 'kms:RevokeGrant'
+            Resource: 
+              - !Ref 'arn:aws:kms:{AWS::Region}:{AWS::AccountId}:key/*'
+
   PolicyCrossAccountExecution:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -201,16 +247,23 @@ Resources:
           - Effect: Allow
             Action:
               - iam:GetRole
-              - iam:CreateRole
               - iam:TagRole
               - iam:GetRolePolicy
-              - iam:PutRolePolicy
               - iam:DeleteRolePolicy
               - iam:DeleteRole
               - iam:PassRole
             Resource:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
+          - Effect: Allow
+            Action:
+              - iam:PutRolePolicy
+            Resource:
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
+            Condition:
+              StringEquals:
+                iam:PermissionsBoundary: PolicyCrossAccountRoleManagement
           - Effect: Allow
             Action:
               - iam:AddRoleToInstanceProfile
@@ -253,12 +306,12 @@ Resources:
             Action:
               - s3:GetObject
               - s3:ListBucket
+              - s3:GetBucketPolicy
               - s3:PutBucketPolicy
               - s3:DeleteObject
               - s3:CreateBucket
             Resource: 
               - 'arn:aws:s3:::sc-*'
-              - !Sub 'arn:aws:s3:::swb-cloudtrail-log-bucket-${AWS::AccountId}'
           - Effect: Allow
             Action:
               - ec2:StartInstances
@@ -268,7 +321,7 @@ Resources:
             Action:
               - ec2:DescribeInstanceStatus
               - ec2:DescribeInstances
-            Resource:'*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - ec2:DescribeSubnets
@@ -413,115 +466,6 @@ Resources:
     Properties:
       AliasName: !Join ['', ['alias/', Ref: Namespace, '-encryption-key']]
       TargetKeyId: !Ref EncryptionKey
-
-  CloudTrailBucket: 
-    DeletionPolicy: Retain
-    Type: AWS::S3::Bucket
-    Properties: 
-      BucketName: !Join ['-', ['swb', 'cloudtrail-log-bucket', Ref: AWS::AccountId]]
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-
-  CloudTrailBucketPolicy: 
-    Type: AWS::S3::BucketPolicy
-    Properties: 
-      Bucket: 
-        Ref: CloudTrailBucket
-      PolicyDocument: 
-        Version: '2012-10-17'
-        Statement: 
-          - 
-            Sid: 'AWSCloudTrailAclCheck'
-            Effect: 'Allow'
-            Principal: 
-              Service: 'cloudtrail.amazonaws.com'
-            Action: 's3:GetBucketAcl'
-            Resource: 
-              !Sub |-
-                arn:aws:s3:::${CloudTrailBucket}
-          - 
-            Sid: 'AWSCloudTrailWrite'
-            Effect: 'Allow'
-            Principal: 
-              Service: 'cloudtrail.amazonaws.com'
-            Action: 's3:PutObject'
-            Resource:
-              !Sub |-
-                arn:aws:s3:::${CloudTrailBucket}/AWSLogs/${AWS::AccountId}/*
-            Condition: 
-              StringEquals:
-                s3:x-amz-acl: 'bucket-owner-full-control'
-
-  LogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: 'swb-initial-stack-cloudtrail-log-group'
-      RetentionInDays: 365
-
-  CloudTrailLogsRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: 'swb-initial-stack-cloudtrail-role'
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action: sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service: cloudtrail.amazonaws.com
-        Version: '2012-10-17'
-      ManagedPolicyArns:
-        - Ref: CloudTrailLogsPolicy
-      PermissionsBoundary: !Ref CloudTrailLogsPolicy
-
-  CloudTrailLogsPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Description: Allows CloudTrail perform logging operations in member account
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Action:
-          - logs:PutLogEvents
-          - logs:CreateLogStream
-          Effect: Allow
-          Resource:
-            Fn::GetAtt:
-            - LogGroup
-            - Arn
-      Roles:
-      - Ref: CloudTrailLogsRole
-
-  CloudTrail:
-    Type: AWS::CloudTrail::Trail
-    Properties:
-      IsLogging: true
-      EnableLogFileValidation: true
-      TrailName : 'swb-initial-stack-default-cloudtrail'
-      Tags:
-        - Key: Name
-          Value: !Sub Cloudtrail for ${AWS::AccountId}
-      S3BucketName: 
-          Ref: CloudTrailBucket
-      CloudWatchLogsLogGroupArn:
-        Fn::GetAtt:
-        - LogGroup
-        - Arn
-      CloudWatchLogsRoleArn:
-        Fn::GetAtt:
-        - CloudTrailLogsRole
-        - Arn
-    DependsOn:
-    - CloudTrailBucketPolicy
-    - CloudTrailLogsPolicy
-    - CloudTrailLogsRole
 
 Outputs:
   CrossAccountEnvMgmtRoleArn:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -212,25 +212,6 @@ Resources:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/SC-*'
           - Effect: Allow
             Action:
-              - iam:AttachRolePolicy
-              - iam:DetachRolePolicy
-            Resource:
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
-            Condition:
-              ArnLike:
-                iam:PolicyARN: arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-          - Effect: Allow
-            Action:
-              - iam:CreateServiceLinkedRole
-              - iam:PutRolePolicy
-            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com*/AWSServiceRoleForEMRCleanup*
-            Condition:
-              StringLike:
-                iam:AWSServiceName:
-                  - elasticmapreduce.amazonaws.com
-                  - elasticmapreduce.amazonaws.com.cn
-          - Effect: Allow
-            Action:
               - ce:GetCostAndUsage
             Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
@@ -238,16 +219,6 @@ Resources:
               - budgets:ViewBudget
               - budgets:ModifyBudget
             Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
-          - Effect: Allow
-            Action:
-              - s3:GetObject
-              - s3:ListBucket
-              - s3:GetBucketPolicy
-              - s3:PutBucketPolicy
-              - s3:DeleteObject
-              - s3:CreateBucket
-            Resource: 
-              - 'arn:aws:s3:::sc-*'
           - Effect: Allow
             Action:
               - ec2:StartInstances
@@ -267,21 +238,8 @@ Resources:
           - Effect: Allow
             Action:
               - ssm:GetParameter
-            Resource: 
+            Resource:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
-          - Effect: Allow
-            Action:
-              - elasticmapreduce:DescribeCluster
-              - elasticmapreduce:TerminateJobFlows
-            Resource: 
-              - !Sub 'arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*'
-          - Effect: Allow
-            Action:
-              - elasticmapreduce:CreateSecurityConfiguration
-              - elasticmapreduce:DeleteSecurityConfiguration
-              - elasticmapreduce:RunJobFlow
-            Resource: 
-              - '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
 
   CrossAccountExecutionRole:
     Type: 'AWS::IAM::Role'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -237,7 +237,7 @@ Resources:
             Action:
               - budgets:ViewBudget
               - budgets:ModifyBudget
-            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated-do-not-update'
+            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
           - Effect: Allow
             Action:
               - s3:GetObject


### PR DESCRIPTION
Issue #, if available:
GALI-779

Description of changes:
Restrict cross-account role

Restrict actions and resources to cross-account-role using CloudTrail. Note that majorly this role is needed for following features
- cost-service
- budget-service
- environment-service (unused, consider removing all these actions after internal discussion)
- environment-sc-service
- Change state of the environment (EC2 start/stop, SageMaker start/stop)
- Update IAM Role Policy (mainly of EC2 instances based on study permissions)
- study-operations
- environment-mount-service
- Define a permission boundary for this role

Tests performed:
 - Prior to re-onboarding member account
   - Out of the box workspace type instances were provisioned, with and without studies
   - Budget was assigned
   - Personal, BYOB, and Org Studies were created
 - After re-onboarding member account
   - Verified existing and newly provisioned workspaces were still accessible along with their mounted studies (honoring study permissions)
   - Workspaces underwent Start/Stop/Terminate/Auto-stop operations as expected
   - Verified budget could be modified
   - New Personal, BYOB, and Org Studies could still be created

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.