### PR TITLE
refactor: handling main acct as member scenario

### DIFF
--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -422,6 +422,7 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/swb-*'
               - 'arn:aws:iam::*:role/analysis-*'
+              - 'arn:aws:iam::${AWS::AccountId}:role/*' # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
           - Effect: Allow
             Action:
               - logs:CreateLog*

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -422,7 +422,9 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/swb-*'
               - 'arn:aws:iam::*:role/analysis-*'
-              - 'arn:aws:iam::${AWS::AccountId}:role/*' # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
+              # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
+              - 'arn:aws:iam::${AWS::AccountId}:role/*-cross-account-role'
+              - 'arn:aws:iam::${AWS::AccountId}:role/*-xacc-env-mgmt'
           - Effect: Allow
             Action:
               - logs:CreateLog*
@@ -566,6 +568,9 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/analysis-*'
               - 'arn:aws:iam::*:role/swb-*'
+              # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
+              - 'arn:aws:iam::${AWS::AccountId}:role/*-cross-account-role'
+              - 'arn:aws:iam::${AWS::AccountId}:role/*-xacc-env-mgmt'
           - Effect: Allow
             Action:
               - logs:CreateLog*

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -422,7 +422,7 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/swb-*'
               - 'arn:aws:iam::*:role/analysis-*'
-              # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
+              # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
               - 'arn:aws:iam::${AWS::AccountId}:role/*-cross-account-role'
               - 'arn:aws:iam::${AWS::AccountId}:role/*-xacc-env-mgmt'
           - Effect: Allow
@@ -568,7 +568,7 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/analysis-*'
               - 'arn:aws:iam::*:role/swb-*'
-              # This is required since when users onboard the main account as a member account, so the onboard CFN stack would also reside there
+              # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
               - 'arn:aws:iam::${AWS::AccountId}:role/*-cross-account-role'
               - 'arn:aws:iam::${AWS::AccountId}:role/*-xacc-env-mgmt'
           - Effect: Allow


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Adding permission for the scenario when main account is onboarded as a member account.

This solves the integration test error on GH actions. For test failures, the root cause was as follows:
`AccessDenied: User: arn:aws:sts::<mainAccountId>:assumed-role/e2etest-va-swb-ApiHandler/e2etest-local-dev is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::<mainAccountId>:role/e2etest-cross-account-role`


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.