### PR TITLE
fix: properly handle SC products with no active versions

### DIFF
--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
@@ -205,6 +205,10 @@ class EnvTypeCandidateService extends Service {
           _.filter(paResult.ProvisioningArtifactDetails || [], pa => pa.Active), // filter out inactive versions
           v => -1 * v.CreatedTime,
         );
+        if (_.isEmpty(provisioningArtifacts)) {
+          // No active versions
+          return null;
+        }
         const latestVersion = provisioningArtifacts[0];
         latestVersion.isLatest = true;
         provisioningArtifacts = versionFilterEnum.includeOnlyLatest(versionFilter)
@@ -220,7 +224,7 @@ class EnvTypeCandidateService extends Service {
         );
       }),
     );
-    return productEnvTypes;
+    return _.filter(productEnvTypes);
   }
 
   /**

--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js
@@ -224,7 +224,7 @@ class EnvTypeCandidateService extends Service {
         );
       }),
     );
-    return _.filter(productEnvTypes);
+    return _.filter(productEnvTypes, productEnvType => productEnvType !== null);
   }
 
   /**


### PR DESCRIPTION
Issue #, if available:
Fix https://github.com/awslabs/service-workbench-on-aws/issues/461

Description of changes:

Fix an issue where if there was a SC product with no active versions, SWB will crash for calls to `/workspace-type-candidates`.

```
2021-04-26T16:43:36.364Z	b08e3a39-bda7-4ce7-b976-45d6d06f63c9	ERROR	TypeError: Cannot set property 'isLatest' of undefined
    at /var/task/src/lambdas/api-handler/webpack:/Users/nestorba/Amazon/AWS/github/service-workbench-on-aws/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-candidate-service.js:209:9
```

Now it correctly filters out products without versions.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.