### PR TITLE
chore: Lock version of packages in provision-rstudio and bootstrap

### DIFF
--- a/.github/workflows/unit-test-code-analysis.yml
+++ b/.github/workflows/unit-test-code-analysis.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/main/solution/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # Various development packages needed to compile R
-sudo yum install -y gcc gcc-gfortran gcc-c++
-sudo yum install -y java-1.8.0-openjdk-devel
-sudo yum install -y readline-devel zlib-devel bzip2-devel xz-devel pcre-devel
-sudo yum install -y libcurl-devel libpng-devel cairo-devel pango-devel
-sudo yum install -y xorg-x11-server-devel libX11-devel libXt-devel
+sudo yum install -y gcc-7.3.* gcc-gfortran-7.3.* gcc-c++-7.3.*
+sudo yum install -y java-1.8.0-openjdk-devel-1.8.0.*
+sudo yum install -y readline-devel-6.2 zlib-devel-1.2.* bzip2-devel-1.0.* xz-devel-5.2.* pcre-devel-8.32
+sudo yum install -y libcurl-devel-7.61.* libpng-devel-1.5.* cairo-devel-1.15.* pango-devel-1.42.*
+sudo yum install -y xorg-x11-server-devel-1.20.* libX11-devel-1.6.* libXt-devel-1.1.*
 
 # Install R from source (https://docs.rstudio.com/resources/install-r-source/)
 R_VERSION="3.6.3"
@@ -61,7 +61,7 @@ sudo crontab "/tmp/crontab"
 
 
 # Install system packages necessary for installing R packages through RStudio CRAN [devtools, tidyverse]
-sudo yum install -y git libcurl-devel openssl-devel libxml2-devel
+sudo yum install -y git-2.23.* openssl-devel-1.0.* libxml2-devel-2.9.*
 libgit2_rpm="libgit2-0.26.6-1.el7.x86_64.rpm"
 libgit2_devel_rpm="libgit2-devel-0.26.6-1.el7.x86_64.rpm"
 mkdir -p "/tmp/libgit2/"
@@ -72,17 +72,17 @@ sudo yum install -y "/tmp/libgit2/${libgit2_devel_rpm}"
 
 
 # Other recommended system packages for installing R packages (https://docs.rstudio.com/rsc/post-setup-tool/)
-sudo yum groupinstall -y 'Development Tools'            # Compiling tools 
-sudo yum install -y libssh2-devel                       # Client SSH
+sudo yum groupinstall -y 'Development Tools'            # Compiling tools
+sudo yum install -y libssh2-devel-1.4.*                       # Client SSH
 
-sudo yum install -y libpng-devel libjpeg-turbo-devel    # Images
-sudo yum install -y ImageMagick ImageMagick-c++-devel   # Images
-sudo yum install -y cairo-devel libGLU-devel            # Graphs
-sudo yum install freetype-devel harfbuzz-devel          # Font
+sudo yum install -y libjpeg-turbo-devel-1.2.*    # Images
+sudo yum install -y ImageMagick-6.9.* ImageMagick-c++-devel-6.9.*   # Images
+sudo yum install -y mesa-libGLU-devel-9.0.*            # Graphs
+sudo yum install freetype-devel-2.8 harfbuzz-devel-1.7.*          # Font
 
-sudo yum install -y mariadb-devel                       # MariaDB/MySQL client & server packages
-sudo yum install -y unixODBC-devel                      # ODBC API client
-sudo yum install -y gmp-devel                           # GNU MP arbitrary precision library
+sudo yum install -y mariadb-devel-5.5.*                       # MariaDB/MySQL client & server packages
+sudo yum install -y unixODBC-devel-2.3.*                      # ODBC API client
+sudo yum install -y gmp-devel-6.0.*                           # GNU MP arbitrary precision library
 
 # Wipe out all traces of provisioning files
 sudo rm -rf "/tmp/rstudio"

--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -38,17 +38,14 @@ update_jupyter_config() {
     # HACK: Update the default SessionManager class used by Jupyter notebooks
     # so that it runs the S3 mount script the first time sessions are listed
     cat << EOF | cut -b5- >> "$config_file"
-
     import subprocess
     from notebook.services.sessions.sessionmanager import SessionManager as BaseSessionManager
-
     class SessionManager(BaseSessionManager):
         def list_sessions(self, *args, **kwargs):
             """Override default list_sessions() method"""
             self.mount_studies()
             result = super(SessionManager, self).list_sessions(*args, **kwargs)
             return result
-
         def mount_studies(self):
             """Execute mount_s3.sh if it hasn't already been run"""
             if not hasattr(self, 'studies_mounted'):
@@ -56,26 +53,23 @@ update_jupyter_config() {
                     "mount_s3.sh",
                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT
                 )
-
                 # Log results
                 if mounting_result.stdout:
                     for line in mounting_result.stdout.decode("utf-8").split("\n"):
                         if line: # Skip empty lines
                             self.log.info(line)
-
                 self.studies_mounted = True
-
     c.NotebookApp.session_manager_class = SessionManager
 EOF
 }
 
 # Install dependencies
-yum install -y fuse jq
+yum install -y jq-1.5
 curl -LSs -o "/usr/local/bin/goofys" "$GOOFYS_URL"
 chmod +x "/usr/local/bin/goofys"
 
 # Install ec2 instance connect agent
-sudo yum install ec2-instance-connect
+sudo yum install ec2-instance-connect-1.1
 
 # Create S3 mount script and config file
 chmod +x "${FILES_DIR}/bin/mount_s3.sh"
@@ -85,17 +79,21 @@ printf "%s" "$S3_MOUNTS" > "/usr/local/etc/s3-mounts.json"
 # Apply updates to environments based on environment type
 case "$(env_type)" in
     "emr") # Update config and restart Jupyter
+        yum install -y fuse-2.9.4
         update_jupyter_config "/opt/hail-on-AWS-spot-instances/src/jupyter_notebook_config.py"
         sudo -u hadoop PATH=$PATH:/usr/local/bin /opt/hail-on-AWS-spot-instances/src/jupyter_run.sh
         ;;
     "sagemaker") # Update config and restart Jupyter
+        yum install -y fuse-2.9.4
         update_jupyter_config "/home/ec2-user/.jupyter/jupyter_notebook_config.py"
         initctl restart jupyter-server --no-wait
         ;;
     "ec2-linux") # Add mount script to bash profile
+        yum install -y fuse-2.9.2
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/ec2-user/.bash_profile"
         ;;
     "rstudio") # Add mount script to bash profile
+        yum install -y fuse-2.9.2
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
         ;;
 esac


### PR DESCRIPTION
Issue #, if available:

Description of changes:
chore: Lock environment installtion file versions

I tested the new `bootstrap.sh` script on Sagemaker, EMR, EC2-linux, and RStudio. All four workspace types could read and write from mounted studies.

I built a new AMI with `provision-rstudio.sh` file and the RStudio instance was able to read and write from mounted studies.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.