### PR TITLE
fix: using the string value of AppStream flag

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -69,7 +69,7 @@ class EnvironmentScService extends Service {
     await super.init();
     const [dbService, environmentAuthzService] = await this.service(['dbService', 'environmentAuthzService']);
     const table = this.settings.get(settingKeys.tableName);
-    this.isAppStreamEnabled = this.settings.get(settingKeys.isAppStreamEnabled);
+    this.isAppStreamEnabled = this.settings.get(settingKeys.isAppStreamEnabled) === 'true';
 
     this._getter = () => dbService.helper.getter().table(table);
     this._query = () => dbService.helper.query().table(table);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/project/project-service.js
@@ -48,7 +48,7 @@ class ProjectService extends Service {
     const [dbService] = await this.service(['dbService']);
     const table = this.settings.get(settingKeys.tableName);
     this.userService = await this.service('userService');
-    this.isAppStreamEnabled = this.settings.get(settingKeys.isAppStreamEnabled);
+    this.isAppStreamEnabled = this.settings.get(settingKeys.isAppStreamEnabled) === 'true';
 
     this._getter = () => dbService.helper.getter().table(table);
     this._updater = () => dbService.helper.updater().table(table);


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Flag value is a boolean but read as a string in backend services.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.