### PR TITLE
fix: egress store data access cross account

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
@@ -528,6 +528,110 @@ describe('EnvironmentResourceService', () => {
       expect(putKeyPolicyMock).toHaveBeenCalledTimes(1);
     });
 
+    it('add new principal to KMS policy with multiple principals with egress feature enabled', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataBucketName') {
+            return 'study-bucket';
+          }
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          if (settingName === 'enableEgressStore') {
+            return 'true';
+          }
+          if (settingName === 'egressStoreBucketName') {
+            return 'test-egressStoreBucketName';
+          }
+          if (settingName === 'egressStoreKmsKeyArn') {
+            return 'test-egressStoreKmsKeyArn';
+          }
+          if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
+            return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+      };
+      const oldKMSPolicy = {
+        Statement: [
+          {
+            Sid: 'KMS Policy',
+            Effect: 'Allow',
+            Principal: {
+              AWS: ['arn:aws:iam::accountId1:root'],
+            },
+            Action: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
+            Resource: '*',
+          },
+        ],
+      };
+      AWSMock.mock('KMS', 'describeKey', (params, callback) => {
+        callback(null, { KeyMetadata: { KeyId: 'kmsStudyKeyId' } });
+      });
+      AWSMock.mock('KMS', 'getKeyPolicy', (params, callback) => {
+        expect(params).toMatchObject({
+          KeyId: 'kmsStudyKeyId',
+          PolicyName: 'default',
+        });
+        callback(null, { Policy: JSON.stringify(oldKMSPolicy) });
+      });
+
+      const putKeyPolicyMock = jest.fn((params, callback) => {
+        callback(null, {});
+      });
+      AWSMock.mock('KMS', 'putKeyPolicy', putKeyPolicyMock);
+      await environmentResourceService.addToKmsKeyPolicy({}, 'accountId2');
+      expect(putKeyPolicyMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('add new principal to KMS policy with no principals with egress feauture enabled', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataBucketName') {
+            return 'study-bucket';
+          }
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          if (settingName === 'enableEgressStore') {
+            return 'true';
+          }
+          if (settingName === 'egressStoreBucketName') {
+            return 'test-egressStoreBucketName';
+          }
+          if (settingName === 'egressStoreKmsKeyArn') {
+            return 'test-egressStoreKmsKeyArn';
+          }
+          if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
+            return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+      };
+      AWSMock.mock('KMS', 'describeKey', (params, callback) => {
+        callback(null, { KeyMetadata: { KeyId: 'kmsStudyKeyId' } });
+      });
+      AWSMock.mock('KMS', 'getKeyPolicy', (params, callback) => {
+        expect(params).toMatchObject({
+          KeyId: 'kmsStudyKeyId',
+          PolicyName: 'default',
+        });
+        callback(null, { Policy: '{}' });
+      });
+      const putKeyPolicyMock = jest.fn((params, callback) => {
+        callback(null, {});
+      });
+      AWSMock.mock('KMS', 'putKeyPolicy', putKeyPolicyMock);
+      await environmentResourceService.addToKmsKeyPolicy({}, 'accountId1');
+      expect(putKeyPolicyMock).toHaveBeenCalledTimes(2);
+    });
+
     it('add new principal to KMS policy with multiple principals', async () => {
       const oldKMSPolicy = {
         Statement: [

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
@@ -729,6 +729,71 @@ describe('EnvironmentResourceService', () => {
       expect(putKeyPolicyMock).toHaveBeenCalledTimes(1);
     });
 
+    it('remove principals from KMS policy with multiple principals with egress feature enabled', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataBucketName') {
+            return 'study-bucket';
+          }
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          if (settingName === 'enableEgressStore') {
+            return 'true';
+          }
+          if (settingName === 'egressStoreBucketName') {
+            return 'test-egressStoreBucketName';
+          }
+          if (settingName === 'egressStoreKmsKeyArn') {
+            return 'test-egressStoreKmsKeyArn';
+          }
+          if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
+            return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+      };
+      const oldKMSPolicy = {
+        Statement: [
+          {
+            Sid: 'KMS Policy',
+            Effect: 'Allow',
+            Principal: {
+              AWS: ['arn:aws:iam::accountId1:root', 'arn:aws:iam::accountId2:root', 'arn:aws:iam::accountId3:root'],
+            },
+            Action: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
+            Resource: '*',
+          },
+        ],
+      };
+      const expectedKMSPolicy = { ...oldKMSPolicy };
+      expectedKMSPolicy.Statement[0].Principal.AWS = ['arn:aws:iam::accountId1:root', 'arn:aws:iam::accountId3:root'];
+      AWSMock.mock('KMS', 'describeKey', (params, callback) => {
+        callback(null, { KeyMetadata: { KeyId: 'kmsStudyKeyId' } });
+      });
+      AWSMock.mock('KMS', 'getKeyPolicy', (params, callback) => {
+        expect(params).toMatchObject({
+          KeyId: 'kmsStudyKeyId',
+          PolicyName: 'default',
+        });
+        callback(null, { Policy: JSON.stringify(oldKMSPolicy) });
+      });
+      const putKeyPolicyMock = jest.fn((params, callback) => {
+        expect(params).toMatchObject({
+          KeyId: 'kmsStudyKeyId',
+          PolicyName: 'default',
+          Policy: JSON.stringify(expectedKMSPolicy),
+        });
+        callback(null, {});
+      });
+      AWSMock.mock('KMS', 'putKeyPolicy', putKeyPolicyMock);
+      await environmentResourceService.removeFromKmsKeyPolicy({}, 'accountId2');
+      expect(putKeyPolicyMock).toHaveBeenCalledTimes(2);
+    });
+
     it('remove one principal from KMS policy with multiple principals', async () => {
       const oldKMSPolicy = {
         Statement: [

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -209,5 +209,6 @@ workflowLoopRunner:
     APP_ENABLE_EGRESS_STORE: ${self:custom.settings.enableEgressStore}
     APP_EGRESS_STORE_BUCKET_NAME: ${self:custom.settings.egressStoreBucketName}
     APP_EGRESS_STORE_KMS_KEY_ALIAS_ARN: ${self:custom.settings.egressStoreKmsKeyAliasArn}
+    APP_EGRESS_STORE_KMS_KEY_ARN: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${self:custom.settings.egressStoreKmsKeyAlias}
     APP_EGRESS_STORE_KMS_POLICY_WORKSPACE_SID: ${self:custom.settings.egressStoreKmsPolicyWorkspaceSid}
     APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -295,7 +295,7 @@ egressStoreKmsKeyAliasArn: arn:aws:kms:${self:custom.settings.awsRegion}:${self:
 
 # The statement ID in the generated KMS key's key policy that controls which workspaces
 #   can decrypt data in the egress store data bucket
-egressStoreKmsPolicyWorkspaceSid: Allow workspace environments to CRUD egress data
+egressStoreKmsPolicyWorkspaceSid: Allow workspace environments to access egress data
 
 # The name of the IAM role created for the Lambda egressStoreObjectsHandler
 egressStoreObjectHandlerRoleName: ${self:custom.settings.namespace}-EgressStoreObject


### PR DESCRIPTION
Issue #, if available:
The  workspace across AWS was not able to access the egress store.

Description of changes:

- update CMS policy 
- add unit tests

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.