### PR TITLE
fix: free-form strings for workspace configs

### DIFF
--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/__tests__/env-type-config-service.test.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/__tests__/env-type-config-service.test.js
@@ -215,7 +215,7 @@ describe('EnvTypeService', () => {
       }
     });
 
-    it('should fail desc incorrect', async () => {
+    it('should pass desc is free-form', async () => {
       // BUILD
       const newConfig = {
         id: 'iFindYourLackOfFaith',
@@ -245,12 +245,17 @@ describe('EnvTypeService', () => {
       envTypeService.mustFind.mockImplementationOnce(() => envType);
       service.audit = jest.fn();
 
-      // OPERATE and CHECK
-      await expect(service.create({}, newConfig.id, newConfig)).rejects.toThrow(
-        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
+      // OPERATE
+      await service.create({}, envType.id, newConfig);
+
+      // CHECK
+      expect(s3Service.api.putObject).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ action: 'create-environment-type-config' }),
       );
     });
-    it('should fail estimatedCostInfo incorrect', async () => {
+    it('should pass estimatedCostInfo is free-form', async () => {
       // BUILD
       const newConfig = {
         id: 'iFindYourLackOfFaith',
@@ -280,9 +285,14 @@ describe('EnvTypeService', () => {
       envTypeService.mustFind.mockImplementationOnce(() => envType);
       service.audit = jest.fn();
 
-      // OPERATE and CHECK
-      await expect(service.create({}, newConfig.id, newConfig)).rejects.toThrow(
-        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
+      // OPERATE
+      await service.create({}, envType.id, newConfig);
+
+      // CHECK
+      expect(s3Service.api.putObject).toHaveBeenCalled();
+      expect(service.audit).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ action: 'create-environment-type-config' }),
       );
     });
 

--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/schema/create-or-update-env-type-config.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/schema/create-or-update-env-type-config.js
@@ -33,13 +33,11 @@ const schema = {
     desc: {
       type: 'string',
       maxLength: 8191,
-      pattern: '^([^<>{}]*)$',
     },
     // A string explaining estimated cost
     estimatedCostInfo: {
       type: 'string',
       maxLength: 1024,
-      pattern: '^([^<>{}]*)$',
     },
     allowRoleIds: {
       type: 'array',


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/service-workbench-on-aws/issues/472

Description of changes:
Removing regex restrictions on environment type config description and estimate cost fields.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.