### PR TITLE
refactor: lock dependency version in bootstrap script

### DIFF
--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -70,12 +70,12 @@ EOF
 }
 
 # Install dependencies
-yum install -y fuse jq
+yum install -y fuse-2.9.2 jq-1.5
 curl -LSs -o "/usr/local/bin/goofys" "$GOOFYS_URL"
 chmod +x "/usr/local/bin/goofys"
 
 # Install ec2 instance connect agent
-sudo yum install ec2-instance-connect
+sudo yum install ec2-instance-connect-1.1
 
 # Create S3 mount script and config file
 chmod +x "${FILES_DIR}/bin/mount_s3.sh"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Lock the dependency version in bootstrap script
* Tested with EC2 Linux instance 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.