### PR TITLE
Check provisioning artefacts is not empty before indexing

### DIFF
--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
@@ -205,11 +205,15 @@ class EnvTypeCandidateService extends Service {
           _.filter(paResult.ProvisioningArtifactDetails || [], pa => pa.Active), // filter out inactive versions
           v => -1 * v.CreatedTime,
         );
-        const latestVersion = provisioningArtifacts[0];
-        latestVersion.isLatest = true;
-        provisioningArtifacts = versionFilterEnum.includeOnlyLatest(versionFilter)
-          ? [latestVersion]
-          : provisioningArtifacts;
+
+        // Ensure there are some items in the array before we index it
+        if(!_.isEmpty(provisioningArtifacts)) {
+          const latestVersion = provisioningArtifacts[0];
+          latestVersion.isLatest = true;
+          provisioningArtifacts = versionFilterEnum.includeOnlyLatest(versionFilter)
+            ? [latestVersion]
+            : provisioningArtifacts;
+        }
 
         // In AWS Service Catalog each product could have one or more versions
         // We want to represent each version of the product as an independent environment type


### PR DESCRIPTION
Issue #461

Description of changes:
Check if the provisioning artefact array is not empty before we start to index it.

Checklist:
- [ X] Have you successfully deployed to an AWS account with your changes?
- [ X] Have you successfully tested with your changes locally?
- [ X] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.