### PR TITLE
fix: Improve user experience for adding new data source 

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-registration-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/data-source-registration-service.js
@@ -31,7 +31,7 @@ const getCreateStackUrl = accountTemplateInfo => {
   // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stacks-quick-create-links.html
   const { name, region, signedUrl } = accountTemplateInfo;
   const url = [
-    `https://console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/new`,
+    `https://console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/create/review`,
     `?templateURL=${encodeURIComponent(signedUrl)}`,
     `&stackName=${name}`,
   ].join('');


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/service-workbench-on-aws/issues/448

Description of changes:
fix: Improve user experience for adding new data source by taking user directly to CloudFormation review step

Before this change it would take user to a review screen, where the user would have to click through the "Next" button several times before the CF stack can be deployed.

![newCF](https://user-images.githubusercontent.com/3661906/115287971-e0f25200-a11e-11eb-8e20-9f43c89da392.png)


Now, it takes the user directly to the final CF review screen where the user only need to click "Create Stack" for the stack to be created.

![quickCreateCF](https://user-images.githubusercontent.com/3661906/115288044-f9fb0300-a11e-11eb-8223-e64811fdef2e.png)
^ At the bottom of this screen is a "Create Stack" button.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.