### PR TITLE
chore: specify Node.js and Go versions across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Read the Service Workbench Deployment Guide provided in the installation. You ca
 npm install -g pnpm
 ```
 
-- **Go:** You also need to install [Go](https://golang.org/doc/install). `Go` is used for creating a multipart S3 downloader tool that is used in AWS Service Catalog EC2 Windows based research environments.
+- **Go:** You also need to install [Go 1.13.7](https://golang.org/doc/install) or later. `Go` is used for creating a multipart S3 downloader tool that is used in AWS Service Catalog EC2 Windows based research environments.
 
 For more information, refer to the **Prerequisites** section of the Service Workbench Deployment Guide.
 

--- a/addons/addon-base-raas/packages/serverless-packer/README.md
+++ b/addons/addon-base-raas/packages/serverless-packer/README.md
@@ -2,7 +2,7 @@
 
 #### Tools
 
-- Node 12
+- Node 12.x or later
 - [Hashicorp Packer](https://www.packer.io/)
     - The Service Workbench code is tested with Packer 1.6.0. You can install Packer 1.6.0 by using Packer version manager [pkenv](https://github.com/iamhsa/pkenv).
 

--- a/addons/addon-base-ui/packages/serverless-ui-tools/README.md
+++ b/addons/addon-base-ui/packages/serverless-ui-tools/README.md
@@ -2,7 +2,7 @@
 
 #### Tools
 
-- Node 12+
+- Node 12.x or later
 - AWS CLI
 
 #### Project variables

--- a/addons/addon-base/packages/serverless-go-build-tools/README.md
+++ b/addons/addon-base/packages/serverless-go-build-tools/README.md
@@ -6,8 +6,8 @@ This package is a Serverless plugin that will build golang code and upload it to
 
 #### Tools
 
-- Node 12
-- Go
+- Node 12.x or later
+- Go 1.13.7 or later
 
 ## Configuration
 

--- a/docs/docs/deployment/pre_deployment/prereq_commands.md
+++ b/docs/docs/deployment/pre_deployment/prereq_commands.md
@@ -8,7 +8,7 @@ The prerequisite software installation includes installing the required tools an
 ## Install the Required Tools
 Before building this solution, you must install the tools that are listed below:
 
-* [Node.js](https://nodejs.org/) (10.15.x or later) 
+* [Node.js](https://nodejs.org/) (12.x or later) 
 * [AWS Command Line Interface](https://aws.amazon.com/cli/)
 * [PNPM](https://pnpm.js.org/) 
 * [Serverless Framework](http://www.serverless.com)


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/service-workbench-on-aws/issues/538

Just making docs consistent when indicating Node.js and Go versions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.