### PR TITLE
Moved notification boxes to avoid blocking the top ribbon

### DIFF
--- a/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
@@ -96,7 +96,7 @@ const toasterErrorOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '20000', // 1000000
   extendedTimeOut: '50000', // 1000000
@@ -107,7 +107,7 @@ const toasterWarningOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '20000', // 1000000
   extendedTimeOut: '50000', // 1000000
@@ -118,7 +118,7 @@ const toasterSuccessOptions = {
   debug: false,
   newestOnTop: true,
   progressBar: true,
-  positionClass: 'toast-top-right',
+  positionClass: 'toast-bottom-right',
   preventDuplicates: true,
   timeOut: '3000',
   extendedTimeOut: '10000',


### PR DESCRIPTION
Issue #, if available: GALI 893

Description of changes:

Minor change to move warning/notification/success alert boxes from the top right corner to the top left corner. This allows the entire top ribbon to be displayed while also preventing accidental logouts caused by the close button on alerts overlapping the logout button. Alert box placement in the lower right is consistent with most webapps and is just as visible as alert boxes in the top right.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.