### PR TITLE
feat: workspace provisioning mgmt

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/Project.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/projects/Project.js
@@ -30,6 +30,7 @@ const Project = types
     updatedAt: '',
     updatedBy: '',
     projectAdmins: types.optional(types.array(types.string), []),
+    isAppStreamConfigured: types.optional(types.boolean, false),
   })
   .actions(self => ({
     setProject(rawProject) {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
@@ -96,10 +96,13 @@ class ScEnvironmentsList extends React.Component {
     const store = this.envsStore;
     let content = null;
     const projects = this.getProjects();
-    const appStreamProjects = _.filter(projects, proj => proj.isAppStreamConfigured);
+    const appStreamProjectIds = _.map(
+      _.filter(projects, proj => proj.isAppStreamConfigured),
+      'id',
+    );
 
     runInAction(() => {
-      if (this.isAppStreamEnabled && _.isEmpty(appStreamProjects)) this.provisionDisabled = true;
+      if (this.isAppStreamEnabled && _.isEmpty(appStreamProjectIds)) this.provisionDisabled = true;
     });
 
     if (isStoreError(store)) {
@@ -109,7 +112,7 @@ class ScEnvironmentsList extends React.Component {
     } else if (isStoreEmpty(store)) {
       content = this.renderEmpty();
     } else if (isStoreNotEmpty(store)) {
-      content = this.renderMain();
+      content = this.renderMain(appStreamProjectIds);
     } else {
       content = null;
     }
@@ -140,10 +143,11 @@ class ScEnvironmentsList extends React.Component {
     );
   }
 
-  renderMain() {
+  renderMain(appStreamProjectIds) {
     const store = this.envsStore;
     const selectedFilter = this.selectedFilter;
-    const list = store.filtered(selectedFilter);
+    let list = store.filtered(selectedFilter);
+    list = this.isAppStreamEnabled ? _.filter(list, env => _.includes(appStreamProjectIds, env.projectId)) : list;
     const isEmpty = _.isEmpty(list);
 
     return (

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
@@ -67,15 +67,15 @@ class ScEnvironmentsList extends React.Component {
     return this.props.scEnvironmentsStore;
   }
 
+  getProjects() {
+    const store = this.getProjectsStore();
+    return store.list;
+  }
+
   getProjectsStore() {
     const store = this.props.projectsStore;
     store.load();
     return store;
-  }
-
-  getProjects() {
-    const store = this.getProjectsStore();
-    return store.list;
   }
 
   handleCreateEnvironment = event => {
@@ -162,9 +162,10 @@ class ScEnvironmentsList extends React.Component {
 
   renderTitle() {
     const projects = this.getProjects();
+    const appStreamProjects = _.filter(projects, proj => proj.isAppStreamConfigured);
 
     runInAction(() => {
-      if (this.isAppStreamEnabled && _.isEmpty(projects)) this.provisionDisabled = true;
+      if (this.isAppStreamEnabled && _.isEmpty(appStreamProjects)) this.provisionDisabled = true;
     });
 
     return (

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
@@ -95,6 +95,12 @@ class ScEnvironmentsList extends React.Component {
   render() {
     const store = this.envsStore;
     let content = null;
+    const projects = this.getProjects();
+    const appStreamProjects = _.filter(projects, proj => proj.isAppStreamConfigured);
+
+    runInAction(() => {
+      if (this.isAppStreamEnabled && _.isEmpty(appStreamProjects)) this.provisionDisabled = true;
+    });
 
     if (isStoreError(store)) {
       content = <ErrorBox error={store.error} className="p0" />;
@@ -111,8 +117,26 @@ class ScEnvironmentsList extends React.Component {
     return (
       <Container className="mt3 animated fadeIn">
         {this.renderTitle()}
+        {this.provisionDisabled && this.renderMissingAppStreamConfig()}
         {content}
       </Container>
+    );
+  }
+
+  renderMissingAppStreamConfig() {
+    return (
+      <>
+        <Segment placeholder className="mt2">
+          <Header icon className="color-grey">
+            <Icon name="lock" />
+            Missing association with AppStream projects
+            <Header.Subheader>
+              Since your projects are not associated to an AppStream-configured account, creating a new workspace is
+              disabled. Please contact your administrator.
+            </Header.Subheader>
+          </Header>
+        </Segment>
+      </>
     );
   }
 
@@ -161,13 +185,6 @@ class ScEnvironmentsList extends React.Component {
   }
 
   renderTitle() {
-    const projects = this.getProjects();
-    const appStreamProjects = _.filter(projects, proj => proj.isAppStreamConfigured);
-
-    runInAction(() => {
-      if (this.isAppStreamEnabled && _.isEmpty(appStreamProjects)) this.provisionDisabled = true;
-    });
-
     return (
       <div className="mb3 flex">
         <Header as="h3" className="color-grey mt1 mb0 flex-auto">

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -141,6 +141,7 @@ class CreateInternalEnvForm extends React.Component {
             </Header.Subheader>
           </Header>
         </Segment>
+        {this.renderButtons()}
       </>
     );
   }

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import { decorate, computed, runInAction, observable, action } from 'mobx';
 import { observer, inject } from 'mobx-react';
-import { Segment, Button, Header } from 'semantic-ui-react';
+import { Segment, Button, Header, Icon } from 'semantic-ui-react';
 import { displayError } from '@aws-ee/base-ui/dist/helpers/notification';
 import Dropdown from '@aws-ee/base-ui/dist/parts/helpers/fields/DropDown';
 import Form from '@aws-ee/base-ui/dist/parts/helpers/fields/Form';
@@ -21,20 +21,37 @@ import SelectConfigurationCards from './SelectConfigurationCards';
 // - defaultCidr (via props)
 // - clientInformationStore (via injection)
 // - userStore (via injection)
+// - projectsStore (via injection)
 class CreateInternalEnvForm extends React.Component {
   constructor(props) {
     super(props);
     runInAction(() => {
       this.form = getCreateInternalEnvForm({
-        projectIdOptions: this.projectIdOptions,
+        projectIdOptions: this.getProjectIdOptions(),
         cidr: this.props.defaultCidr,
       });
     });
   }
 
-  get projectIdOptions() {
+  // The list of projects assigned to the user might be broader than the
+  // list of projects actually available for environment provisioning
+  // For example: Projects not fully configured with AppStream need to be filtered out
+  getProjectIdOptions() {
     const store = this.userStore;
-    return store.projectIdDropdown;
+    if (!this.isAppStreamEnabled) return store.projectIdDropdown;
+
+    const projects = this.getProjects();
+    const filteredProjects = _.filter(projects, proj => proj.isAppStreamConfigured);
+    if (_.isEmpty(filteredProjects)) return [];
+
+    const filteredProjectIds = _.map(filteredProjects, proj => proj.id);
+    const retVal = _.filter(store.projectIdDropdown, proj => _.includes(filteredProjectIds, proj.key));
+
+    return retVal;
+  }
+
+  get isAppStreamEnabled() {
+    return process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
   }
 
   get envTypeId() {
@@ -47,6 +64,17 @@ class CreateInternalEnvForm extends React.Component {
 
   get userStore() {
     return this.props.userStore;
+  }
+
+  getProjects() {
+    const store = this.getProjectsStore();
+    return store.list;
+  }
+
+  getProjectsStore() {
+    const store = this.props.projectsStore;
+    store.load();
+    return store;
   }
 
   // eslint-disable-next-line consistent-return
@@ -77,10 +105,57 @@ class CreateInternalEnvForm extends React.Component {
     );
   }
 
+  renderButtons() {
+    return (
+      <div className="mt3">
+        <Button
+          floated="right"
+          icon="right arrow"
+          labelPosition="right"
+          className="ml2"
+          primary
+          content="Next"
+          disabled
+        />
+        <Button
+          floated="right"
+          icon="left arrow"
+          labelPosition="left"
+          className="ml2"
+          content="Previous"
+          onClick={this.handlePrevious}
+        />
+      </div>
+    );
+  }
+
+  renderMissingAppStreamConfig() {
+    return (
+      <>
+        <Segment placeholder className="mt2">
+          <Header icon className="color-grey">
+            <Icon name="lock" />
+            Missing association with AppStream projects
+            <Header.Subheader>
+              Your projects are not associated to an AppStream-configured account. Please contact your administrator.
+            </Header.Subheader>
+          </Header>
+        </Segment>
+      </>
+    );
+  }
+
   renderForm() {
     const form = this.form;
     const askForCidr = !_.isUndefined(this.props.defaultCidr);
     const configurations = this.configurations;
+
+    // we show the AppStream configuration warning when the feature is enabled,
+    // and the user's projects are not linked to AppStream-configured accounts
+    const projects = this.getProjectIdOptions();
+    if (this.isAppStreamEnabled && _.isEmpty(projects)) {
+      return this.renderMissingAppStreamConfig();
+    }
 
     return (
       <Segment clearing className="p3 mb3">
@@ -125,8 +200,8 @@ decorate(CreateInternalEnvForm, {
   envTypeId: computed,
   configurations: computed,
   userStore: computed,
-  projectIdOptions: computed,
+  isAppStreamEnabled: computed,
   handlePrevious: action,
 });
 
-export default inject('userStore', 'clientInformationStore')(observer(CreateInternalEnvForm));
+export default inject('userStore', 'projectsStore', 'clientInformationStore')(observer(CreateInternalEnvForm));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/ScEnvironmentSetup.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/ScEnvironmentSetup.js
@@ -198,7 +198,7 @@ class ScEnvironmentSetup extends React.Component {
             <Icon name="lock" />
             Missing association with projects
             <Header.Subheader>
-              You currently do not have permissions to use any projects for the workspace. please contact your
+              You currently do not have permissions to use any projects for the workspace. Please contact your
               administrator.
             </Header.Subheader>
           </Header>

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -1239,6 +1239,44 @@ describe('EnvironmentSCService', () => {
     });
   });
 
+  describe('filterAppStreamProjectEnvs function', () => {
+    it('should filter out envs by AppStream config', async () => {
+      // BUILD
+      const requestContext = {
+        principal: {
+          isExternalUser: true,
+        },
+      };
+      const envs = [
+        {
+          id: 'env-1',
+          projectId: 'proj-1',
+        },
+        {
+          id: 'env-2',
+          projectId: 'proj-2',
+        },
+      ];
+      const projects = [
+        { id: 'proj-1', isAppStreamConfigured: true },
+        { id: 'proj-2', isAppStreamConfigured: false },
+      ];
+      projectService.list = jest.fn(() => projects);
+      const expected = [
+        {
+          id: 'env-1',
+          projectId: 'proj-1',
+        },
+      ];
+
+      // OPERATE
+      const retVal = await service.filterAppStreamProjectEnvs(requestContext, envs);
+
+      // CHECK
+      expect(retVal).toEqual(expected);
+    });
+  });
+
   describe('getSecurityGroupDetails function', () => {
     it('should send filtered security group rules as expected', async () => {
       // BUILD

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
@@ -101,6 +101,9 @@ class EnvironmentScCidrService extends Service {
       { ...existingEnvironment, updateRequest },
     );
 
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await environmentScService.verifyAppStreamConfig(requestContext, id);
+
     await lockService.tryWriteLockAndRun({ id: `${id}-CidrUpdate` }, async () => {
       // Calculate diff and update CIDR ranges in ingress rules
       const { currentIngressRules, securityGroupId } = await environmentScService.getSecurityGroupDetails(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
@@ -145,6 +145,9 @@ class EnvironmentScConnectionService extends Service {
       return connection;
     }
 
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await environmentScService.verifyAppStreamConfig(requestContext, envId);
+
     if (_.toLower(_.get(connection, 'type', '')) === 'sagemaker') {
       const sagemaker = await environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
@@ -237,6 +240,9 @@ class EnvironmentScConnectionService extends Service {
     // Validate input
     await validationService.ensureValid(sshConnectionInfo, sshConnectionInfoSchema);
 
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await environmentScService.verifyAppStreamConfig(requestContext, envId);
+
     // The following will succeed only if the user has permissions to access the specified environment
     const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
@@ -305,6 +311,9 @@ class EnvironmentScConnectionService extends Service {
       'environmentScService',
       'environmentScKeypairService',
     ]);
+
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await environmentScService.verifyAppStreamConfig(requestContext, envId);
 
     // The following will succeed only if the user has permissions to access the specified environment
     // and connection

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
@@ -32,11 +32,19 @@ const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-sett
 jest.mock('@aws-ee/base-services/lib/user/user-service');
 const UserServiceMock = require('@aws-ee/base-services/lib/user/user-service');
 
+jest.mock('../../aws-accounts/aws-accounts-service');
+const AwsAccountsServiceMock = require('../../aws-accounts/aws-accounts-service');
+
+jest.mock('../../indexes/indexes-service');
+const IndexesServiceMock = require('../../indexes/indexes-service');
+
 const ProjectService = require('../project-service');
 
 describe('ProjectService', () => {
   let service = null;
   let dbService = null;
+  let indexesService = null;
+  let awsAccountsService = null;
   beforeAll(async () => {
     // Initialize services container and register dependencies
     const container = new ServicesContainer();
@@ -47,12 +55,16 @@ describe('ProjectService', () => {
     container.register('auditWriterService', new AuditServiceMock());
     container.register('settings', new SettingsServiceMock());
     container.register('userService', new UserServiceMock());
+    container.register('awsAccountsService', new AwsAccountsServiceMock());
+    container.register('indexesService', new IndexesServiceMock());
 
     await container.initServices();
 
     // Get instance of the service we are testing
     service = await container.find('projectService');
     dbService = await container.find('dbService');
+    indexesService = await container.find('indexesService');
+    awsAccountsService = await container.find('awsAccountsService');
 
     // Skip authorization
     service.assertAuthorized = jest.fn();
@@ -124,6 +136,30 @@ describe('ProjectService', () => {
     });
   });
 
+  it('should fail if rev is empty', async () => {
+    const project = {
+      id: 'my-new-project',
+      description: 'Some relevant description',
+      indexId: '123',
+      // empty rev should cause error
+    };
+
+    try {
+      await service.update({}, project);
+      expect.hasAssertions();
+    } catch (err) {
+      expect(err.payload).toBeDefined();
+      const error = err.payload.validationErrors[0];
+      expect(error).toMatchObject({
+        keyword: 'required',
+        dataPath: '',
+        schemaPath: '#/required',
+        params: { missingProperty: 'rev' },
+        message: "should have required property 'rev'",
+      });
+    }
+  });
+
   describe('update', () => {
     it('should NOT fail for all required properties present', async () => {
       const project = {
@@ -160,28 +196,149 @@ describe('ProjectService', () => {
     });
   });
 
-  it('should fail if rev is empty', async () => {
-    const project = {
-      id: 'my-new-project',
-      description: 'Some relevant description',
-      indexId: '123',
-      // empty rev should cause error
-    };
-
-    try {
-      await service.update({}, project);
-      expect.hasAssertions();
-    } catch (err) {
-      expect(err.payload).toBeDefined();
-      const error = err.payload.validationErrors[0];
-      expect(error).toMatchObject({
-        keyword: 'required',
-        dataPath: '',
-        schemaPath: '#/required',
-        params: { missingProperty: 'rev' },
-        message: "should have required property 'rev'",
+  describe('verifyAppStreamConfig', () => {
+    it('should return list of projects with appropriate isAppStreamConfigured bool', async () => {
+      // BUILD
+      const input = [
+        {
+          id: 'my-appstream-project',
+          description: 'Some relevant description',
+          indexId: 'index-1',
+          rev: 1,
+        },
+        {
+          id: 'my-non-appstream-project',
+          description: 'Some relevant description',
+          indexId: 'index-2',
+          rev: 1,
+        },
+      ];
+      awsAccountsService.list = jest.fn(() => {
+        return [
+          {
+            id: 'awsAccountId-1',
+            appStreamFleetName: 'sampleAppStreamFleetName',
+            appStreamSecurityGroupId: 'sampleAppStreamSecurityGroupId',
+            appStreamStackName: 'sampleAppStreamStackName',
+          },
+          { id: 'awsAccountId-2' },
+          { id: 'awsAccountId-3' },
+        ];
       });
-    }
+      indexesService.list = jest.fn(() => {
+        return [
+          { id: 'index-1', awsAccountId: 'awsAccountId-1' },
+          { id: 'index-2', awsAccountId: 'awsAccountId-2' },
+          { id: 'index-3', awsAccountId: 'awsAccountId-3' },
+        ];
+      });
+      const expectedRetVal = [
+        {
+          id: 'my-appstream-project',
+          description: 'Some relevant description',
+          indexId: 'index-1',
+          rev: 1,
+          isAppStreamConfigured: true,
+        },
+        {
+          id: 'my-non-appstream-project',
+          description: 'Some relevant description',
+          indexId: 'index-2',
+          rev: 1,
+          isAppStreamConfigured: false,
+        },
+      ];
+
+      // EXECUTE
+      const retVal = await service.verifyAppStreamConfig(input);
+
+      // CHECK
+      await expect(retVal).toEqual(expectedRetVal);
+    });
+
+    it('should return project with appropriate isAppStreamConfigured bool', async () => {
+      // BUILD
+      const input = {
+        id: 'my-appstream-project',
+        description: 'Some relevant description',
+        indexId: 'index-1',
+        rev: 1,
+      };
+      awsAccountsService.list = jest.fn(() => {
+        return [
+          {
+            id: 'awsAccountId-1',
+            appStreamFleetName: 'sampleAppStreamFleetName',
+            appStreamSecurityGroupId: 'sampleAppStreamSecurityGroupId',
+            appStreamStackName: 'sampleAppStreamStackName',
+          },
+          { id: 'awsAccountId-2' },
+          { id: 'awsAccountId-3' },
+        ];
+      });
+      indexesService.list = jest.fn(() => {
+        return [
+          { id: 'index-1', awsAccountId: 'awsAccountId-1' },
+          { id: 'index-2', awsAccountId: 'awsAccountId-2' },
+          { id: 'index-3', awsAccountId: 'awsAccountId-3' },
+        ];
+      });
+      const expectedRetVal = {
+        id: 'my-appstream-project',
+        description: 'Some relevant description',
+        indexId: 'index-1',
+        rev: 1,
+        isAppStreamConfigured: true,
+      };
+
+      // EXECUTE
+      const retVal = await service.verifyAppStreamConfig(input);
+
+      // CHECK
+      await expect(retVal).toEqual(expectedRetVal);
+    });
+
+    it('should return project with unset isAppStreamConfigured for incomplete AppStream configuration', async () => {
+      // BUILD
+      const input = {
+        id: 'my-appstream-project',
+        description: 'Some relevant description',
+        indexId: 'index-1',
+        rev: 1,
+      };
+      awsAccountsService.list = jest.fn(() => {
+        return [
+          {
+            id: 'awsAccountId-1',
+            appStreamFleetName: 'sampleAppStreamFleetName',
+            appStreamSecurityGroupId: 'sampleAppStreamSecurityGroupId',
+            // appStreamStackName: 'sampleAppStreamStackName', // missing config
+          },
+          { id: 'awsAccountId-2' },
+          { id: 'awsAccountId-3' },
+        ];
+      });
+      indexesService.list = jest.fn(() => {
+        return [
+          { id: 'index-1', awsAccountId: 'awsAccountId-1' },
+          { id: 'index-2', awsAccountId: 'awsAccountId-2' },
+          { id: 'index-3', awsAccountId: 'awsAccountId-3' },
+        ];
+      });
+      const expectedRetVal = {
+        id: 'my-appstream-project',
+        description: 'Some relevant description',
+        indexId: 'index-1',
+        rev: 1,
+        isAppStreamConfigured: false,
+      };
+
+      // EXECUTE
+      const retVal = await service.verifyAppStreamConfig(input);
+
+      // CHECK
+      await expect(retVal).toEqual(expectedRetVal);
+    });
   });
 
   describe('delete', () => {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/__tests__/project-service.test.js
@@ -196,7 +196,7 @@ describe('ProjectService', () => {
     });
   });
 
-  describe('verifyAppStreamConfig', () => {
+  describe('updateWithAppStreamConfig', () => {
     it('should return list of projects with appropriate isAppStreamConfigured bool', async () => {
       // BUILD
       const input = [
@@ -250,7 +250,7 @@ describe('ProjectService', () => {
       ];
 
       // EXECUTE
-      const retVal = await service.verifyAppStreamConfig(input);
+      const retVal = await service.updateWithAppStreamConfig(input);
 
       // CHECK
       await expect(retVal).toEqual(expectedRetVal);
@@ -292,7 +292,7 @@ describe('ProjectService', () => {
       };
 
       // EXECUTE
-      const retVal = await service.verifyAppStreamConfig(input);
+      const retVal = await service.updateWithAppStreamConfig(input);
 
       // CHECK
       await expect(retVal).toEqual(expectedRetVal);
@@ -334,7 +334,7 @@ describe('ProjectService', () => {
       };
 
       // EXECUTE
-      const retVal = await service.verifyAppStreamConfig(input);
+      const retVal = await service.updateWithAppStreamConfig(input);
 
       // CHECK
       await expect(retVal).toEqual(expectedRetVal);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
@@ -77,7 +77,7 @@ class ProjectService extends Service {
       .get();
 
     if (this.isAppStreamEnabled) {
-      result = this.verifyAppStreamConfig(result);
+      result = this.updateWithAppStreamConfig(result);
     }
 
     return this._fromDbToDataObject(result);
@@ -231,7 +231,7 @@ class ProjectService extends Service {
       .scan();
 
     if (this.isAppStreamEnabled) {
-      projects = await this.verifyAppStreamConfig(projects);
+      projects = await this.updateWithAppStreamConfig(projects);
     }
 
     // Only return projects that the user has been associated with unless user is an admin
@@ -256,7 +256,7 @@ class ProjectService extends Service {
    *
    * @param input The Project entity, or list of Project entities
    */
-  async verifyAppStreamConfig(input) {
+  async updateWithAppStreamConfig(input) {
     try {
       const systemContext = getSystemRequestContext();
       const [awsAccountsService, indexesService] = await this.service(['awsAccountsService', 'indexesService']);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
@@ -17,8 +17,9 @@ const _ = require('lodash');
 const Service = require('@aws-ee/base-services-container/lib/service');
 const { runAndCatch } = require('@aws-ee/base-services/lib/helpers/utils');
 const { allowIfActive, allowIfAdmin } = require('@aws-ee/base-services/lib/authorization/authorization-utils');
+const { getSystemRequestContext } = require('@aws-ee/base-services/lib/helpers/system-context');
 
-const { isExternalGuest, isExternalResearcher, isInternalGuest } = require('../helpers/is-role');
+const { isExternalGuest, isExternalResearcher, isInternalGuest, isAdmin, isSystem } = require('../helpers/is-role');
 const createSchema = require('../schema/create-project');
 const updateSchema = require('../schema/update-project');
 
@@ -62,7 +63,13 @@ class ProjectService extends Service {
 
     if (restrict) return undefined;
 
-    // Future task: return undefined if the user is not associated with this project, unless they are admin
+    // Throw unauthorized error if the user is not associated with this project, unless they are admin
+    if (
+      !isAdmin(requestContext) &&
+      !isSystem(requestContext) &&
+      !(await this.verifyUserProjectAssociation(_.get(requestContext, 'principalIdentifier.uid'), id))
+    )
+      throw this.boom.forbidden(`You're not authorized to access project "${id}"`, true);
 
     let result = await this._getter()
       .key({ id })
@@ -70,7 +77,7 @@ class ProjectService extends Service {
       .get();
 
     if (this.isAppStreamEnabled) {
-      result = this.verifyAppStreamConfig(requestContext, result);
+      result = this.verifyAppStreamConfig(result);
     }
 
     return this._fromDbToDataObject(result);
@@ -217,8 +224,6 @@ class ProjectService extends Service {
 
     if (restrict) return [];
 
-    // Future task: only return projects that the user has been associated with unless the user is an admin
-
     // Remember doing a scan is not a good idea if you billions of rows
     let projects = await this._scanner()
       .limit(1000)
@@ -226,28 +231,53 @@ class ProjectService extends Service {
       .scan();
 
     if (this.isAppStreamEnabled) {
-      projects = await this.verifyAppStreamConfig(requestContext, projects);
+      projects = await this.verifyAppStreamConfig(projects);
     }
-    return projects;
+
+    // Only return projects that the user has been associated with unless user is an admin
+    if (isAdmin(requestContext) || isSystem(requestContext)) return projects;
+
+    const by = _.get(requestContext, 'principalIdentifier.uid');
+    const retVal = await Promise.all(
+      _.map(projects, async proj => {
+        if (await this.verifyUserProjectAssociation(by, proj.id)) return proj;
+        return undefined;
+      }),
+    );
+    return _.filter(retVal, val => !_.isUndefined(val));
   }
 
-  async verifyAppStreamConfig(requestContext, input) {
+  /**
+   * Returns the same object type as the input with an added isAppStreamConfigured boolean flag for each project entity
+   *
+   * IMPORTANT: The system context is used instead of the user's request context.
+   * This is because non-admin users do not have access to resources like indexes and awsAccounts,
+   * which are required for config verification. No other information from these resources are made available to non-admins
+   *
+   * @param input The Project entity, or list of Project entities
+   */
+  async verifyAppStreamConfig(input) {
     try {
+      const systemContext = getSystemRequestContext();
       const [awsAccountsService, indexesService] = await this.service(['awsAccountsService', 'indexesService']);
-      const accounts = await awsAccountsService.list(requestContext, {
+      const accounts = await awsAccountsService.list(systemContext, {
         fields: ['id', 'appStreamFleetName', 'appStreamSecurityGroupId', 'appStreamStackName'],
       });
-      const accountsWithAppStream = _.filter(
-        accounts,
-        account =>
-          !_.isUndefined(account.appStreamFleetName) &&
-          !_.isUndefined(account.appStreamSecurityGroupId) &&
-          !_.isUndefined(account.appStreamStackName),
+      const indexes = await indexesService.list(systemContext, { fieldsToGet: ['id', 'awsAccountId'] });
+      const accountIdsWithAppStream = _.map(
+        _.filter(
+          accounts,
+          account =>
+            !_.isUndefined(account.appStreamFleetName) &&
+            !_.isUndefined(account.appStreamSecurityGroupId) &&
+            !_.isUndefined(account.appStreamStackName),
+        ),
+        'id',
       );
-      const accountIdsWithAppStream = _.map(accountsWithAppStream, account => account.id);
-      const indexes = await indexesService.list(requestContext, { fieldsToGet: ['id', 'awsAccountId'] });
-      const indexesWithAppStream = _.filter(indexes, index => _.includes(accountIdsWithAppStream, index.awsAccountId));
-      const indexIdsWithAppStream = _.map(indexesWithAppStream, index => index.id);
+      const indexIdsWithAppStream = _.map(
+        _.filter(indexes, index => _.includes(accountIdsWithAppStream, index.awsAccountId)),
+        'id',
+      );
 
       if (_.isArray(input)) {
         return _.map(input, project => {

--- a/main/end-to-end-tests/cypress.local.example.json
+++ b/main/end-to-end-tests/cypress.local.example.json
@@ -6,6 +6,8 @@
   "env": {
     "researcherEmail": "thingut+researcher@amazon.com",
     "researcherPassword": "abcd1234",
+    "restrictedResearcherEmail": "dummyResearcher@amazon.com",
+    "restrictedResearcherPassword": "abcd1234",
     "isCognitoEnabled": false,
     "workspaces": {
       "sagemaker": {

--- a/main/end-to-end-tests/cypress/integration/workspaces.appstream.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspaces.appstream.spec.js
@@ -122,3 +122,23 @@ describe('Launch new workspaces', () => {
     return workspaceName;
   };
 });
+
+describe('Verify workspace creation button disabled', () => {
+  before(() => {
+    // We use the restricted researcher credentials for this test.
+    // This user should not be assigned to a project with AppStream configuration
+    cy.login('restrictedResearcher');
+    navigateToWorkspaces();
+  });
+
+  const navigateToWorkspaces = () => {
+    cy.get('.left.menu')
+      .contains('Workspaces')
+      .click();
+    cy.get('[data-testid=workspaces]');
+  };
+
+  it('should launch show create workspace button as disabled', () => {
+    cy.get('button[data-testid=create-workspace]').should('be.disabled');
+  });
+});

--- a/main/end-to-end-tests/cypress/support/commands.js
+++ b/main/end-to-end-tests/cypress/support/commands.js
@@ -51,6 +51,12 @@ Cypress.Commands.add('login', role => {
       email: Cypress.env('researcherEmail'),
       password: Cypress.env('researcherPassword'),
     };
+  }
+  if (role === 'restrictedResearcher') {
+    loginInfo = {
+      email: Cypress.env('restrictedResearcherEmail'),
+      password: Cypress.env('restrictedResearcherPassword'),
+    };
   } else if (role === 'admin') {
     loginInfo = {
       email: Cypress.env('adminEmail'),


### PR DESCRIPTION
Issue #, if available:
GALI-921

Description of changes:
[TRE] Disable workspace provisioning if AppStream is not setup in AWS account.

UI: Disable provision button
Backend: Throw error if workspace provision API is called
In scope: end to end test

In a gist:
Show workspace provisioning button only if any project account is AppStream-configured.
Finally, env provisioning should only list projects configured with AppStream (If a user tries this for non-AppStream configured projects, API throws error)


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.