### PR TITLE
feat: add permissions boundary to custom role serverless uses to manage CW log publishing

### DIFF
--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -89,6 +89,39 @@ functions: ${file(./config/infra/functions.yml)}
 resources:
   - Description: Service-Workbench-on-AWS ${self:custom.settings.version} ${self:custom.settings.solutionName} ${self:custom.settings.envName} Backend
   - ${file(./config/infra/cloudformation.yml)}
+  - Resources:
+      # Create a permissions boundary for role serverless creates to manage Cloudwatch access
+      # The default role has permission to create any role and attach any policy. Here we are restricting
+      # the role to only create a specific role and attach only Cloudwatch publishing managed policy
+      ServerlessLogsBoundary:
+        Type: AWS::IAM::ManagedPolicy
+        Properties:
+          Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - apigateway:GET
+                  - apigateway:PATCH
+                Resource: 'arn:aws:apigateway:*::/account'
+              - Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:AttachRolePolicy
+                  - iam:ListAttachedRolePolicies
+                  - iam:PassRole
+                Resource: 'arn:aws:iam::${self:custom.settings.awsAccountInfo.awsAccountId}:role/serverlessApiGatewayCloudWatchRole'
+                Condition:
+                  ArnEqualsIfExists:
+                    iam:PolicyARN: 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
+  - extensions:
+      # Add custom permission boundary to role serverless uses for creating Cloudwatch publishing role
+      IamRoleCustomResourcesLambdaExecution:
+        Properties:
+          PermissionsBoundary: !Ref ServerlessLogsBoundary
+
+
 
 plugins:
   - serverless-webpack

--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -90,13 +90,13 @@ resources:
   - Description: Service-Workbench-on-AWS ${self:custom.settings.version} ${self:custom.settings.solutionName} ${self:custom.settings.envName} Backend
   - ${file(./config/infra/cloudformation.yml)}
   - Resources:
-      # Create a permissions boundary for role serverless creates to manage Cloudwatch access
+      # Create a permissions boundary for role Serverless creates to manage Cloudwatch access
       # The default role has permission to create any role and attach any policy. Here we are restricting
       # the role to only create a specific role and attach only Cloudwatch publishing managed policy
       ServerlessLogsBoundary:
         Type: AWS::IAM::ManagedPolicy
         Properties:
-          Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
+          Description: Allows serverless to manage CloudWatch publishing
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -104,7 +104,7 @@ resources:
                 Action:
                   - apigateway:GET
                   - apigateway:PATCH
-                Resource: 'arn:aws:apigateway:*::/account'
+                Resource: 'arn:aws:apigateway:${self:custom.settings.awsRegion}::/account'
               - Effect: Allow
                 Action:
                   - iam:CreateRole

--- a/main/solution/machine-images/assumerole.json
+++ b/main/solution/machine-images/assumerole.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::363460477264:root"
+        ]
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}

--- a/main/solution/machine-images/policy.json
+++ b/main/solution/machine-images/policy.json
@@ -1,0 +1,14 @@
+{ 
+   "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Issue #, if available: GALI-725

Description of changes:
1. Add permissions boundary to custom role that `serverless` uses for managing CW access
2. Restrict the permissions boundary to specific role and policy while performing `iam` operations

Testing done:
1. Verified that the stack was updated successfully with permissions boundary and log publishing worked
2. Verified that new stack can be created successfully and log publishing works. Steps performed:
     1. I tested this by removing logs configuration in serverless.yml and performed the deployment.
     2. The log removal ended up deleting all the log publishing related resources like role, log group and lambda function. Note that I had to manually delete the actual CW publishing role.
     3. Once resources were deleted, I redeployed the change in PR and verified that appropriate roles, log group, and lambda function were created and log publishing worked correctly
3. Also assumed the role from AWS CLI and verified that I wasn't able to perform any operations outside the specific role and policy in the boundary.
```
aws iam attach-role-policy --role-name serverlessApiGatewayCloudWatchRole --policy-arn arn:aws:iam::aws:policy/aws-service-role/AccessAnalyzerServiceRolePolicy

An error occurred (AccessDenied) when calling the AttachRolePolicy operation: User: arn:aws:sts::|AccountId Hidden|:assumed-role/jeetend-or-raas-backend-IamRoleCustomResourcesLamb-96MXL2DA7NKB/serverless-cw-role is not authorized to perform: iam:AttachRolePolicy on resource: role serverlessApiGatewayCloudWatchRole

aws iam attach-role-policy --role-name serverlessApiGatewayCloudWatchRole --policy-arn arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs

<<No Error>>
```

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.