### PR TITLE
fix: adding s3 resources for appdeployer

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -269,6 +269,8 @@ Resources:
             Resource:
               - !Sub arn:aws:s3:::${AWS::AccountId}-${self:custom.settings.namespace}*
               - !Sub arn:aws:s3:::${AWS::AccountId}-${self:custom.settings.namespace}*/*
+              - !Sub arn:aws:s3:::${AWS::AccountId}-${self:custom.settings.envName}-va-${self:custom.settings.solutionName}*
+              - !Sub arn:aws:s3:::${AWS::AccountId}-${self:custom.settings.envName}-va-${self:custom.settings.solutionName}*/*
           - Effect: Allow
             Action:
               - ssm:GetParameter


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Adding S3 permissions for EdgeLambda bucket in AppDeployer policy

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.