### PR TITLE
fix: Provision environment pulls namespace value from stack id

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -8,7 +8,7 @@ Parameters:
     Description: An environment name that will be prefixed to resource names
   SolutionNamespace:
     Type: String
-    Description: Environment name of the solution. It should be the same value as provided in onboard-account.cfn.yml for "Namespace"
+    Description: The namespace value provided when onboarding the Member account
   IsAppStreamEnabled:
     Type: String
     AllowedValues: [true, false]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -8,7 +8,7 @@ Parameters:
     Description: An environment name that will be prefixed to resource names
   SolutionNamespace:
     Type: String
-    Description: Environment name of the solution. It should be the same value as provided in onboard-account.cfn.yml for "Namespace"
+    Description: The namespace value provided when onboarding the Member account
   IsAppStreamEnabled:
     Type: String
     AllowedValues: [true, false]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -8,7 +8,7 @@ Parameters:
     Description: An environment name that will be prefixed to resource names
   SolutionNamespace:
     Type: String
-    Description: Environment name of the solution. It should be the same value as provided in onboard-account.cfn.yml for "Namespace"
+    Description: The namespace value provided when onboarding the Member account
   IsAppStreamEnabled:
     Type: String
     AllowedValues: [true, false]

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
@@ -62,6 +62,9 @@ const EnvironmentSCKeyPairServiceMock = require('../environment-sc-keypair-servi
 jest.mock('../../../data-egress/data-egress-service.js');
 const DataEgressService = require('../../../data-egress/data-egress-service.js');
 
+jest.mock('../../../account/account-service.js');
+const AccountService = require('../../../account/account-service.js');
+
 const EnvironmentConfigVarsService = require('../environment-config-vars-service');
 
 describe('EnvironmentSCService', () => {
@@ -73,6 +76,7 @@ describe('EnvironmentSCService', () => {
   let environmentAmiService = null;
   let userService = null;
   let settingsService = null;
+  let accountService = null;
 
   beforeEach(async () => {
     const container = new ServicesContainer();
@@ -92,6 +96,7 @@ describe('EnvironmentSCService', () => {
     container.register('environmentScKeypairService', new EnvironmentSCKeyPairServiceMock());
     container.register('studyService', new StudyServiceMock());
     container.register('dataEgressService', new DataEgressService());
+    container.register('accountService', new AccountService());
     await container.initServices();
 
     // suppress expected console errors
@@ -106,7 +111,14 @@ describe('EnvironmentSCService', () => {
     environmentAmiService = await container.find('environmentAmiService');
     userService = await container.find('userService');
     settingsService = await container.find('settings');
+    accountService = await container.find('accountService');
 
+    accountService.mustFind = jest.fn(() => {
+      return Promise.resolve({
+        stackId:
+          'arn:aws:cloudformation:eu-west-1:123456789012:stack/initial-stack-1625689755737/ff9a0dc0-df61-11eb-8b32-024312ba26d9',
+      });
+    });
     // Skip authorization by default
     service.assertAuthorized = jest.fn();
   });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
@@ -289,7 +289,7 @@ describe('EnvironmentSCService', () => {
       mockSettingsService({
         environmentInstanceFiles: '{}',
         isAppStreamEnabled: 'true',
-        solutionNamespace: 'gamma',
+        solutionNamespace: 'initial-stack-1625689755737',
       });
       const expectedResponse = {
         accountId: '123456789012',
@@ -315,7 +315,7 @@ describe('EnvironmentSCService', () => {
         vpcId: 'VpcId-Test',
         xAccEnvMgmtRoleArn: 'xAccEnvMgmtRole-Test',
         isAppStreamEnabled: 'true',
-        solutionNamespace: 'gamma',
+        solutionNamespace: 'initial-stack-1625689755737',
       };
 
       // EXECUTE & CHECK
@@ -329,7 +329,7 @@ describe('EnvironmentSCService', () => {
       mockSettingsService({
         environmentInstanceFiles: '{}',
         isAppStreamEnabled: 'true',
-        solutionNamespace: 'gamma',
+        solutionNamespace: 'initial-stack-1625689755737',
         enableEgressStore: 'true',
       });
       const requestContext = 'sampleRequestContext';
@@ -402,7 +402,7 @@ describe('EnvironmentSCService', () => {
         vpcId: 'VpcId-Test',
         xAccEnvMgmtRoleArn: 'xAccEnvMgmtRole-Test',
         isAppStreamEnabled: 'true',
-        solutionNamespace: 'gamma',
+        solutionNamespace: 'initial-stack-1625689755737',
       };
 
       // EXECUTE & CHECK

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
@@ -249,6 +249,7 @@ class EnvironmentConfigVarsService extends Service {
       });
     }
 
+    // eslint-disable-next-line no-template-curly-in-string
     const isAdminKeyPairRequired = !!_.find(envTypeConfig.params, p => p.value === '${adminKeyPairName}');
     let adminKeyPairName = '';
     if (isAdminKeyPairRequired) {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
@@ -23,7 +23,6 @@ const settingKeys = {
   enableEgressStore: 'enableEgressStore',
   environmentInstanceFiles: 'environmentInstanceFiles',
   isAppStreamEnabled: 'isAppStreamEnabled',
-  solutionNamespace: 'solutionNamespace',
 };
 
 /**
@@ -158,8 +157,7 @@ class EnvironmentConfigVarsService extends Service {
       },
       {
         name: 'solutionNamespace',
-        desc:
-          'Environment name of the solution. It should be the same value as provided in onboard-account.cfn.yml for "Namespace"',
+        desc: 'The namespace value provided when onboarding the Member account',
       },
     ];
   }
@@ -251,22 +249,6 @@ class EnvironmentConfigVarsService extends Service {
       });
     }
 
-    // TODO: If the ami sharing gets moved (because it doesn't contribute to an env var)
-    // then move the update local resource policies too.
-    // Using the account root provides basically the same level of security because in either
-    // case we have to trust that the member account hasn't altered the role's assume role policy to allow other
-    // principals assume it
-    // if (s3Prefixes.length > 0) {
-    //   await environmentMountService.addRoleArnToLocalResourcePolicies(`arn:aws:iam::${accountId}:root`, s3Prefixes);
-    // }
-
-    // Check if the environment being launched needs an admin key-pair to be created in the target account
-    // If the configuration being used has any parameter that uses the "adminKeyPairName" variable then it means
-    // we need to provision that key in the target account and provide the name of the generated key as the
-    // "adminKeyPairName" variable
-    // Disabling "no-template-curly-in-string" lint rule because we need to compare with the string literal "${adminKeyPairName}"
-    // i.e., without any string interpolation
-    // eslint-disable-next-line no-template-curly-in-string
     const isAdminKeyPairRequired = !!_.find(envTypeConfig.params, p => p.value === '${adminKeyPairName}');
     let adminKeyPairName = '';
     if (isAdminKeyPairRequired) {
@@ -313,54 +295,11 @@ class EnvironmentConfigVarsService extends Service {
     return result;
   }
 
-  // async getNewAWSAccountCredentials(requestContext, externalId) {
-  //   const [aws] = await this.mustFindServices(['aws']);
-  //   const credential = await this.getCredentials();
-  //   // const [requestContext, ExternalId] = await Promise.all([
-  //   //   this.payload.object('requestContext'),
-  //   //   this.payload.string('externalId'),
-  //   // ]);
-  //   const accountId = await this.state.string('ACCOUNT_ID');
-  //   // TODO: pass user customized role name, for now it's fixed as OrganizationAccountAccessRole
-  //   const RoleArn = `arn:aws:iam::${accountId}:role/OrganizationAccountAccessRole`;
-  //   const sts = new aws.sdk.STS(credential);
-  //   const {
-  //     Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
-  //   } = await sts
-  //     .assumeRole({
-  //       RoleArn,
-  //       RoleSessionName: `RaaS-${requestContext.principalIdentifier.uid}-CfnRole`,
-  //       ExternalId: externalId,
-  //     })
-  //     .promise();
-  //   return { accessKeyId, secretAccessKey, sessionToken };
-  // }
-  //
-  // async getCloudFormationService(requestContext, externalId) {
-  //   const [aws] = await this.mustFindServices(['aws']);
-  //   const { accessKeyId, secretAccessKey, sessionToken } = await this.getNewAWSAccountCredentials(
-  //     requestContext,
-  //     externalId,
-  //   );
-  //   return new aws.sdk.CloudFormation({ accessKeyId, secretAccessKey, sessionToken });
-  // }
-  //
-
   async getSolutionNamespace(requestContext, externalId, accountId) {
     const [accountService] = await this.service(['accountService']);
-    console.log('accountId', accountId);
     const { stackId } = await accountService.mustFind(requestContext, { id: accountId });
-    console.log('stackId', stackId);
     return stackId.match(/\d{12}:stack\/(.+)\//)[1];
   }
-
-  // getCfnOutputs(stackInfo) {
-  //   const details = {};
-  //   stackInfo.Outputs.forEach(option => {
-  //     _.set(details, option.OutputKey, option.OutputValue);
-  //   });
-  //   return details;
-  // }
 
   async getEnvRolePolicy(requestContext, { environment, studies, memberAccountId }) {
     const policyDoc = new StudyPolicy();

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -193,5 +193,4 @@ workflowLoopRunner:
     APP_EGRESS_STORE_BUCKET_NAME: ${self:custom.settings.egressStoreBucketName}
     APP_EGRESS_STORE_KMS_KEY_ALIAS_ARN: ${self:custom.settings.egressStoreKmsKeyAliasArn}
     APP_EGRESS_STORE_KMS_POLICY_WORKSPACE_SID: ${self:custom.settings.egressStoreKmsPolicyWorkspaceSid}
-    APP_SOLUTION_NAMESPACE: ${self:custom.settings.envName}
     APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Pull the `stackId` from from `Accounts` table in DDB. From the `stackId` we can parse out the `SolutionNamespace` since the stack name and the `SolutionNamespace` is identical.


**Tested:** I deployed the code and tested that I can launch a new linux workspace.

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.