### PR TITLE
fix: Fix cost dashboard bugs

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/Dashboard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/Dashboard.js
@@ -34,8 +34,8 @@ class Dashboard extends React.Component {
     super(props);
     this.state = {
       totalCost: 0,
-      projNameToTotalCost: {},
-      projNameToUserTotalCost: {},
+      indexNameToTotalCost: {},
+      indexNameToUserTotalCost: {},
       envIdToCostInfo: {},
       envIdToEnvMetadata: {},
       duplicateEnvNames: new Set(),
@@ -46,18 +46,20 @@ class Dashboard extends React.Component {
   async componentDidMount() {
     window.scrollTo(0, 0);
     try {
+      const environmentFn = enableBuiltInWorkspaces ? getEnvironments : getScEnvironments;
+      const getEnvironmentCostFn = enableBuiltInWorkspaces ? getEnvironmentCost : getScEnvironmentCost;
       const {
         totalCost,
-        projNameToTotalCost,
-        projNameToUserTotalCost,
+        indexNameToTotalCost,
+        indexNameToUserTotalCost,
         envIdToCostInfo,
         envIdToEnvMetadata,
         duplicateEnvNames,
-      } = await this.getCosts();
+      } = await getCosts(environmentFn, getEnvironmentCostFn);
       this.setState({
         totalCost,
-        projNameToTotalCost,
-        projNameToUserTotalCost,
+        indexNameToTotalCost,
+        indexNameToUserTotalCost,
         envIdToCostInfo,
         envIdToEnvMetadata,
         duplicateEnvNames,
@@ -111,10 +113,10 @@ class Dashboard extends React.Component {
           <Segment className="bold">No cost data to show</Segment>
         ) : (
           <>
-            <Segment>{this.renderCostPerProj()}</Segment>
+            <Segment>{this.renderCostPerIndex()}</Segment>
             <Segment>{this.renderPastMonthCostPerEnv()}</Segment>
             <Segment>{this.renderYesterdayCostPerEnv()}</Segment>
-            <Segment className="clearfix">{this.renderPastMonthCostPerProjPerUser()}</Segment>
+            <Segment className="clearfix">{this.renderPastMonthCostPerIndexPerUser()}</Segment>
             <Segment className="bold">
               Total cost of all research workspaces for the past 30 days: $
               {Math.round(this.state.totalCost * 100) / 100}
@@ -125,114 +127,14 @@ class Dashboard extends React.Component {
     );
   }
 
-  async getCosts() {
-    const { envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames } = await this.getAccumulatedEnvCost();
-
-    const projNameToUserTotalCost = {};
-    Object.keys(envIdToCostInfo).forEach(envId => {
-      const projName = envIdToEnvMetadata[envId].index;
-      if (projNameToUserTotalCost[projName] === undefined) {
-        projNameToUserTotalCost[projName] = {};
-      }
-      Object.keys(envIdToCostInfo[envId].pastMonthCostByUser).forEach(user => {
-        const currentUserCost = _.get(projNameToUserTotalCost[projName], user, 0);
-        projNameToUserTotalCost[projName][user] = currentUserCost + envIdToCostInfo[envId].pastMonthCostByUser[user];
-      });
-    });
-
-    const projNameToTotalCost = {};
-    let totalCost = 0;
-    Object.keys(projNameToUserTotalCost).forEach(projName => {
-      let indexCost = 0;
-      Object.keys(projNameToUserTotalCost[projName]).forEach(user => {
-        indexCost += projNameToUserTotalCost[projName][user];
-      });
-      totalCost += indexCost;
-      projNameToTotalCost[projName] = indexCost;
-    });
-
-    return {
-      totalCost,
-      projNameToTotalCost,
-      projNameToUserTotalCost,
-      envIdToCostInfo,
-      envIdToEnvMetadata,
-      duplicateEnvNames,
-    };
-  }
-
-  async getAccumulatedEnvCost() {
-    const environments = enableBuiltInWorkspaces ? await getEnvironments() : await getScEnvironments();
-
-    const duplicateEnvNames = new Set();
-    const envNameToEnvId = {};
-    const envIdToEnvMetadata = {};
-    environments.forEach(env => {
-      if (env.isExternal) return;
-      envIdToEnvMetadata[env.id] = {
-        index: env.indexId,
-        name: env.name,
-      };
-      if (envNameToEnvId[env.name] === undefined) {
-        envNameToEnvId[env.name] = env.id;
-      } else {
-        duplicateEnvNames.add(env.name);
-      }
-    });
-
-    const envIds = Object.keys(envIdToEnvMetadata);
-    const envCostPromises = envIds.map(envId => {
-      return enableBuiltInWorkspaces
-        ? getEnvironmentCost(envId, 30, false, true)
-        : getScEnvironmentCost(envId, 30, false, true);
-    });
-
-    const envCostResults = await Promise.all(envCostPromises);
-    const pastMonthCostByUserArray = envCostResults.map(costResult => {
-      const createdByToCost = {};
-      _.forEach(costResult, costDate => {
-        const cost = costDate.cost;
-        Object.keys(cost).forEach(group => {
-          let createdBy = group.split('$')[1];
-          createdBy = createdBy || 'None';
-          const currentUserCost = _.get(createdByToCost, createdBy, 0);
-          createdByToCost[createdBy] = currentUserCost + cost[group].amount;
-        });
-      });
-      return createdByToCost;
-    });
-
-    const yesterdayCostArray = envCostResults.map(costResult => {
-      const yesterdayCost = costResult.length > 0 ? costResult[costResult.length - 1] : {};
-      let totalCost = 0;
-      if (yesterdayCost) {
-        const arrayOfCosts = _.flatMapDeep(yesterdayCost.cost);
-        arrayOfCosts.forEach(cost => {
-          totalCost += cost.amount;
-        });
-      }
-      return totalCost;
-    });
-
-    const envIdToCostInfo = {};
-    for (let i = 0; i < envIds.length; i++) {
-      envIdToCostInfo[envIds[i]] = {
-        pastMonthCostByUser: pastMonthCostByUserArray[i],
-        yesterdayCost: yesterdayCostArray[i],
-      };
-    }
-
-    return { envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames };
-  }
-
-  renderCostPerProj() {
-    if (_.isEmpty(this.state.projNameToTotalCost)) {
+  renderCostPerIndex() {
+    if (_.isEmpty(this.state.indexNameToTotalCost)) {
       return <ProgressPlaceHolder />;
     }
     const title = 'Index Costs for Past 30 Days';
-    const labels = Object.keys(this.state.projNameToTotalCost);
-    const dataPoints = Object.keys(this.state.projNameToTotalCost).map(projName => {
-      return this.state.projNameToTotalCost[projName];
+    const labels = Object.keys(this.state.indexNameToTotalCost);
+    const dataPoints = Object.keys(this.state.indexNameToTotalCost).map(indexName => {
+      return this.state.indexNameToTotalCost[indexName];
     });
     const data = {
       labels,
@@ -249,20 +151,11 @@ class Dashboard extends React.Component {
 
     const pastMonthCostTotalArray = [];
     Object.keys(this.state.envIdToCostInfo).forEach(envId => {
-      let total = 0;
-      Object.keys(this.state.envIdToCostInfo[envId].pastMonthCostByUser).forEach(user => {
-        total += this.state.envIdToCostInfo[envId].pastMonthCostByUser[user];
-      });
+      const total = _.sum(_.values(this.state.envIdToCostInfo[envId].pastMonthCostByUser));
       pastMonthCostTotalArray.push(total);
     });
     const title = 'Env Cost for Past 30 Days';
-    const labels = Object.keys(this.state.envIdToCostInfo).map(envId => {
-      const envName = this.state.envIdToEnvMetadata[envId].name;
-      if (this.state.duplicateEnvNames.has(envName)) {
-        return `${envName}: ${envId}`;
-      }
-      return envName;
-    });
+    const labels = getLabels(this.state.envIdToCostInfo, this.state.envIdToEnvMetadata, this.state.duplicateEnvNames);
     const dataPoints = pastMonthCostTotalArray;
     const data = {
       labels,
@@ -277,13 +170,7 @@ class Dashboard extends React.Component {
       return <ProgressPlaceHolder />;
     }
     const title = "Yesterday's Env Cost";
-    const labels = Object.keys(this.state.envIdToCostInfo).map(envId => {
-      const envName = this.state.envIdToEnvMetadata[envId].name;
-      if (this.state.duplicateEnvNames.has(envName)) {
-        return `${envName}: ${envId}`;
-      }
-      return envName;
-    });
+    const labels = getLabels(this.state.envIdToCostInfo, this.state.envIdToEnvMetadata, this.state.duplicateEnvNames);
     const dataPoints = Object.keys(this.state.envIdToCostInfo).map(envId => {
       return this.state.envIdToCostInfo[envId].yesterdayCost;
     });
@@ -295,20 +182,20 @@ class Dashboard extends React.Component {
     return <BarGraph className="mr4" data={data} title={title} />;
   }
 
-  renderPastMonthCostPerProjPerUser() {
-    if (_.isEmpty(this.state.projNameToUserTotalCost)) {
+  renderPastMonthCostPerIndexPerUser() {
+    if (_.isEmpty(this.state.indexNameToUserTotalCost)) {
       return <ProgressPlaceHolder />;
     }
     const results = [];
-    Object.keys(this.state.projNameToUserTotalCost).forEach(projName => {
-      const projCostData = this.state.projNameToUserTotalCost[projName];
-      const labels = Object.keys(projCostData);
+    Object.keys(this.state.indexNameToUserTotalCost).forEach(indexName => {
+      const indexCostData = this.state.indexNameToUserTotalCost[indexName];
+      const labels = Object.keys(indexCostData);
       // NOTE: We need a color for each user
       const colors = ['#FF6384', '#36A2EB', '#FFCE56', '#CDDC39', '#4527a0', '#f4511e'];
       const datasets = [
         {
-          data: Object.keys(projCostData).map(user => {
-            return projCostData[user];
+          data: Object.keys(indexCostData).map(user => {
+            return indexCostData[user];
           }),
           backgroundColor: colors,
           hoverBackgroundColor: colors,
@@ -321,8 +208,8 @@ class Dashboard extends React.Component {
       };
 
       results.push(
-        <div key={projName} className="col col-6">
-          <div className="center">{projName}</div>
+        <div key={indexName} className="col col-6">
+          <div className="center">{indexName}</div>
           <Pie data={data} />
         </div>,
       );
@@ -336,7 +223,119 @@ class Dashboard extends React.Component {
   }
 }
 
+async function getCosts(getEnvironmentsFn, getEnvironmentCostFn) {
+  const { envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames } = await getAccumulatedEnvCost(
+    getEnvironmentsFn,
+    getEnvironmentCostFn,
+  );
+
+  const indexNameToUserTotalCost = {};
+  Object.keys(envIdToCostInfo).forEach(envId => {
+    const indexName = envIdToEnvMetadata[envId].index;
+    if (indexNameToUserTotalCost[indexName] === undefined) {
+      indexNameToUserTotalCost[indexName] = {};
+    }
+    Object.keys(envIdToCostInfo[envId].pastMonthCostByUser).forEach(user => {
+      const currentUserCost = _.get(indexNameToUserTotalCost[indexName], user, 0);
+      indexNameToUserTotalCost[indexName][user] = currentUserCost + envIdToCostInfo[envId].pastMonthCostByUser[user];
+    });
+  });
+
+  const indexNameToTotalCost = {};
+  let totalCost = 0;
+  Object.keys(indexNameToUserTotalCost).forEach(indexName => {
+    let indexCost = 0;
+    Object.keys(indexNameToUserTotalCost[indexName]).forEach(user => {
+      indexCost += indexNameToUserTotalCost[indexName][user];
+    });
+    totalCost += indexCost;
+    indexNameToTotalCost[indexName] = indexCost;
+  });
+
+  return {
+    totalCost,
+    indexNameToTotalCost,
+    indexNameToUserTotalCost,
+    envIdToCostInfo,
+    envIdToEnvMetadata,
+    duplicateEnvNames,
+  };
+}
+
+function getLabels(envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames) {
+  const labels = Object.keys(envIdToCostInfo).map(envId => {
+    const envName = envIdToEnvMetadata[envId].name;
+    if (duplicateEnvNames.has(envName)) {
+      return `${envName}: ${envId}`;
+    }
+    return envName;
+  });
+  return labels;
+}
+
+async function getAccumulatedEnvCost(getEnvironmentsFn, getEnvironmentCostFn) {
+  const environments = await getEnvironmentsFn();
+  const duplicateEnvNames = new Set();
+  const envNameToEnvId = {};
+  const envIdToEnvMetadata = {};
+  environments.forEach(env => {
+    if (env.isExternal) return;
+    envIdToEnvMetadata[env.id] = {
+      index: env.indexId,
+      name: env.name,
+    };
+    if (envNameToEnvId[env.name] === undefined) {
+      envNameToEnvId[env.name] = env.id;
+    } else {
+      duplicateEnvNames.add(env.name);
+    }
+  });
+
+  const envIds = Object.keys(envIdToEnvMetadata);
+  const envCostPromises = envIds.map(envId => {
+    return getEnvironmentCostFn(envId, 30, false, true);
+  });
+
+  const envCostResults = await Promise.all(envCostPromises);
+  const pastMonthCostByUserArray = envCostResults.map(costResult => {
+    const createdByToCost = {};
+    _.forEach(costResult, costDate => {
+      const cost = costDate.cost;
+      Object.keys(cost).forEach(group => {
+        let createdBy = group.split('$')[1];
+        createdBy = createdBy || 'None';
+        const currentUserCost = _.get(createdByToCost, createdBy, 0);
+        createdByToCost[createdBy] = currentUserCost + cost[group].amount;
+      });
+    });
+    return createdByToCost;
+  });
+
+  const yesterdayCostArray = envCostResults.map(costResult => {
+    const yesterdayCost = costResult.length > 0 ? costResult[costResult.length - 1] : {};
+    let totalCost = 0;
+    if (yesterdayCost) {
+      const arrayOfCosts = _.flatMapDeep(yesterdayCost.cost);
+      arrayOfCosts.forEach(cost => {
+        totalCost += cost.amount;
+      });
+    }
+    return totalCost;
+  });
+
+  const envIdToCostInfo = {};
+  for (let i = 0; i < envIds.length; i++) {
+    envIdToCostInfo[envIds[i]] = {
+      pastMonthCostByUser: pastMonthCostByUserArray[i],
+      yesterdayCost: yesterdayCostArray[i],
+    };
+  }
+
+  return { envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames };
+}
+
 // see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
 decorate(Dashboard, {});
 
 export default inject('userStore')(withRouter(observer(Dashboard)));
+export { getAccumulatedEnvCost, getCosts, getLabels };

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/__tests__/Dashboard.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/dashboard/__tests__/Dashboard.test.js
@@ -1,0 +1,312 @@
+import { getCosts, getLabels } from '../Dashboard';
+
+describe('Dashboard tests', () => {
+  describe('Labels', () => {
+    it('Test labels with duplicates', async () => {
+      const duplicateEnvNames = new Set();
+      duplicateEnvNames.add('name2_2');
+      const envIdToCostInfo = {
+        id1: { pastMonthCostByUser: { 'user1@gmail.com': 5.64 }, yesterdayCost: 0 },
+        id2: { pastMonthCostByUser: { 'user2@gmail.com': 2 }, yesterdayCost: 0 },
+        id3: { pastMonthCostByUser: { 'user1@gmail.com': 3 }, yesterdayCost: 0 },
+        id4: { pastMonthCostByUser: { 'user1@gmail.com': 4 }, yesterdayCost: 4 },
+        id5: { pastMonthCostByUser: {}, yesterdayCost: 0 },
+      };
+      const envIdToEnvMetadata = {
+        id1: { index: 'index1', name: 'name1_1' },
+        id2: { index: 'index1', name: 'name2_1' },
+        id3: { index: 'index2', name: 'name1_2' },
+        id4: { index: 'index2', name: 'name2_2' },
+        id5: { index: 'index2', name: 'name2_2' },
+      };
+      const labels = getLabels(envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames);
+      expect(labels).toEqual(['name1_1', 'name2_1', 'name1_2', 'name2_2: id4', 'name2_2: id5']);
+    });
+
+    it('Test labels without duplicates', async () => {
+      const duplicateEnvNames = new Set();
+      const envIdToCostInfo = {
+        id1: { pastMonthCostByUser: { 'user1@gmail.com': 5.64 }, yesterdayCost: 0 },
+        id2: { pastMonthCostByUser: { 'user2@gmail.com': 2 }, yesterdayCost: 0 },
+        id3: { pastMonthCostByUser: { 'user1@gmail.com': 3 }, yesterdayCost: 0 },
+        id4: { pastMonthCostByUser: { 'user1@gmail.com': 4 }, yesterdayCost: 4 },
+        id5: { pastMonthCostByUser: {}, yesterdayCost: 0 },
+      };
+      const envIdToEnvMetadata = {
+        id1: { index: 'index1', name: 'name1_1' },
+        id2: { index: 'index1', name: 'name2_1' },
+        id3: { index: 'index2', name: 'name1_2' },
+        id4: { index: 'index2', name: 'name2_2' },
+        id5: { index: 'index2', name: 'name3_2' },
+      };
+      const labels = getLabels(envIdToCostInfo, envIdToEnvMetadata, duplicateEnvNames);
+      expect(labels).toEqual(['name1_1', 'name2_1', 'name1_2', 'name2_2', 'name3_2']);
+    });
+  });
+
+  describe('Cost aggregation', () => {
+    it('Test with no cost data', async () => {
+      function getEnvironments() {
+        return [
+          {
+            name: 'name1_1',
+            indexId: 'index1',
+            id: 'id1',
+          },
+          {
+            name: 'name2_1',
+            indexId: 'index1',
+            id: 'id2',
+          },
+        ];
+      }
+      const getEnvironmentCost = jest.fn();
+      getEnvironmentCost.mockImplementation((envId, days, groupByService, groupByUser) => {
+        expect(days).toEqual(30);
+        expect(groupByService).toEqual(false);
+        expect(groupByUser).toEqual(true);
+        switch (envId) {
+          case 'id1':
+            return [
+              {
+                startDate: '2021-03-31',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-01',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          case 'id2':
+            return [
+              {
+                startDate: '2021-04-01',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          default:
+            throw Error('Invalid environmentId');
+        }
+      });
+      const aggregatedCosts = await getCosts(getEnvironments, getEnvironmentCost);
+      const duplicateEnvNames = new Set();
+      expect(aggregatedCosts.duplicateEnvNames).toEqual(duplicateEnvNames);
+      expect(aggregatedCosts.totalCost).toEqual(0);
+      expect(aggregatedCosts.indexNameToTotalCost).toEqual({
+        index1: 0,
+      });
+      expect(aggregatedCosts.envIdToEnvMetadata).toEqual({
+        id1: { index: 'index1', name: 'name1_1' },
+        id2: { index: 'index1', name: 'name2_1' },
+      });
+      expect(aggregatedCosts.indexNameToUserTotalCost).toEqual({
+        index1: {},
+      });
+      expect(aggregatedCosts.envIdToCostInfo).toEqual({
+        id1: { pastMonthCostByUser: {}, yesterdayCost: 0 },
+        id2: { pastMonthCostByUser: {}, yesterdayCost: 0 },
+      });
+    });
+
+    it('Test with multiple indexes, users and environments', async () => {
+      function getEnvironments() {
+        return [
+          {
+            name: 'name1_1',
+            indexId: 'index1',
+            id: 'id1',
+          },
+          {
+            name: 'name2_1',
+            indexId: 'index1',
+            id: 'id2',
+          },
+          {
+            name: 'name1_2',
+            indexId: 'index2',
+            id: 'id3',
+          },
+          {
+            name: 'name2_2',
+            indexId: 'index2',
+            id: 'id4',
+          },
+          {
+            name: 'name2_2',
+            indexId: 'index2',
+            id: 'id5',
+          },
+        ];
+      }
+      const getEnvironmentCost = jest.fn();
+      getEnvironmentCost.mockImplementation((envId, days, groupByService, groupByUser) => {
+        expect(days).toEqual(30);
+        expect(groupByService).toEqual(false);
+        expect(groupByUser).toEqual(true);
+        switch (envId) {
+          case 'id1':
+            return [
+              {
+                startDate: '2021-03-31',
+                cost: {
+                  'CreatedBy$user1@gmail.com': {
+                    amount: 1.0,
+                    unit: 'USD',
+                  },
+                },
+              },
+              {
+                startDate: '2021-04-01',
+                cost: {
+                  'CreatedBy$user1@gmail.com': {
+                    amount: 4.0,
+                    unit: 'USD',
+                  },
+                },
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {
+                  'CreatedBy$user1@gmail.com': {
+                    amount: 0.64,
+                    unit: 'USD',
+                  },
+                },
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          case 'id2':
+            return [
+              {
+                startDate: '2021-04-01',
+                cost: {
+                  'CreatedBy$user2@gmail.com': {
+                    amount: 2.0,
+                    unit: 'USD',
+                  },
+                },
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          case 'id3':
+            return [
+              {
+                startDate: '2021-04-01',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {
+                  'CreatedBy$user1@gmail.com': {
+                    amount: 3.0,
+                    unit: 'USD',
+                  },
+                },
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          case 'id4':
+            return [
+              {
+                startDate: '2021-04-01',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {
+                  'CreatedBy$user1@gmail.com': {
+                    amount: 4.0,
+                    unit: 'USD',
+                  },
+                },
+              },
+            ];
+
+          case 'id5':
+            return [
+              {
+                startDate: '2021-04-01',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-02',
+                cost: {},
+              },
+              {
+                startDate: '2021-04-03',
+                cost: {},
+              },
+            ];
+
+          default:
+            throw Error('Invalid environmentId');
+        }
+      });
+      const aggregatedCosts = await getCosts(getEnvironments, getEnvironmentCost);
+      const duplicateEnvNames = new Set();
+      duplicateEnvNames.add('name2_2');
+      expect(aggregatedCosts.duplicateEnvNames).toEqual(duplicateEnvNames);
+      expect(aggregatedCosts.totalCost).toEqual(14.64);
+      expect(aggregatedCosts.indexNameToTotalCost).toEqual({
+        index1: 7.64,
+        index2: 7,
+      });
+      expect(aggregatedCosts.envIdToEnvMetadata).toEqual({
+        id1: { index: 'index1', name: 'name1_1' },
+        id2: { index: 'index1', name: 'name2_1' },
+        id3: { index: 'index2', name: 'name1_2' },
+        id4: { index: 'index2', name: 'name2_2' },
+        id5: { index: 'index2', name: 'name2_2' },
+      });
+      expect(aggregatedCosts.indexNameToUserTotalCost).toEqual({
+        index1: { 'user1@gmail.com': 5.64, 'user2@gmail.com': 2 },
+        index2: { 'user1@gmail.com': 7 },
+      });
+      expect(aggregatedCosts.envIdToCostInfo).toEqual({
+        id1: { pastMonthCostByUser: { 'user1@gmail.com': 5.64 }, yesterdayCost: 0 },
+        id2: { pastMonthCostByUser: { 'user2@gmail.com': 2 }, yesterdayCost: 0 },
+        id3: { pastMonthCostByUser: { 'user1@gmail.com': 3 }, yesterdayCost: 0 },
+        id4: { pastMonthCostByUser: { 'user1@gmail.com': 4 }, yesterdayCost: 4 },
+        id5: { pastMonthCostByUser: {}, yesterdayCost: 0 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Bug 1: Fix cost per index when index has more than one environments that have non-zero cost
Bug 2: Collect cost by environment Id so that identical environment names don't overwrite costs

Issue #, if available: GALI-689, GALI-781

Description of changes:

1. Bug 1: Any time an index had multiple non-zero costs associated with it, we would not track the costs correctly, and the result was that the whatever was the last environment seen for that index, we would just use its cost.  Mainly I noticed that `_.get(projNameToUserTotalCost, `${projName}.${user}`, 0);` always returned a zero since user contains a '.' since it is an email address so I have changed it to `_.get(projNameToUserTotalCost[projName], user, 0);`. This fixed the cost reporting on index and total cost. Note that this resulted in both- inaccurate costs or costs not showing up at all since some environment might have had no costs associated with it and that might have been the final environment in the index that the code saw and assumed that index's cost is zero USD

Before snapshot where there were multiple environments in the index but cost of just one environment was showing up in total
![image](https://user-images.githubusercontent.com/68876606/114217773-d74e3a80-9925-11eb-929d-7c1414d6b151.png)


After the fix, the index costs are getting reflected correctly
![image](https://user-images.githubusercontent.com/68876606/114217668-b259c780-9925-11eb-820a-cc2d22eb6015.png)



2. Bug 2:  Before this change we were treating environment names as unique when they aren’t necessarily unique. This results in the code using and showing costs for one of the environment and messes up with the total cost reflected for projects/indexes. As an example: if you have two workspaces with the same name- cost of one of them will replace the other when we display costs in our dashboard and only one of the costs would be used when aggregating the cost for projects. This can lead to accuracy issue and also result in costs not being reflected at all (assuming an environment with zero cost replaces an environment with non-zero cost)
 
To distinguish the environments with same name in the UI we only have environmentId as the identifier where uniqueness is guaranteed. Since environment name isn’t unique, the change here will display the name multiple times but add environmentId along with its name to indicate that there are multiple environments that share the same name.

As an example have a look at the following screenshot where environmentId is appended since environment name wasn't unique. Note that environmentId is only appended when we have duplicate names

![image](https://user-images.githubusercontent.com/68876606/114105564-378f9e80-988a-11eb-97fc-ac9948df5525.png)

Note: This issue doesn't fix the scaling issue where we make calls for all the environments together and the fact that our cost explorer UI doesn't handle pagination. This only fixes the accuracy issues which can lead to incorrect cost data or cost dashboard not showing up at all. We have a separate epic for fixing such scaling issues.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.