### PR TITLE
Adds 'stopped' filter for workspaces

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentsFilterButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentsFilterButtons.js
@@ -10,7 +10,8 @@ import { filterNames } from '../../../models/environments-sc/ScEnvironmentsStore
 const filterColorMap = {
   [filterNames.ALL]: 'blue',
   [filterNames.AVAILABLE]: 'green',
-  [filterNames.PENDING]: 'orange',
+  [filterNames.PENDING]: 'gold',
+  [filterNames.STOPPED]: 'orange',
   [filterNames.ERRORED]: 'red',
   [filterNames.TERMINATED]: 'grey',
 };


### PR DESCRIPTION
Issue #, if available: GALI-537

Description of changes:

Adds a "Stopped" filter for workspaces view. Looks like this was already implemented, someone just missed adding it to the list of filters to have. Used `orange` for 'Stopped' since `red` suits 'Errored' better. 'Pending' was changed to `gold`, which is a more readable yellow. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.