### PR TITLE
fix: Do not allow users to change root password

### DIFF
--- a/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/create-root-user-service.js
+++ b/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/create-root-user-service.js
@@ -60,9 +60,8 @@ class CreateRootUserService extends Service {
       });
       this.log.info('Created root user in the data lake');
 
-      await dbPasswordService.savePassword(getSystemRequestContext(), {
+      await dbPasswordService.saveRootPassword(getSystemRequestContext(), {
         uid: createdUser.uid,
-        username: rootUserName,
         password: rootUserPassword,
       });
       this.log.info("Created root user's password");

--- a/addons/addon-base/packages/services/lib/db-password/__tests__/db-password-service.test.js
+++ b/addons/addon-base/packages/services/lib/db-password/__tests__/db-password-service.test.js
@@ -81,7 +81,7 @@ describe('db-password-service', () => {
       // OPERATE & CHECK
       await expect(
         service.saveRootPassword(adminNonSystemRequestContext, { uid: 'abcd', password: 'fakePassword' }),
-      ).rejects.toEqual(new Boom().badRequest("'root' password can not be changed", true));
+      ).rejects.toEqual(new Boom().badRequest("'root' password can only be changed by 'system' user", true));
     });
   });
 

--- a/addons/addon-base/packages/services/lib/db-password/__tests__/db-password-service.test.js
+++ b/addons/addon-base/packages/services/lib/db-password/__tests__/db-password-service.test.js
@@ -1,0 +1,159 @@
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+const Boom = require('@aws-ee/base-services-container/lib/boom');
+
+const DbServiceMock = require('@aws-ee/base-services/lib/db-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+const DbPasswordService = require('../db-password-service');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/db-service');
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+
+describe('db-password-service', () => {
+  let service = null;
+  let dbService = null;
+  let settingService = null;
+  const settingMockFunction = jest.fn();
+  beforeAll(async () => {
+    const container = new ServicesContainer();
+    container.register('dbService', new DbServiceMock());
+    container.register('dbPasswordService', new DbPasswordService());
+    container.register('settings', new SettingsServiceMock());
+
+    await container.initServices();
+
+    service = await container.find('dbPasswordService');
+    dbService = await container.find('dbService');
+    settingService = await container.find('settings');
+
+    settingMockFunction.mockReturnValue('root');
+
+    settingService.get = settingMockFunction;
+    service.assertAuthorized = jest.fn();
+  });
+
+  const adminNonSystemRequestContext = {
+    actions: [],
+    resources: [],
+    authenticated: true,
+    principal: {
+      uid: 'abcd',
+      username: 'user1',
+      ns: 'internal',
+      isAdmin: true,
+      userRole: 'admin',
+      status: 'active',
+    },
+    attr: {},
+    principalIdentifier: { uid: 'abcd' },
+  };
+
+  const systemRequestContext = {
+    actions: [],
+    resources: [],
+    authenticated: true,
+    principal: {
+      uid: '_system_',
+      username: '_system_',
+      ns: 'internal',
+      isAdmin: true,
+      userRole: 'admin',
+      status: 'active',
+    },
+    attr: {},
+    principalIdentifier: { uid: '_system_' },
+  };
+
+  describe('saveRootPassword', () => {
+    it('should allow system to save root password', async () => {
+      // OPERATE
+      await service.saveRootPassword(systemRequestContext, { uid: 'abcd', password: 'fakePassword' });
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+
+    it('should NOT allow non-system user to save root password', async () => {
+      // OPERATE & CHECK
+      await expect(
+        service.saveRootPassword(adminNonSystemRequestContext, { uid: 'abcd', password: 'fakePassword' }),
+      ).rejects.toEqual(new Boom().badRequest("'root' password can not be changed", true));
+
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+  });
+
+  describe('savePassword', () => {
+    it('should allow admin to save password', async () => {
+      // OPERATE
+      await service.savePassword(adminNonSystemRequestContext, {
+        username: 'John',
+        uid: 'abcd',
+        password: 'fakePassword',
+      });
+
+      // CHECK
+      expect(dbService.table.update).toHaveBeenCalled();
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+
+    it('should NOT allow admin to save root password', async () => {
+      // OPERATE
+      await expect(
+        service.savePassword(adminNonSystemRequestContext, {
+          username: 'root',
+          uid: 'abcd',
+          password: 'fakePassword',
+        }),
+      ).rejects.toEqual(new Boom().badRequest("'root' password can not be changed", true));
+
+      // CHECK
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+
+    it('should NOT allow system to save root password', async () => {
+      // OPERATE
+      await expect(
+        service.savePassword(systemRequestContext, {
+          username: 'root',
+          uid: 'abcd',
+          password: 'fakePassword',
+        }),
+      ).rejects.toEqual(new Boom().badRequest("'root' password can not be changed", true));
+
+      // CHECK
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+
+    it('should NOT allow non current user to save password', async () => {
+      const nonAdminRequestContext = {
+        actions: [],
+        resources: [],
+        authenticated: true,
+        principal: {
+          uid: 'xyz',
+          username: 'user2',
+          ns: 'internal',
+          isAdmin: false,
+          userRole: 'admin',
+          status: 'active',
+        },
+        attr: {},
+        principalIdentifier: { uid: 'xyz' },
+      };
+
+      // OPERATE
+      await expect(
+        service.savePassword(nonAdminRequestContext, {
+          username: 'fakeUser',
+          uid: 'abcd',
+          password: 'fakePassword',
+        }),
+      ).rejects.toEqual(new Boom().forbidden('You are not authorized to perform this operation', true));
+
+      // CHECK
+      expect(settingMockFunction.mock.calls[0][0]).toBe('rootUserName');
+    });
+  });
+});

--- a/addons/addon-base/packages/services/lib/db-password/db-password-service.js
+++ b/addons/addon-base/packages/services/lib/db-password/db-password-service.js
@@ -19,6 +19,7 @@ const uuid = require('uuid/v4');
 const Service = require('@aws-ee/base-services-container/lib/service');
 const { ensureCurrentUserOrAdmin } = require('../authorization/assertions');
 const { runAndCatch } = require('../helpers/utils');
+const { isSystem } = require('../authorization/authorization-utils');
 
 const settingKeys = {
   tableName: 'dbPasswords',
@@ -45,10 +46,27 @@ class DbPasswordService extends Service {
     }
   }
 
+  async saveRootPassword(requestContext, { password, uid }) {
+    const username = this.settings.get('rootUserName');
+    if (!isSystem(requestContext)) {
+      throw this.boom.badRequest("'root' password can not be changed", true);
+    }
+    await this.savePasswordHelper(username, password, uid);
+  }
+
   async savePassword(requestContext, { username, password, uid }) {
     // Allow only current user or admin to update (or create) the user's password
     await ensureCurrentUserOrAdmin(requestContext, { uid });
 
+    // Don't allow users to change root user's password
+    if (username === this.settings.get('rootUserName')) {
+      throw this.boom.badRequest("'root' password can not be changed", true);
+    }
+
+    await this.savePasswordHelper(username, password, uid);
+  }
+
+  async savePasswordHelper(username, password, uid) {
     const isValidPassword = await this.passwordMatchesPasswordPolicy(password);
     if (!isValidPassword) {
       throw this.boom.badRequest(

--- a/addons/addon-base/packages/services/lib/db-password/db-password-service.js
+++ b/addons/addon-base/packages/services/lib/db-password/db-password-service.js
@@ -49,7 +49,7 @@ class DbPasswordService extends Service {
   async saveRootPassword(requestContext, { password, uid }) {
     const username = this.settings.get('rootUserName');
     if (!isSystem(requestContext)) {
-      throw this.boom.badRequest("'root' password can not be changed", true);
+      throw this.boom.badRequest("'root' password can only be changed by 'system' user", true);
     }
     await this.savePasswordHelper(username, password, uid);
   }

--- a/addons/addon-base/packages/services/package.json
+++ b/addons/addon-base/packages/services/package.json
@@ -22,6 +22,7 @@
     "validatorjs": "^3.18.1"
   },
   "devDependencies": {
+    "@aws-ee/base-services": "workspace:*",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.10.0",

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -156,6 +156,7 @@ apiHandler:
     APP_ENV_TYPE_CONFIGS_BUCKET_NAME: ${self:custom.settings.envTypeConfigsBucketName}
     APP_ENV_BOOTSTRAP_BUCKET_NAME: ${self:custom.settings.environmentsBootstrapBucketName}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
+    APP_ROOT_USER_NAME: ${self:custom.settings.rootUserName}
 
 workflowLoopRunner:
   handler: src/lambdas/workflow-loop-runner/handler.handler

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,7 @@ importers:
 
   addons/addon-base/packages/services:
     specifiers:
+      '@aws-ee/base-services': workspace:*
       '@aws-ee/base-services-container': workspace:*
       ajv: ^6.11.0
       aws-sdk: ^2.647.0
@@ -1340,6 +1341,7 @@ importers:
       uuid: 3.4.0
       validatorjs: 3.18.1
     devDependencies:
+      '@aws-ee/base-services': 'link:'
       eslint: 6.8.0
       eslint-config-airbnb-base: 14.1.0_8cdb6d8c18c3319a1365bd5afa0063a3
       eslint-config-prettier: 6.10.1_eslint@6.8.0
@@ -7522,7 +7524,7 @@ packages:
   /aws-sdk-mock/5.1.0:
     resolution: {integrity: sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==}
     dependencies:
-      aws-sdk: 2.721.0
+      aws-sdk: 2.847.0
       sinon: 9.0.3
       traverse: 0.6.6
     dev: true
@@ -7582,7 +7584,6 @@ packages:
       url: 0.10.3
       uuid: 3.3.2
       xml2js: 0.4.19
-    dev: false
 
   /aws-sign2/0.7.0:
     resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Do not allow users to change root password
* Allow post deployment lambda to change root user password by having the lambda use the function `saveRootPassword`

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] If new dependencies have been added, have they been pinned to specific versions?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.