### PR TITLE
chore: Update aws sdk depencdeny to be ^2.647.0

### DIFF
--- a/addons/addon-base/packages/services/package.json
+++ b/addons/addon-base/packages/services/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@aws-ee/base-services-container": "workspace:*",
     "ajv": "^6.11.0",
-    "aws-sdk": "^2.7.15",
+    "aws-sdk": "^2.647.0",
     "aws-xray-sdk": "^3.2.0",
     "cycle": "^1.0.3",
     "jsonwebtoken": "^8.5.1",

--- a/main/solution/backend/package.json
+++ b/main/solution/backend/package.json
@@ -28,7 +28,7 @@
     "@aws-ee/base-workflow-core": "workspace:*",
     "@aws-ee/base-workflow-steps": "workspace:*",
     "services": "workspace:*",
-    "aws-sdk": "^2.7.15",
+    "aws-sdk": "^2.647.0",
     "controllers": "workspace:*",
     "js-yaml": "^3.13.1",
     "jwt-decode": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,7 +1298,7 @@ importers:
     specifiers:
       '@aws-ee/base-services-container': 'workspace:*'
       ajv: ^6.11.0
-      aws-sdk: ^2.7.15
+      aws-sdk: ^2.647.0
       aws-xray-sdk: ^3.2.0
       cycle: ^1.0.3
       eslint: ^6.8.0
@@ -2074,7 +2074,7 @@ importers:
       '@babel/core': ^7.8.4
       '@babel/plugin-transform-runtime': ^7.8.3
       '@babel/preset-env': ^7.8.4
-      aws-sdk: ^2.7.15
+      aws-sdk: ^2.647.0
       babel-jest: ^24.9.0
       babel-loader: ^8.0.6
       babel-plugin-source-map-support: ^2.1.1


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Checklist:
chore: Update aws sdk depencdeny to be ^2.647.0

Reverting the dependency version back to 2.647.0 since that version is used in the rest of the repo, and that version is also newer than 2.7.15