### PR TITLE
docs: add note for pipeline redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - chore: team email removed from feedback section in readme
 - chore: updates to npm dependencies
 
-To fully incorporate the fix made to CI/CD pipeline, please redeploy the pipeline stack by following the steps listed on the `main/cicd/README.md` file.
+If you have been using CI/CD pipeline, please redeploy the pipeline stack to incorporate this fix by following the steps listed on the `main/cicd/README.md` file.
 
 ## [2.1.1] - 2021-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - chore: team email removed from feedback section in readme
 - chore: updates to npm dependencies
 
+To fully incorporate the fix made to CI/CD pipeline, please redeploy the pipeline stack by following the steps listed on the `main/cicd/README.md` file.
+
 ## [2.1.1] - 2021-03-19
 
 ### Added


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Adding reminder note for CI/CD pipeline redeploy.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.