### PR TITLE
fix: Remove delete user feature from UI and handle study permissions which have stale users

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
@@ -158,7 +158,17 @@ const UsersStore = BaseStore.named('UsersStore')
           if (user) {
             result.push(user);
           } else {
-            result.push(User.create(getSnapshot(userIdentifier)));
+            let userSnapshot;
+            try {
+              userSnapshot = getSnapshot(userIdentifier);
+            } catch (error) {
+              // Note that user might be already deleted. In order to prevent UI from crashing log the error instead
+              // and not add it to User list
+              console.log(`User ${userIdentifier.uid} doesn't exist`, error);
+            }
+            if (userSnapshot) {
+              result.push(User.create(userSnapshot));
+            }
           } // this could happen in the employee is no longer active or with the company
         }
       });

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/studies/__tests__/StudyPermissionsTable.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/studies/__tests__/StudyPermissionsTable.test.js
@@ -1,0 +1,35 @@
+import { getStaleUsers } from '../StudyPermissionsTable';
+
+describe('StudyPermissionsTable tests', () => {
+  describe('getStaleUsers', () => {
+    it('Test stale users when no users are stale', async () => {
+      const usersStore = {};
+      usersStore.asUserObjects = jest.fn().mockImplementationOnce(() => {
+        return [{ id: 1 }, { id: 2 }];
+      });
+      const staleUsers = getStaleUsers([1, 2], usersStore);
+      expect(staleUsers).toEqual([]);
+      expect(usersStore.asUserObjects).toHaveBeenCalledTimes(1);
+    });
+
+    it('Test stale users when all users are stale', async () => {
+      const usersStore = {};
+      usersStore.asUserObjects = jest.fn().mockImplementationOnce(() => {
+        return [];
+      });
+      const staleUsers = getStaleUsers([1, 2], usersStore);
+      expect(staleUsers).toEqual([1, 2]);
+      expect(usersStore.asUserObjects).toHaveBeenCalledTimes(1);
+    });
+
+    it('Test stale users when one user is stale', async () => {
+      const usersStore = {};
+      usersStore.asUserObjects = jest.fn().mockImplementationOnce(() => {
+        return [{ id: 1 }, { id: 4 }, { id: 3 }];
+      });
+      const staleUsers = getStaleUsers([1, 2, 4, 3], usersStore);
+      expect(staleUsers).toEqual([2]);
+      expect(usersStore.asUserObjects).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UpdateUser.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UpdateUser.js
@@ -149,18 +149,6 @@ class UpdateUser extends React.Component {
       disabled: this.processing,
     });
 
-    const deleteButton =
-      // TODO: deletion actions should be confirmed by user first
-      this.view === 'detail'
-        ? makeButton({
-            label: 'Delete',
-            floated: 'right',
-            color: 'red',
-            onClick: this.handleDeleteClick,
-            disabled: currentUser.isRootUser || this.processing,
-          })
-        : '';
-
     const activeButton =
       this.props.user.status === 'pending' || this.props.user.status === 'inactive'
         ? makeButton({
@@ -191,7 +179,6 @@ class UpdateUser extends React.Component {
       <div className="mt4 mb4">
         <Modal.Actions>
           {cancelButton}
-          {deleteButton}
           {deactiveButton}
           {activeButton}
           {editButton}
@@ -378,19 +365,6 @@ class UpdateUser extends React.Component {
     } catch (error) {
       displayError(error);
     }
-  };
-
-  handleDeleteClick = async () => {
-    try {
-      this.processing = true;
-      await this.usersStore.deleteUser(this.getCurrentUser());
-    } catch (error) {
-      displayError(error);
-    }
-    runInAction(() => {
-      this.processing = false;
-    });
-    this.handleClose();
   };
 
   handleApproveDisapproveClick = async status => {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-permission-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-permission-service.js
@@ -339,7 +339,9 @@ class StudyPermissionService extends Service {
 
       applyUpdateRequest(studyPermissionsEntity, updateRequest);
 
-      const userIds = getImpactedUsers(updateRequest);
+      // impacted users for update are only those users who are being added. Don't validate if users being removed
+      // exist or not since their permissions are being removed
+      const userIds = _.map(updateRequest.usersToAdd, item => item.uid);
       if (_.size(userIds) > 100) {
         // To protect against a large number
         throw this.boom.badRequest('You can only change permissions for up to 100 users', true);

--- a/addons/addon-base-ui/packages/base-ui/src/models/users/UsersStore.js
+++ b/addons/addon-base-ui/packages/base-ui/src/models/users/UsersStore.js
@@ -142,7 +142,6 @@ const UsersStore = BaseStore.named('UsersStore')
             if (userSnapshot) {
               result.push(User.create(userSnapshot));
             }
-            // result.push(User.create(getSnapshot(userIdentifier)));
           }
         }
       });

--- a/addons/addon-base-ui/packages/base-ui/src/models/users/UsersStore.js
+++ b/addons/addon-base-ui/packages/base-ui/src/models/users/UsersStore.js
@@ -131,7 +131,18 @@ const UsersStore = BaseStore.named('UsersStore')
           if (user) {
             result.push(user);
           } else {
-            result.push(User.create(getSnapshot(userIdentifier)));
+            let userSnapshot;
+            try {
+              userSnapshot = getSnapshot(userIdentifier);
+            } catch (error) {
+              // Note that user might be already deleted. In order to prevent UI from crashing log the error instead
+              // and not add it to User list
+              console.log(`User ${userIdentifier.uid} doesn't exist`, error);
+            }
+            if (userSnapshot) {
+              result.push(User.create(userSnapshot));
+            }
+            // result.push(User.create(getSnapshot(userIdentifier)));
           }
         }
       });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -264,7 +264,9 @@ paths:
       summary: Delete a User
       operationId: DeleteUser
       description: |
-        Delete a User
+        Delete a User. Note that this API doesn't check for outstanding resources like studies, environments, projects
+        etc. the user might have permissions to. Take caution while using this API since those resources might stop
+        functioning as expected. Consider using update API instead and change 'state' to 'inactive'.
       responses:
         '200':
           description: User deleted


### PR DESCRIPTION
Issue #, if available: [Issue-590](https://github.com/awslabs/service-workbench-on-aws/issues/590)

Description of changes:

* In [Issue-590](https://github.com/awslabs/service-workbench-on-aws/issues/590) it was observed that expanding study permissions on a study which has already deleted users causes SWB website to crash.
* Since deleting a user is can cause unknown side effects on resources that the user has permission to, I have removed the delete user button from UI. Note that the API still exists and the documentation has been updated to reflect the warning.
* I have updated permissions loading to account for deleted users so now UI wouldn't crash but we would still log the stale user on console as an error.
* Our update permission workflow has been changed to account for deleted users as well. I have made it such that our UI would now send stale user ids to remove list of update study permissions API.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.