### PR TITLE
fix: Allow sagemaker to have the proper IAM permission to autostop itself

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -180,7 +180,7 @@ Resources:
                 chmod a+x /usr/local/bin/autostop.py
                 IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
                 echo "Starting the SageMaker autostop script in cron"
-                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections > /var/log/autostop.log") | crontab -
+                (crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections >> /var/log/autostop.log") | crontab -
               fi
 
 Outputs:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -180,7 +180,7 @@ Resources:
                 chmod a+x /usr/local/bin/autostop.py
                 IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
                 echo "Starting the SageMaker autostop script in cron"
-                (crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections >> /var/log/autostop.log") | crontab -
+                (crontab -l 2>/dev/null; echo "*/1 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections >> /var/log/autostop.log") | crontab -
               fi
 
 Outputs:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -73,6 +73,11 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
+          - Effect: Allow
+            Action:
+              - sagemaker:DescribeNotebookInstance
+              - sagemaker:StopNotebookInstance
+            Resource: '*'
   IAMRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -175,7 +180,7 @@ Resources:
                 chmod a+x /usr/local/bin/autostop.py
                 IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
                 echo "Starting the SageMaker autostop script in cron"
-                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+                (crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections > /var/log/autostop.log") | crontab -
               fi
 
 Outputs:

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -33,7 +33,7 @@ envStatusPollHandler:
   description: Handles status polling for sc environments
   events:
     - schedule:
-        rate: rate(3 minutes)
+        rate: rate(1 minute)
         description: 'Invokes the lambda function that polls and synchronize environment status.'
   environment:
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Update permission boundary for Sagemaker instance to allow stopping a Sagemaker instance
* Change Sagemaker to check whether idle limit has passed, on a minute by minute cadence instead of an hourly cadence
* Update `envStatusPollHandler` to run once every minute instead of once every 3 minutes. (More accurate, since users can choose to have Sagemaker stop itself after 1 minute of inactivity)


I tested that Sagemaker was able to stop itself after inactivity. I saw the Sagemaker instance was stopped on the AWS Console and within SWB UI.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] If new dependencies have been added, have they been pinned to specific versions?
- [x] Is this change also required on the AWS Solution version?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [x] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.