### PR TITLE
Fix: Move Notification Popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [3.1.0](https://github.com/nguyen102/service-workbench-on-aws/compare/v3.0.0...v3.1.0) (2021-05-10)
+
+
+### Features
+
+* Allow uploading a folder to My Studies ([#475](https://github.com/awslabs/service-workbench-on-aws/issues/475)) ([cb17d4b](https://github.com/awslabs/service-workbench-on-aws/commit/cb17d4be8c0fdaaee7384229629e4bc7ec7d95a1))
+* Run coverage for merge commit ([#458](https://github.com/awslabs/service-workbench-on-aws/issues/458)) ([03afe0e](https://github.com/awslabs/service-workbench-on-aws/commit/03afe0e1387b30dfc50ffab48b9982103048c585))
+* Test coverage ([#456](https://github.com/awslabs/service-workbench-on-aws/issues/456)) ([252b504](https://github.com/awslabs/service-workbench-on-aws/commit/252b5049400c1d3fcb2ceb4720f64210bf0d5359))
+
+
+### Bug Fixes
+
+* Fix BYOB app role to only modify FS roles ([#454](https://github.com/awslabs/service-workbench-on-aws/issues/454)) ([35f6cce](https://github.com/awslabs/service-workbench-on-aws/commit/35f6cce3ccc301921ead742240c15c1a7e332f0c))
+* free-form strings for workspace configs ([#479](https://github.com/awslabs/service-workbench-on-aws/issues/479)) ([fca73f4](https://github.com/awslabs/service-workbench-on-aws/commit/fca73f4dbaf509f06ce55b6b0c87c66e31ed8a88))
+* properly handle SC products with no active versions ([#468](https://github.com/awslabs/service-workbench-on-aws/issues/468)) ([3c561f4](https://github.com/awslabs/service-workbench-on-aws/commit/3c561f4850faffe3ccc6fd0ffcc5b7065f53f3c6))
+* Update workspace name reg exp and workspace config tags reg exp ([#452](https://github.com/awslabs/service-workbench-on-aws/issues/452)) ([f9b7d62](https://github.com/awslabs/service-workbench-on-aws/commit/f9b7d628a08b337eaa0a9c8b71bb6226ff0f7b34))
+
 ## [3.0.0] - 2021-04-19
 
 ### Added

--- a/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
@@ -96,7 +96,7 @@ const toasterErrorOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '20000', // 1000000
   extendedTimeOut: '50000', // 1000000
@@ -107,7 +107,7 @@ const toasterWarningOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '20000', // 1000000
   extendedTimeOut: '50000', // 1000000
@@ -118,7 +118,7 @@ const toasterSuccessOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '3000',
   extendedTimeOut: '10000',


### PR DESCRIPTION
Issue #, if available: GALI 893

Description of changes:

Minor change to move warning/error/status messages from the top right to the bottom right. This location is still easily visible and is a consistent format to many other webapps like Service Workbench. Relocating these text boxes allows the user to see the top ribbon when error messages arise, and prevents the possibility of users accidentally logging out while trying to close warning boxes.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.