### PR TITLE
fix: adding deny for appDeployer perm restrict

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -221,6 +221,12 @@ Resources:
             Effect: Allow
             Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-*'
           - Action:
+              - iam:CreateRole
+              - iam:PutRolePolicy
+              - iam:AttachRolePolicy
+            Effect: Deny
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-cicd-pipeline-AppDeployerRole-*'
+          - Action:
               - iam:CreatePolicy
               - iam:GetPolicy
               - iam:DeletePolicy

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -282,6 +282,9 @@ Resources:
               - cloudformation:ValidateTemplate
               - kms:CreateKey
               - kms:ListKeys
+              - kms:ListAliases
+              - kms:PutKeyPolicy
+              - kms:GenerateRandom
               - s3:ListBuckets
             Resource:
               - '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
@@ -316,14 +319,20 @@ Resources:
           - Effect: 'Allow'
             Action:
               - kms:DescribeKey
+              - kms:EnableKey
               - kms:Encrypt
               - kms:Decrypt
               - kms:CreateAlias
+              - kms:ListKeyPolicies
               - kms:ReEncrypt*
               - kms:GenerateDataKey
+              - kms:ListGrants
               - kms:GenerateDataKeyWithoutPlaintext
               - kms:CreateGrant
               - kms:RevokeGrant
+              - kms:TagResource
+              - kms:UntagResource
+              - kms:GetKeyPolicy
             Resource:
               - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/*${self:custom.settings.namespace}*'
               - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Adding deny statement for AppDeployer permission boundary

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.