### PR TITLE
bulkUserAdd API bugfix

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/user-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/user-service.js
@@ -124,7 +124,7 @@ class UserService extends BaseUserService {
       // Write audit event before throwing error since some users were still added
       await this.audit(requestContext, {
         action: 'create-users-batch',
-        body: { totalUsers: _.size(users), completedSuccessfully: false, numErrors: errors },
+        body: { totalUsers: _.size(users), completedSuccessfully: false, numErrors: errorCount },
       });
       throw this.boom
         .internalError(`Errors creating users in bulk. Check the payload for more details.`, true)

--- a/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
+++ b/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
@@ -68,7 +68,8 @@ describe('Create user scenarios', () => {
     it('should fail with internalError code for adding malformed users', async () => {
       const admin1Session = await setup.createAdminSession();
       const badUser = {};
-      await expect(admin1Session.resources.users.bulkAddUsers([badUser])).rejects.toMatchObject({
+      const newUser = admin1Session.resources.users.defaults();
+      await expect(admin1Session.resources.users.bulkAddUsers([newUser, badUser])).rejects.toMatchObject({
         code: errorCode.http.code.internalError,
       });
     });

--- a/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
+++ b/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
@@ -57,10 +57,18 @@ describe('Create user scenarios', () => {
       });
     });
 
-    it('should fail for adding user that already exist', async () => {
+    it('should fail with badRequest code for adding users that already exist', async () => {
       const admin1Session = await setup.createAdminSession();
       const newUser = admin1Session.resources.users.defaults();
       await expect(admin1Session.resources.users.bulkAddUsers([defaultUser, newUser])).rejects.toMatchObject({
+        code: errorCode.http.code.badRequest,
+      });
+    });
+
+    it('should fail with internalError code for adding malformed users', async () => {
+      const admin1Session = await setup.createAdminSession();
+      const badUser = {};
+      await expect(admin1Session.resources.users.bulkAddUsers([badUser])).rejects.toMatchObject({
         code: errorCode.http.code.internalError,
       });
     });

--- a/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
+++ b/main/integration-tests/__test__/api-tests/users/bulk-add-users.test.js
@@ -65,12 +65,12 @@ describe('Create user scenarios', () => {
       });
     });
 
-    it('should fail with internalError code for adding malformed users', async () => {
+    it('should fail with badRequest code for adding malformed users', async () => {
       const admin1Session = await setup.createAdminSession();
       const badUser = {};
       const newUser = admin1Session.resources.users.defaults();
       await expect(admin1Session.resources.users.bulkAddUsers([newUser, badUser])).rejects.toMatchObject({
-        code: errorCode.http.code.internalError,
+        code: errorCode.http.code.badRequest,
       });
     });
   });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3062,7 +3062,7 @@ components:
             - pending
             - error
             - reachable
-            - *
+            - "*"
           description: id must be * when status is specified
     RegisterStudy:
       type: object


### PR DESCRIPTION
Issue #, if available: GALI-742

Description of changes:

- Fixes malformed YAML in `openapi.yaml` 
- Adds additional validation and more informative error messages to bulk-add-users API call. 
  - Method now checks to see if any staged users to add already exist, and if any do, it throws a `badRequest` error along with the users that are duplicates in the payload.  If the method errors this way, no new users are added.
  - If the list contains no duplicates, the method proceeds as normal. Errors are reported as `internalError` with a message to check the error payload for more details. The most common way this would be triggered is with misformatted/missing user details.
  - Fixes a bug where users could be added with no record of the operation being recorded in the audit log.
- Updates integration tests for new functionality. One new integration test added.

API definition is unchanged so no update to `openapi.yaml` was needed for bulkAddUsers.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [x] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.