### PR TITLE
fix: Corrected Spark defaults to fix read/write functionality from Spark

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -266,11 +266,13 @@ Resources:
             yarn.nodemanager.vmem-check-enabled: false
         - Classification: spark-defaults
           ConfigurationProperties:
-            spark.hadoop.io.compression.codecs: 'org.apache.hadoop.io.compress.DefaultCodec,is.hail.io.compress.BGzipCodec,org.apache.hadoop.io.compress.GzipCodec'
+            spark.hadoop.io.compression.codecs: 'org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.GzipCodec'
             spark.serializer: 'org.apache.spark.serializer.KryoSerializer'
-            spark.hadoop.parquet.block.size: '1099511627776'
-            spark.sql.files.maxPartitionBytes: '1099511627776'
-            spark.sql.files.openCostInBytes: '1099511627776'
+            # Defaults picked from spark conf
+            # https://github.com/apache/spark/blob/878527d9fae8945d087ec871bb0a5f49b6341939/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L1322-L1339
+            spark.hadoop.parquet.block.size: '134217728' # 128MB
+            spark.sql.files.maxPartitionBytes: '134217728' # 128 MB
+            spark.sql.files.openCostInBytes: '4194304' # 4 MB
           Configurations: []
       Instances:
         AdditionalMasterSecurityGroups:


### PR DESCRIPTION
Issue #, if available: [Issue 496](https://github.com/awslabs/service-workbench-on-aws/issues/496) and [Issue 495](https://github.com/awslabs/service-workbench-on-aws/issues/495)

Description of changes: See [Issue 496](https://github.com/awslabs/service-workbench-on-aws/issues/496) and [Issue 495](https://github.com/awslabs/service-workbench-on-aws/issues/495) for details.

* Removing `is.hail.io.compress.BGzipCodec` since Hail isn't setup correctly
* For Parquet- the main issue was parquet block size config which was defaulted to 1 TB and therefore was failing file writing. I have changed block size and other defaults to same as what Spark uses internally

### Testing

* Deployed the change, imported the new SC template and provisioned EMR. Verified that read/write functionality and parquet writes specifically now work. Also verified that defaults are now updated correctly.

![image](https://user-images.githubusercontent.com/68876606/121597871-6e0aa680-c9fe-11eb-94ae-fe45ecec532c.png)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.