### PR TITLE
fix: Filter out empty CIDR blocks from security group details

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -1041,7 +1041,9 @@ class EnvironmentScService extends Service {
       };
     });
 
-    return { currentIngressRules: returnVal, securityGroupId };
+    const nonEmptyCidrRanges = _.filter(returnVal, cidr => !_.isEmpty(cidr.cidrBlocks));
+
+    return { currentIngressRules: nonEmptyCidrRanges, securityGroupId };
   }
 
   isAppStreamEnabled() {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

1. Return non empty CIDR ranges so that we don't have to apply additional filtering on the UI
2. Also updated the cfn templates in unit tests such that we can get empty cidr ranges.
3. Moved couple of orphaned test scenarios under `getSecurityGroupDetails`  category 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.