### PR TITLE
feat: Disable CIDR feature when AppStream is enabled

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/settings.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/settings.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 const enableBuiltInWorkspaces = process.env.REACT_APP_ENABLE_BUILT_IN_WORKSPACES === 'true';
 const enableEgressStore = process.env.REACT_APP_ENABLE_EGRESS_STORE;
+const isAppStreamEnabled = process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
 
-export { enableBuiltInWorkspaces, enableEgressStore };
+export { enableBuiltInWorkspaces, enableEgressStore, isAppStreamEnabled };

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
@@ -9,7 +9,7 @@ import { displayError } from '@aws-ee/base-ui/dist/helpers/notification';
 
 import ScEnvironmentConnections from './ScEnvironmentConnections';
 import ScEnvironmentUpdateCidrs from './ScEnvironmentUpdateCidrs';
-import { enableEgressStore } from '../../../helpers/settings';
+import { enableEgressStore, isAppStreamEnabled } from '../../../helpers/settings';
 import ScEnvironmentEgressStoreDetail from './ScEnvironmentEgressStoreDetail';
 
 const PROCESSING_STATUS_CODE = 'PROCESSING';
@@ -212,7 +212,7 @@ class ScEnvironmentButtons extends React.Component {
               View Detail
             </Button>
           )}
-          {state.canTerminate && !state.key.includes('FAILED') && (
+          {!isAppStreamEnabled && state.canTerminate && !state.key.includes('FAILED') && (
             <Button
               floated="left"
               basic

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -28,7 +28,7 @@ class CreateInternalEnvForm extends React.Component {
     runInAction(() => {
       this.form = getCreateInternalEnvForm({
         projectIdOptions: this.getProjectIdOptions(),
-        cidr: this.props.defaultCidr,
+        cidr: this.isAppStreamEnabled ? undefined : this.props.defaultCidr,
       });
     });
   }
@@ -148,7 +148,7 @@ class CreateInternalEnvForm extends React.Component {
 
   renderForm() {
     const form = this.form;
-    const askForCidr = !_.isUndefined(this.props.defaultCidr);
+    const askForCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
     const configurations = this.configurations;
 
     // we show the AppStream configuration warning when the feature is enabled,

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -23,6 +23,7 @@ Parameters:
   AccessFromCIDRBlock:
     Type: String
     Description: The CIDR used to access the ec2 instances.
+    Default: 10.0.0.0/19
   S3Mounts:
     Type: String
     Description: A JSON array of objects with name, bucket, and prefix properties used to mount data
@@ -137,10 +138,13 @@ Resources:
           FromPort: 0
           ToPort: 65535
           CidrIp: 0.0.0.0/0
-        - IpProtocol: icmp
-          FromPort: -1
-          ToPort: -1
-          CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: icmp
+            FromPort: -1
+            ToPort: -1
+            CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - DestinationSecurityGroupId:
@@ -148,24 +152,29 @@ Resources:
             IpProtocol: '-1'
           - !Ref "AWS::NoValue"
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref AccessFromCIDRBlock
-        - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: !Ref AccessFromCIDRBlock
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - SourceSecurityGroupId:
               Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
             IpProtocol: '-1'
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
           - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 80
+            ToPort: 80
+            CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: !Ref AccessFromCIDRBlock
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-sg']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -26,6 +26,7 @@ Parameters:
   AccessFromCIDRBlock:
     Type: String
     Description: The CIDR used to access the ec2 instances.
+    Default: 10.0.0.0/19
   S3Mounts:
     Type: String
     Description: A JSON array of objects with name, bucket, and prefix properties used to mount data
@@ -159,10 +160,13 @@ Resources:
           FromPort: 0
           ToPort: 65535
           CidrIp: 0.0.0.0/0
-        - IpProtocol: icmp
-          FromPort: -1
-          ToPort: -1
-          CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: icmp
+            FromPort: -1
+            ToPort: -1
+            CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - DestinationSecurityGroupId:
@@ -170,16 +174,15 @@ Resources:
             IpProtocol: '-1'
           - !Ref "AWS::NoValue"
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 3389
-          ToPort: 3389
-          CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - SourceSecurityGroupId:
               Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
             IpProtocol: '-1'
-          - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 3389
+            ToPort: 3389
+            CidrIp: !Ref AccessFromCIDRBlock
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-sg']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -21,7 +21,8 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
   AccessFromCIDRBlock:
     Type: String
-    Description: The CIDR used to access sagemaker.
+    Description: The CIDR used to access sagemaker. This parameter is only required when AppStream is disabled
+    Default: 10.0.0.0/19
   S3Mounts:
     Type: String
     Description: A JSON array of objects with name, bucket and prefix properties used to mount data
@@ -60,6 +61,9 @@ Resources:
       VpcId:
         Ref: VPC
       SecurityGroupIngress:
+        !If
+        - AppStreamEnabled
+        - !Ref 'AWS::NoValue'
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -61,13 +61,13 @@ Resources:
       VpcId:
         Ref: VPC
       SecurityGroupIngress:
-        !If
-        - AppStreamEnabled
-        - !Ref 'AWS::NoValue'
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: !Ref AccessFromCIDRBlock
 
   PreSignedURLBoundary:
     Type: AWS::IAM::ManagedPolicy

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
@@ -71,11 +71,11 @@ describe('EnvironmentScCidrService', () => {
     lockService = await container.find('lockService');
     environmentScService = await container.find('environmentScService');
     settings = await container.find('settings');
-    settings.optionalBoolean = jest.fn(key => {
+    settings.getBoolean = jest.fn(key => {
       if (key === 'isAppStreamEnabled') {
         return false;
       }
-      return undefined;
+      throw Error(`${key} not found`);
     });
 
     // Skip authorization by default
@@ -89,11 +89,11 @@ describe('EnvironmentScCidrService', () => {
   describe('Validation checks', () => {
     it('should fail validation check since AppStream is enabled', async () => {
       // BUILD
-      settings.optionalBoolean = jest.fn(key => {
+      settings.getBoolean = jest.fn(key => {
         if (key === 'isAppStreamEnabled') {
           return true;
         }
-        return undefined;
+        throw Error(`${key} not found`);
       });
       const requestContext = {};
       const params = {
@@ -115,8 +115,8 @@ describe('EnvironmentScCidrService', () => {
       } catch (err) {
         expect(service.boom.is(err, 'badRequest')).toBe(true);
         expect(err.message).toContain('CIDR operation unavailable when AppStream is enabled');
-        expect(settings.optionalBoolean).toHaveBeenCalledTimes(1);
-        expect(settings.optionalBoolean).toHaveBeenCalledWith('isAppStreamEnabled', false);
+        expect(settings.getBoolean).toHaveBeenCalledTimes(1);
+        expect(settings.getBoolean).toHaveBeenCalledWith('isAppStreamEnabled');
       }
     });
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
@@ -46,6 +46,7 @@ describe('EnvironmentScCidrService', () => {
   let service = null;
   let environmentScService = null;
   let lockService = null;
+  let settings = null;
 
   beforeEach(async () => {
     const container = new ServicesContainer();
@@ -69,6 +70,13 @@ describe('EnvironmentScCidrService', () => {
     service = await container.find('environmentScCidrService');
     lockService = await container.find('lockService');
     environmentScService = await container.find('environmentScService');
+    settings = await container.find('settings');
+    settings.optionalBoolean = jest.fn(key => {
+      if (key === 'isAppStreamEnabled') {
+        return false;
+      }
+      return undefined;
+    });
 
     // Skip authorization by default
     service.assertAuthorized = jest.fn();
@@ -79,6 +87,39 @@ describe('EnvironmentScCidrService', () => {
   });
 
   describe('Validation checks', () => {
+    it('should fail validation check since AppStream is enabled', async () => {
+      // BUILD
+      settings.optionalBoolean = jest.fn(key => {
+        if (key === 'isAppStreamEnabled') {
+          return true;
+        }
+        return undefined;
+      });
+      const requestContext = {};
+      const params = {
+        id: 'testId',
+        updateRequest: [
+          {
+            protocol: 'tcp',
+            fromPort: 123,
+            toPort: 123,
+            cidrBlocks: ['123.123.123.123/32'],
+          },
+        ],
+      };
+
+      // OPERATE
+      try {
+        await service.update(requestContext, params);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(service.boom.is(err, 'badRequest')).toBe(true);
+        expect(err.message).toContain('CIDR operation unavailable when AppStream is enabled');
+        expect(settings.optionalBoolean).toHaveBeenCalledTimes(1);
+        expect(settings.optionalBoolean).toHaveBeenCalledWith('isAppStreamEnabled', false);
+      }
+    });
+
     it('should fail because the updateRequest contains additional properties', async () => {
       // BUILD
       const params = {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
@@ -19,6 +19,10 @@ const Service = require('@aws-ee/base-services-container/lib/service');
 
 const cidrUpdateSchema = require('../../schema/update-environment-sc-cidr');
 
+const settingKeys = {
+  isAppStreamEnabled: 'isAppStreamEnabled',
+};
+
 class EnvironmentScCidrService extends Service {
   constructor() {
     super();
@@ -42,6 +46,10 @@ class EnvironmentScCidrService extends Service {
   }
 
   checkRequest(updateRequest) {
+    const isAppStreamEnabled = this.settings.optionalBoolean(settingKeys.isAppStreamEnabled, false);
+    if (isAppStreamEnabled) {
+      throw this.boom.badRequest(`CIDR operation unavailable when AppStream is enabled`, true);
+    }
     const erroneousInputs = [];
     const ipv6Format = [];
     const protPortCombos = {};

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
@@ -46,7 +46,7 @@ class EnvironmentScCidrService extends Service {
   }
 
   checkRequest(updateRequest) {
-    const isAppStreamEnabled = this.settings.optionalBoolean(settingKeys.isAppStreamEnabled, false);
+    const isAppStreamEnabled = this.settings.getBoolean(settingKeys.isAppStreamEnabled);
     if (isAppStreamEnabled) {
       throw this.boom.badRequest(`CIDR operation unavailable when AppStream is enabled`, true);
     }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -1020,19 +1020,23 @@ class EnvironmentScService extends Service {
 
     // Only send back details of groups configured by the SC CFN stack
     const returnVal = _.map(cfnTemplateIngressRules, cfnRule => {
+      let ruleToUse = cfnRule;
+      if ('Fn::If' in cfnRule && cfnRule['Fn::If'][0] === 'AppStreamEnabled') {
+        ruleToUse = cfnRule['Fn::If'][2];
+      }
       const matchingRule = _.find(
         workspaceIngressRules,
         workspaceRule =>
-          cfnRule.FromPort === workspaceRule.FromPort &&
-          cfnRule.ToPort === workspaceRule.ToPort &&
-          cfnRule.IpProtocol === workspaceRule.IpProtocol,
+          ruleToUse.FromPort === workspaceRule.FromPort &&
+          ruleToUse.ToPort === workspaceRule.ToPort &&
+          ruleToUse.IpProtocol === workspaceRule.IpProtocol,
       );
       const currentCidrRanges = matchingRule ? _.map(matchingRule.IpRanges, ipRange => ipRange.CidrIp) : [];
 
       return {
-        fromPort: cfnRule.FromPort,
-        toPort: cfnRule.ToPort,
-        protocol: cfnRule.IpProtocol,
+        fromPort: ruleToUse.FromPort,
+        toPort: ruleToUse.ToPort,
+        protocol: ruleToUse.IpProtocol,
         cidrBlocks: currentCidrRanges,
       };
     });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -1041,7 +1041,7 @@ class EnvironmentScService extends Service {
   }
 
   isAppStreamEnabled() {
-    return this.settings.optionalBoolean(settingKeys.isAppStreamEnabled, false);
+    return this.settings.getBoolean(settingKeys.isAppStreamEnabled);
   }
 
   /**

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/models/forms/CfnParamsForm.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/models/forms/CfnParamsForm.js
@@ -33,15 +33,18 @@ import { createForm } from '@aws-ee/base-ui/dist/helpers/form';
  * @param existingParamValues Array containing key/value pairs for existing values for the params. Has the shape [{key,value}]
  */
 function getCfnParamsForm(cfnParams, existingParamValues) {
+  const isAppStreamEnabled = process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
   const fields = {};
   _.forEach(cfnParams, ({ ParameterKey, Description, DefaultValue }) => {
     const existingValue = _.get(_.find(existingParamValues, { key: ParameterKey }), 'value') || DefaultValue;
-    fields[ParameterKey] = {
-      label: ParameterKey,
-      extra: { explain: Description },
-      value: existingValue,
-      rules: 'required',
-    };
+    if (!isAppStreamEnabled || (isAppStreamEnabled && !(ParameterKey === 'AccessFromCIDRBlock'))) {
+      fields[ParameterKey] = {
+        label: ParameterKey,
+        extra: { explain: Description },
+        value: existingValue,
+        rules: 'required',
+      };
+    }
   });
   return createForm(fields);
 }

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/models/forms/__tests__/CfnParamsForm.test.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/models/forms/__tests__/CfnParamsForm.test.js
@@ -1,0 +1,134 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { getCfnParamsForm } from '../CfnParamsForm';
+
+jest.mock('@aws-ee/base-ui/dist/helpers/form');
+const formMock = require('@aws-ee/base-ui/dist/helpers/form');
+
+describe('CfnParamsForm', () => {
+  const param1 = { ParameterKey: 'key1', Description: 'desc1', DefaultValue: 'default1' };
+  const param2 = { ParameterKey: 'key2', Description: 'desc2', DefaultValue: 'default2' };
+  let defaultParams = null;
+  let defaultFields = null;
+  const expectedForm = 'testForm';
+
+  beforeEach(async () => {
+    defaultParams = [param1, param2];
+    defaultFields = {
+      key1: {
+        label: param1.ParameterKey,
+        extra: { explain: param1.Description },
+        value: param1.DefaultValue,
+        rules: 'required',
+      },
+      key2: {
+        label: param2.ParameterKey,
+        extra: { explain: param2.Description },
+        value: param2.DefaultValue,
+        rules: 'required',
+      },
+    };
+
+    formMock.createForm = jest.fn(() => {
+      return expectedForm;
+    });
+  });
+
+  afterEach(async () => {
+    formMock.createForm.mockReset();
+  });
+
+  it('should return all fields when AppStream is enabled and no CIDR config present', async () => {
+    // BUILD
+    process.env.REACT_APP_IS_APP_STREAM_ENABLED = true;
+
+    // OPERATE
+    const returnedForm = getCfnParamsForm(defaultParams, []);
+
+    // CHECK
+    expect(returnedForm).toBe(expectedForm);
+    expect(formMock.createForm).toHaveBeenCalledTimes(1);
+    expect(formMock.createForm).toHaveBeenCalledWith(defaultFields);
+  });
+
+  it('should return all fields when AppStream is disabled and no CIDR config present', async () => {
+    // BUILD
+    process.env.REACT_APP_IS_APP_STREAM_ENABLED = false;
+
+    // OPERATE
+    const returnedForm = getCfnParamsForm(defaultParams, []);
+
+    // CHECK
+    expect(returnedForm).toBe(expectedForm);
+    expect(formMock.createForm).toHaveBeenCalledTimes(1);
+    expect(formMock.createForm).toHaveBeenCalledWith(defaultFields);
+  });
+
+  it('should return default values correctly', async () => {
+    // BUILD
+    const overwriteParam2 = { ParameterKey: 'key2', Description: 'desc2', DefaultValue: 'newDefault2' };
+    const params = [param1, overwriteParam2];
+    const newFields = JSON.parse(JSON.stringify(defaultFields));
+    newFields.key2.value = overwriteParam2.DefaultValue;
+
+    // OPERATE
+    const returnedForm = getCfnParamsForm(params, []);
+
+    // CHECK
+    expect(returnedForm).toBe(expectedForm);
+    expect(formMock.createForm).toHaveBeenCalledTimes(1);
+    expect(formMock.createForm).toHaveBeenCalledWith(newFields);
+  });
+
+  it('should not return cidr field when AppStream is enabled and CIDR config present', async () => {
+    // BUILD
+    process.env.REACT_APP_IS_APP_STREAM_ENABLED = true;
+    const param3 = { ParameterKey: 'AccessFromCIDRBlock', Description: 'cidr', DefaultValue: '0.0.0.0/32' };
+    const paramsWithCidr = [...defaultParams];
+    paramsWithCidr.push(param3);
+
+    // OPERATE
+    const returnedForm = getCfnParamsForm(paramsWithCidr, []);
+
+    // CHECK
+    expect(returnedForm).toBe(expectedForm);
+    expect(formMock.createForm).toHaveBeenCalledTimes(1);
+    expect(formMock.createForm).toHaveBeenCalledWith(defaultFields);
+  });
+
+  it('should return all fields including cidr field when AppStream is disabled and CIDR config present', async () => {
+    // BUILD
+    process.env.REACT_APP_IS_APP_STREAM_ENABLED = false;
+    const param3 = { ParameterKey: 'AccessFromCIDRBlock', Description: 'cidr', DefaultValue: '0.0.0.0/32' };
+    const paramsWithCidr = [...defaultParams];
+    paramsWithCidr.push(param3);
+    const fieldsWithCidr = JSON.parse(JSON.stringify(defaultFields));
+    fieldsWithCidr.AccessFromCIDRBlock = {
+      label: param3.ParameterKey,
+      extra: { explain: param3.Description },
+      value: param3.DefaultValue,
+      rules: 'required',
+    };
+
+    // OPERATE
+    const returnedForm = getCfnParamsForm(paramsWithCidr, []);
+
+    // CHECK
+    expect(returnedForm).toBe(expectedForm);
+    expect(formMock.createForm).toHaveBeenCalledTimes(1);
+    expect(formMock.createForm).toHaveBeenCalledWith(fieldsWithCidr);
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3414,6 +3414,7 @@ components:
           type: string
           pattern: '^(?:([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?)?$'
           example: '192.255.255.255/32'
+          description: optional field only to be specified if AppStream feature is disabled
         studyIds:
           type: array
           example: ['test_study1']


### PR DESCRIPTION
Issue #, if available: GALI-920

Description of changes:

Made following changes if AppStream is enabled:
1. [UI] Disabled edit CIDR 
2. [UI] Remove CIDR field from CFN templates and workspace provisioning form
3. [API] Throw error if CIDR change is required 
4. [API] Stop vending out CIDR info if AppStream is enabled
5. [Templates] Update SageMaker, EC2 Linux and EC2 Windows templates to not include access CIDR block
6. Added unit tests and tested changes from UI
7. Backwards compatibility when AppStream is disabled

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.