### PR TITLE
feat: Add warning that internal authentication shouldn't be used in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ cd -
 
 Once Service Workbench is fully deployed, the console will output the Website URL and Root Password for Service Workbench. You can log in by navigating to the Website URL in any browser, and then using the username 'root' and the Root Password given by the console. Please note that logging as the root user is highly discouraged, and should only be used for initial setup. You can create a new user by clicking the "Users" tab on the left, then "Add Local User". Follow the instructions given to create the user (you can leave the 'Project' field blank for now), then log out of the root account and into your new user account.
 
+Adding a local user should only be done in test environments. We highly recommend using an IDP for prod environments. For more details on how to set up an IDP, please click [here](/docs/docs/user_guide/sidebar/admin/auth/introduction.md)
 ## Linking an existing AWS account
 
 Once in your user account, you'll need to link your AWS account. Navigate to "AWS Accounts" in the left bar, then click the "AWS Accounts" tab. From here, you can create an AWS account, or link an existing one.

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/User.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/User.js
@@ -103,7 +103,6 @@ const User = types
     },
 
     get isInternalAuthUser() {
-      console.log('self', self);
       return _.toLower(self.authenticationProviderId) === 'internal';
     },
 

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/User.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/User.js
@@ -102,6 +102,11 @@ const User = types
       return _.toLower(self.userType) === 'root';
     },
 
+    get isInternalAuthUser() {
+      console.log('self', self);
+      return _.toLower(self.authenticationProviderId) === 'internal';
+    },
+
     get isActive() {
       return _.toLower(self.status) === 'active';
     },

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/User.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/__tests__/User.test.js
@@ -1,0 +1,50 @@
+import { User } from '../User';
+
+describe('User', () => {
+  it('should get all user fields correctly', () => {
+    const userJson = {
+      uid: 'u-N__Z_pJTr5oSNUaM6-oP7',
+      firstName: 'John',
+      lastName: 'Smith',
+      isAdmin: false,
+      isExternalUser: false,
+      username: 'JohnSmith@amazon.com',
+      ns: 'internal',
+      email: 'JohnSmith@amazon.com',
+      authenticationProviderId: 'internal',
+      status: 'active',
+      createdBy: 'u-0Jse-jzwgiczKaa74IFKg',
+      rev: 1,
+      userRole: 'researcher',
+      projectId: ['Project1'],
+      encryptedCreds: 'N/A',
+      applyReason: 'N/A',
+    };
+
+    const user = User.create(userJson);
+
+    expect(user.displayName).toEqual('John Smith');
+    expect(user.longDisplayName).toEqual('John Smith (JohnSmith@amazon.com)');
+    expect(user.unknown).toEqual(false);
+    expect(user.isRootUser).toEqual(false);
+    expect(user.isInternalAuthUser).toEqual(true);
+    expect(user.isActive).toEqual(true);
+    expect(user.isInternalGuest).toEqual(false);
+    expect(user.isExternalGuest).toEqual(false);
+    expect(user.isInternalResearcher).toEqual(true);
+    expect(user.isSystem).toEqual(false);
+    expect(user.isSame('abcd')).toEqual(false);
+    expect(user.isSamePrincipal('abcd', 'xyz')).toEqual(false);
+    expect(user.id).toEqual('u-N__Z_pJTr5oSNUaM6-oP7');
+    expect(user.principal).toEqual({ username: 'JohnSmith@amazon.com', ns: 'internal' });
+    expect(user.principalStr).toEqual(JSON.stringify({ username: 'JohnSmith@amazon.com', ns: 'internal' }));
+    expect(user.hasProjects).toEqual(true);
+    expect(user.hasCredentials).toEqual(false);
+    expect(user.capabilities).toEqual({
+      canCreateStudy: true,
+      canCreateWorkspace: true,
+      canSelectStudy: true,
+      canViewDashboard: true,
+    });
+  });
+});

--- a/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
+++ b/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
@@ -84,9 +84,13 @@ async function postInit(payload, appContext) {
   if (isRootUser) {
     displayWarning('You have logged in as root user. Logging in as root user is discouraged.');
   }
-  if (isInternalAuthUser) {
+
+  console.log('Env', process.env);
+  const isProduction = process.env.REACT_APP_SITE_ENV_TYPE === 'prod';
+  console.log('Is Production', isProduction);
+  if (isInternalAuthUser && isProduction) {
     displayWarning(
-      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod accounts. Please consider using an alternate Auth Provider such as Cognito.',
+      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod environments. Please consider using an alternate Auth Provider such as Cognito.',
     );
   }
 }

--- a/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
+++ b/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
@@ -88,7 +88,7 @@ async function postInit(payload, appContext) {
   const isProduction = process.env.REACT_APP_SITE_ENV_TYPE === 'prod';
   if (isInternalAuthUser && isProduction) {
     displayWarning(
-      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod environments. Please consider using an alternate IDP.',
+      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod environments. Please consider using an IDP.',
     );
   }
 }

--- a/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
+++ b/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
@@ -80,8 +80,14 @@ async function postInit(payload, appContext) {
   await userStore.load();
 
   const isRootUser = userStore.user.isRootUser;
+  const isInternalAuthUser = userStore.user.isInternalAuthUser;
   if (isRootUser) {
     displayWarning('You have logged in as root user. Logging in as root user is discouraged.');
+  }
+  if (isInternalAuthUser) {
+    displayWarning(
+      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod accounts. Please consider using an alternate Auth Provider such as Cognito.',
+    );
   }
 }
 

--- a/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
+++ b/addons/addon-base-ui/packages/base-ui/src/plugins/initialization-plugin.js
@@ -85,12 +85,10 @@ async function postInit(payload, appContext) {
     displayWarning('You have logged in as root user. Logging in as root user is discouraged.');
   }
 
-  console.log('Env', process.env);
   const isProduction = process.env.REACT_APP_SITE_ENV_TYPE === 'prod';
-  console.log('Is Production', isProduction);
   if (isInternalAuthUser && isProduction) {
     displayWarning(
-      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod environments. Please consider using an alternate Auth Provider such as Cognito.',
+      'You are using internal Authentication for this user. Internal Authentication is not recommended for prod environments. Please consider using an alternate IDP.',
     );
   }
 }

--- a/docs/docs/deployment/post_deployment/create_admin_user.md
+++ b/docs/docs/deployment/post_deployment/create_admin_user.md
@@ -15,8 +15,10 @@ _**Figure 7: Create an Administrator**_
 
 _**Note**: A root user account will already be created, however, you must not routinely use the root user account._ 
 
-1.	Click ‘**Add Local User**’. Assign the user the administrator’s role, and associate the user with the **Project** you created, and set the status to ‘**Active**’. See **Figure 8**.
+For testing purposes, you can create a local user by clicking  ‘**Add Local User**’. Assign the user the administrator’s role, and associate the user with the **Project** you created, and set the status to ‘**Active**’. See **Figure 8**.
 
 <img src={useBaseUrl('img/deployment/post_deployment/create_user_01.jpg')} />
 
 _**Figure 8: Add Local User**_
+
+**In prod environments we highly recommend using an IDP. For more details, click [here](../../user_guide/sidebar/admin/auth/introduction.md)**

--- a/main/solution/ui/config/environment/env-template.yml
+++ b/main/solution/ui/config/environment/env-template.yml
@@ -17,6 +17,7 @@ REACT_APP_AUTO_LOGOUT_TIMEOUT_IN_MINUTES: ${self:custom.settings.autoLogoutTimeo
 REACT_APP_ENV_MGMT_ROLE_NAME: ${self:custom.settings.envMgmtRoleName}
 REACT_APP_ENABLE_BUILT_IN_WORKSPACES: ${self:custom.settings.enableBuiltInWorkspaces}
 REACT_APP_VERSION_AND_DATE: ${self:custom.settings.versionAndDate}
+REACT_APP_SITE_ENV_TYPE: ${self:custom.settings.envType}
 
 # ========================================================================
 # Overrides for .env.local


### PR DESCRIPTION
Issue #, if available:

Description of changes:
feat: Add warning that internal authentication shouldn't be used in production

This warning only shows up if internal auth is used and the env is `prod`.

![Screen Shot 2021-05-27 at 11 25 09 AM](https://user-images.githubusercontent.com/3661906/119875146-6faf7700-bef4-11eb-8b5e-989696d90980.png)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] If new dependencies have been added, have they been pinned to specific versions?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.