### PR TITLE
feat: run coverage for merge commit

### DIFF
--- a/.github/workflows/deploy-integ.yml
+++ b/.github/workflows/deploy-integ.yml
@@ -40,14 +40,6 @@ jobs:
         run: ./scripts/install.sh
       - name: Build all packages
         run: ./scripts/build-all-packages.sh
-      - name: Run unit tests
-        run: |
-          npm install -g codecov
-          pnpm run coverage --recursive --if-present --stream
-      - name: CodeCov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos, but helps in smoother report uploads
       - name: Deploy
         env:
           STAGE_NAME: e2etest

--- a/.github/workflows/deploy-integ.yml
+++ b/.github/workflows/deploy-integ.yml
@@ -40,6 +40,14 @@ jobs:
         run: ./scripts/install.sh
       - name: Build all packages
         run: ./scripts/build-all-packages.sh
+      - name: Run unit tests
+        run: |
+          npm install -g codecov
+          pnpm run coverage --recursive --if-present --stream
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos, but helps in smoother report uploads
       - name: Deploy
         env:
           STAGE_NAME: e2etest

--- a/.github/workflows/merge-coverage-report.yml
+++ b/.github/workflows/merge-coverage-report.yml
@@ -3,15 +3,14 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-name: Unit Tests & Code Analysis
+name: Push Merge Commit Coverage Report
 on:
-  pull_request:
+  push:
     branches:
       - develop
-      - "feat-*"
 jobs:
-  static-code-analysis-and-unit-test:
-    name: Unit Tests & Code Analysis
+  codecov:
+    name: Send merge commit coverage report
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,9 +32,6 @@ jobs:
           npm install -g pnpm
           npm install -g codecov
           pnpm recursive install --unsafe-perm --stream
-      - name: Run static code analysis & linting tests
-        run: |
-          ./scripts/run-static-code-analysis.sh --stream
       - name: Run unit tests
         run: |
           pnpm run coverage --recursive --if-present --stream


### PR DESCRIPTION
Issue #, if available:
GALI-802

Description of changes:
When a PR is merged onto develop on GitHub, it creates a merge commit. The test coverage for this commit is unknown to codecov. Therefore adding coverage check on integration workflow.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.