### PR TITLE
feat: post deploy appstream step

### DIFF
--- a/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/__fixtures__/settings.js
+++ b/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/__fixtures__/settings.js
@@ -18,6 +18,7 @@ const { registerServices } = require('@aws-ee/base-services/lib/utils/services-r
 const keys = {
   enableegressstore: 'enableegressstore',
   backendStackName: 'backendStackName',
+  isAppStreamEnabled: 'isAppStreamEnabled',
 };
 
 const extensionPoints = {

--- a/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/update-cfn-stack-policy.test.js
+++ b/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/update-cfn-stack-policy.test.js
@@ -25,7 +25,7 @@ const UpdateCfnStackPolicy = require('../update-cfn-stack-policy');
 const CloudFormation = require('./__fixtures__/cloudformation');
 const registerSettings = require('./__fixtures__/settings');
 
-describe('UpgradeToUserId', () => {
+describe('UpdateCfnStackPolicy', () => {
   let service;
   let aws;
   let container;

--- a/addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
+++ b/addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
@@ -61,7 +61,7 @@ class UpdateCfnStackPolicy extends Service {
     const isAppStreamEnabled = this.settings.get(settingKeys.isAppStreamEnabled);
 
     if (!isEgressStoreEnabled && !isAppStreamEnabled) {
-      this.log.info('CFN stack policy is not updated');
+      this.log.info('AppStream and EgressStore disabled. CFN stack policy does not need updates');
       return;
     }
 
@@ -85,7 +85,6 @@ class UpdateCfnStackPolicy extends Service {
       isEmptyPolicy = isEmptyPolicy || finalPolicyBody.Statement.length === 0;
 
       if (isEmptyPolicy) {
-        // At least one of the features, AppStream or EgressStore, is enabled
         finalPolicyBody.Statement.push(baseAllowStatement);
         if (isEgressStoreEnabled) finalPolicyBody.Statement.push(egressStoreStatement);
         if (isAppStreamEnabled) finalPolicyBody.Statement.push(appStreamStatement);

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -1,8 +1,22 @@
 Conditions:
   IsDev: !Equals ['${self:custom.settings.envType}', 'dev']
   EnableEgressStore: !Equals ['${self:custom.settings.enableEgressStore}', 'true']
+  AppStreamEnabled: !Equals ['${self:custom.settings.isAppStreamEnabled}', true]
 
 Resources:
+  # =============================================================================================
+  # SSM
+  # =============================================================================================
+
+  # This parameter is created for its LogicalID. This is leveraged to ensure user cannot
+  # deploy SWB with AppStream disabled once it has been activated
+  AppStreamEnabled:
+    Condition: AppStreamEnabled
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: '${self:custom.settings.isAppStreamEnabled}'
+
   # =============================================================================================
   # S3
   # =============================================================================================

--- a/main/solution/post-deployment/config/infra/functions.yml
+++ b/main/solution/post-deployment/config/infra/functions.yml
@@ -35,6 +35,7 @@ postDeployment:
     APP_ENV_MGMT_ROLE_ARN: ${self:custom.settings.envMgmtRoleArn}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
     APP_ENABLE_EGRESS_STORE: ${self:custom.settings.enableEgressStore}
+    APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}
 
 egressStoreObjectsHandler:
   role: RoleEgressStoreObjectsHandler


### PR DESCRIPTION
Issue #, if available:
GALI-910

Description of changes:
This change attempts to make the `isAppStreamEnabled` flag immutable by restricting backend stack from updating when changed, similar to `enableEgressStore`.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.