### PR TITLE
fix: update kms policy when no study selected

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/legacy/environment-resource-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/legacy/environment-resource-service.js
@@ -35,7 +35,6 @@ const settingKeys = {
   studyDataKmsKeyArn: 'studyDataKmsKeyArn',
   studyDataKmsPolicyWorkspaceSid: 'studyDataKmsPolicyWorkspaceSid',
   enableEgressStore: 'enableEgressStore',
-  egressStoreBucketName: 'egressStoreBucketName',
   egressStoreKmsKeyArn: 'egressStoreKmsKeyArn',
   egressStoreKmsPolicyWorkspaceSid: 'egressStoreKmsPolicyWorkspaceSid',
 };
@@ -310,16 +309,18 @@ class EnvironmentResourceService extends Service {
   // @private
   async addToKmsKeyPolicy(requestContext, memberAccountId) {
     await this.updateKMSPolicy(environmentStatement => addAccountToStatement(environmentStatement, memberAccountId));
+    await this.addToEgressKmsKeyPolicy(memberAccountId);
+    // Write audit event
+    await this.audit(requestContext, { action: 'add-to-KmsKey-policy', body: memberAccountId });
+  }
 
+  async addToEgressKmsKeyPolicy(memberAccountId) {
     const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
     if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
       await this.updateEgressKMSPolicy(environmentStatement =>
         addAccountToStatement(environmentStatement, memberAccountId),
       );
     }
-
-    // Write audit event
-    await this.audit(requestContext, { action: 'add-to-KmsKey-policy', body: memberAccountId });
   }
 
   // @private

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/environment-resource-service.test.js
@@ -245,7 +245,7 @@ describe('EnvironmentResourceService', () => {
     service.addToEgressKmsKeyPolicy = jest.fn();
     service.audit = jest.fn();
 
-    await service.allocateEgressResourcesOnly(requestContext, { studies, memberAccountId });
+    await service.updateKMSPolicyForEgress(requestContext, { studies, memberAccountId });
 
     expect(service.addToEgressKmsKeyPolicy).toHaveBeenCalledTimes(1);
     expect(service.addToEgressKmsKeyPolicy).toHaveBeenCalledWith(memberAccountId);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
@@ -19,11 +19,18 @@ const Service = require('@aws-ee/base-services-container/lib/service');
 const { getSystemRequestContext } = require('@aws-ee/base-services/lib/helpers/system-context');
 const { processInBatches } = require('@aws-ee/base-services/lib/helpers/utils');
 
+const { addAccountToStatement } = require('../../../helpers/utils');
+
 /**
  * This service is responsible for allocating and de-allocating AWS resources for the environment so that
  * the environment can access what it needs, such as studies. This service implements the roles only
  * study access strategy.
  */
+const settingKeys = {
+  enableEgressStore: 'enableEgressStore',
+  egressStoreKmsKeyArn: 'egressStoreKmsKeyArn',
+  egressStoreKmsPolicyWorkspaceSid: 'egressStoreKmsPolicyWorkspaceSid',
+};
 class EnvironmentResourceService extends Service {
   constructor() {
     super();
@@ -254,6 +261,71 @@ class EnvironmentResourceService extends Service {
     return s3Mounts;
   }
 
+  async allocateEgressResourcesOnly(requestContext, { studies: allStudies, memberAccountId }) {
+    // Legacy access strategy is only applicable for studies that have resources attributes
+    const kmsKeyAlias = this.settings.get(settingKeys.egressStoreKmsKeyArn);
+    const studies = _.filter(allStudies, study => !_.isEmpty(study.resources));
+    const lockService = await this.service('lockService');
+    const lockId = `kms-policy-access-${kmsKeyAlias}`;
+
+    if (_.isEmpty(studies)) {
+      await lockService.tryWriteLockAndRun({ id: lockId }, async () => {
+        await this.addToEgressKmsKeyPolicy(memberAccountId);
+      });
+      return;
+    }
+    await this.audit(requestContext, { action: 'add-to-egress-kms-policy', body: kmsKeyAlias });
+  }
+
+  async addToEgressKmsKeyPolicy(memberAccountId) {
+    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
+    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+      await this.updateEgressKMSPolicy(environmentStatement =>
+        addAccountToStatement(environmentStatement, memberAccountId),
+      );
+    }
+  }
+
+  async updateEgressKMSPolicy(updateStatementFn) {
+    const kmsClient = await this.getKMS();
+    const kmsKeyAlias = this.settings.get(settingKeys.egressStoreKmsKeyArn);
+    const keyId = (await kmsClient.describeKey({ KeyId: kmsKeyAlias }).promise()).KeyMetadata.KeyId;
+
+    // Get existing policy
+    const kmsPolicy = JSON.parse(
+      (await kmsClient.getKeyPolicy({ KeyId: keyId, PolicyName: 'default' }).promise()).Policy,
+    );
+
+    // Get statement
+    const sid = this.settings.get(settingKeys.egressStoreKmsPolicyWorkspaceSid);
+    if (!kmsPolicy.Statement) {
+      kmsPolicy.Statement = [];
+    }
+    let environmentStatement = kmsPolicy.Statement.find(statement => statement.Sid === sid);
+    if (!environmentStatement) {
+      // Create new statement if it doesn't already exist
+      environmentStatement = {
+        Sid: sid,
+        Effect: 'Allow',
+        Principal: { AWS: [] },
+        Action: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
+        Resource: '*', // Only refers to this key since it's a resource policy
+      };
+    }
+
+    // Update policy
+    environmentStatement = await updateStatementFn(environmentStatement);
+
+    // remove the old statement from KMS policy
+    kmsPolicy.Statement = kmsPolicy.Statement.filter(statement => statement.Sid !== sid);
+
+    // add the revised statement if it contains principals (otherwise leave it out)
+    if (environmentStatement.Principal.AWS.length > 0) {
+      kmsPolicy.Statement.push(environmentStatement);
+    }
+    await kmsClient.putKeyPolicy({ KeyId: keyId, PolicyName: 'default', Policy: JSON.stringify(kmsPolicy) }).promise();
+  }
+
   async audit(requestContext, auditEvent) {
     const auditWriterService = await this.service('auditWriterService');
     // Calling "writeAndForget" instead of "write" to allow main call to continue without waiting for audit logging
@@ -261,6 +333,16 @@ class EnvironmentResourceService extends Service {
     // If the main call also needs to fail in case writing to any audit destination fails then switch to "write" method as follows
     // return auditWriterService.write(requestContext, auditEvent);
     return auditWriterService.writeAndForget(requestContext, auditEvent);
+  }
+
+  async getKMS() {
+    const aws = await this.getAWS();
+    return new aws.sdk.KMS();
+  }
+
+  async getAWS() {
+    const aws = await this.service('aws');
+    return aws;
   }
 }
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
@@ -261,7 +261,7 @@ class EnvironmentResourceService extends Service {
     return s3Mounts;
   }
 
-  async allocateEgressResourcesOnly(requestContext, { studies: allStudies, memberAccountId }) {
+  async updateKMSPolicyForEgress(requestContext, { studies: allStudies, memberAccountId }) {
     // Legacy access strategy is only applicable for studies that have resources attributes
     const kmsKeyAlias = this.settings.get(settingKeys.egressStoreKmsKeyArn);
     const studies = _.filter(allStudies, study => !_.isEmpty(study.resources));

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
@@ -69,7 +69,7 @@ describe('envProvisioningPlugin', () => {
       expect(environmentScService.getMemberAccount).toHaveBeenCalledWith(requestContext, { id: 'env-id' });
       expect(pluginRegistryService.visitPlugins).toHaveBeenCalledWith(
         'study-access-strategy',
-        'allocateEnvEgressResourcesOnly',
+        'updateKMSPolicyForEgress',
         {
           payload: expect.objectContaining({
             environmentScEntity: {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
@@ -56,12 +56,36 @@ describe('envProvisioningPlugin', () => {
   });
 
   describe('preProvisioning', () => {
-    it('should do nothing if there is no study to be linked', async () => {
+    it('should invoke kms update for egress store if there is no study to be linked', async () => {
+      // BUILD
+      environmentScService.mustFind = jest.fn().mockResolvedValueOnce({ id: 'env-id' });
+      environmentScService.getStudies = jest.fn().mockResolvedValueOnce([]);
+      environmentScService.getMemberAccount = jest.fn().mockResolvedValueOnce({ accountId: '1234567' });
+      pluginRegistryService.visitPlugins = jest.fn();
+
       // OPERATE
       await plugin.onEnvPreProvisioning({ requestContext, container, envId: 'some-env-id' });
       // TEST
-      expect(environmentScService.getMemberAccount).not.toHaveBeenCalled();
-      expect(pluginRegistryService.visitPlugins).not.toHaveBeenCalled();
+      expect(environmentScService.getMemberAccount).toHaveBeenCalledWith(requestContext, { id: 'env-id' });
+      expect(pluginRegistryService.visitPlugins).toHaveBeenCalledWith(
+        'study-access-strategy',
+        'allocateEnvEgressResourcesOnly',
+        {
+          payload: expect.objectContaining({
+            environmentScEntity: {
+              id: 'env-id',
+            },
+            memberAccountId: '1234567',
+            requestContext: {
+              principal: {
+                isAdmin: true,
+                status: 'active',
+              },
+            },
+            studies: [],
+          }),
+        },
+      );
     });
 
     it('visit plugins with correct parameters if there is study to be linked', async () => {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -73,7 +73,7 @@ async function preProvisioning({ requestContext, container, envId }) {
   const pluginRegistryService = await container.find('pluginRegistryService');
 
   if (_.isEmpty(studies)) {
-    await pluginRegistryService.visitPlugins('study-access-strategy', 'allocateEnvEgressResourcesOnly', {
+    await pluginRegistryService.visitPlugins('study-access-strategy', 'updateKMSPolicyForEgress', {
       payload: {
         requestContext,
         container,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/roles-only-strategy-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/roles-only-strategy-plugin.js
@@ -81,6 +81,15 @@ async function allocateEnvStudyResources(payload) {
   return payload;
 }
 
+async function allocateEnvEgressResourcesOnly(payload) {
+  const { requestContext, container, environmentScEntity, studies, memberAccountId } = payload;
+
+  const resourceService = await container.find('roles-only/environmentResourceService');
+  await resourceService.allocateEgressResourcesOnly(requestContext, { environmentScEntity, studies, memberAccountId });
+
+  return payload;
+}
+
 /**
  * A plugin method to implement any specific logic for the 'roles-only' access logic when a environment
  * is terminated or failed provisioning. This method simply delegates to the roles-only/EnvironmentResourceService
@@ -147,6 +156,7 @@ const plugin = {
   onStudyRegistration,
   provideAccountCfnTemplate,
   allocateEnvStudyResources,
+  allocateEnvEgressResourcesOnly,
   deallocateEnvStudyResources,
   provideEnvRolePolicy,
   provideStudyMount,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/roles-only-strategy-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/roles-only-strategy-plugin.js
@@ -81,11 +81,11 @@ async function allocateEnvStudyResources(payload) {
   return payload;
 }
 
-async function allocateEnvEgressResourcesOnly(payload) {
+async function updateKMSPolicyForEgress(payload) {
   const { requestContext, container, environmentScEntity, studies, memberAccountId } = payload;
 
   const resourceService = await container.find('roles-only/environmentResourceService');
-  await resourceService.allocateEgressResourcesOnly(requestContext, { environmentScEntity, studies, memberAccountId });
+  await resourceService.updateKMSPolicyForEgress(requestContext, { environmentScEntity, studies, memberAccountId });
 
   return payload;
 }
@@ -156,7 +156,7 @@ const plugin = {
   onStudyRegistration,
   provideAccountCfnTemplate,
   allocateEnvStudyResources,
-  allocateEnvEgressResourcesOnly,
+  updateKMSPolicyForEgress,
   deallocateEnvStudyResources,
   provideEnvRolePolicy,
   provideStudyMount,


### PR DESCRIPTION
Issue #, if available:
Original issue: Researchers can not create object in egress store when workspace is launched in another account

Description of changes:
add fix to update egress store kms key policy when no study is selected

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.