### PR TITLE
fix: egress store should be terminated if it's not used after creation

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
@@ -522,7 +522,7 @@ describe('DataEgressService', () => {
       );
     });
 
-    it('should success delete egress store while egress store is not touched since created', async () => {
+    it('should successfully delete egress store while egress store is not touched since created', async () => {
       dataEgressService.removeEgressStoreBucketPolicy = jest.fn();
       const s3Policy = testS3PolicyFn();
       dataEgressService._settings = {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
@@ -522,6 +522,92 @@ describe('DataEgressService', () => {
       );
     });
 
+    it('should success delete egress store while egress store is not touched since created', async () => {
+      dataEgressService.removeEgressStoreBucketPolicy = jest.fn();
+      const s3Policy = testS3PolicyFn();
+      dataEgressService._settings = {
+        get: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return 'true';
+          }
+          if (settingName === 'egressStoreKmsKeyAliasArn') {
+            return 'test-egressStoreKmsKeyAliasArn';
+          }
+          if (settingName === 'egressStoreBucketName') {
+            return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+      };
+
+      dbService.table.scan.mockResolvedValueOnce([
+        {
+          status: 'CREATED',
+          workspaceId: 'test-workspace-id',
+          s3BucketName: 'test-s3BucketName',
+          s3BucketPath: 'test-s3BucketPath',
+          id: 'test-egress-store-id',
+          isAbleToSubmitEgressRequest: false,
+        },
+      ]);
+      const requestContext = {};
+      const envId = 'test-workspace-id';
+
+      AWSMock.mock('S3', 'listObjectsV2', (params, callback) => {
+        expect(params).toMatchObject({
+          Bucket: 'test-s3BucketName',
+        });
+        callback(null, {
+          Contents: [],
+        });
+      });
+      AWSMock.mock('S3', 'deleteObjects', (params, callback) => {
+        expect(params).toMatchObject({
+          Bucket: 'test-s3BucketName',
+        });
+        callback(null, {});
+      });
+
+      AWSMock.mock('S3', 'getBucketPolicy', (params, callback) => {
+        expect(params).toMatchObject({
+          Bucket: 'test-egressStoreBucketName',
+        });
+        callback(null, {
+          Policy: JSON.stringify(s3Policy),
+        });
+      });
+
+      const putBucketPolicyMock = jest.fn((params, callback) => {
+        expect(params).toMatchObject({
+          Bucket: 'test-egressStoreBucketName',
+        });
+        callback(null, {});
+      });
+      // Mock locking so that the putBucketPolicy actually gets called
+      lockService.tryWriteLockAndRun = jest.fn((_params, callback) => callback());
+      AWSMock.mock('S3', 'putBucketPolicy', putBucketPolicyMock);
+
+      await dataEgressService.terminateEgressStore(requestContext, envId);
+      expect(dataEgressService.removeEgressStoreBucketPolicy).toHaveBeenCalledTimes(1);
+      expect(dataEgressService.removeEgressStoreBucketPolicy).toHaveBeenCalledWith(
+        {},
+        {
+          bucket: 'test-s3BucketName',
+          createdBy: undefined,
+          envPermission: { read: true, write: true },
+          id: 'egress-store-test-workspace-id',
+          prefix: 'test-s3BucketPath',
+          projectId: undefined,
+          readable: true,
+          resources: [{ arn: 'arn:aws:s3:::test-s3BucketName/test-workspace-id/' }],
+          status: 'reachable',
+          workspaceId: 'test-workspace-id',
+          writeable: true,
+        },
+        'test-accountId',
+      );
+    });
+
     it('should remove bucket policy', async () => {
       dataEgressService.getS3BucketAndPolicy = jest.fn().mockResolvedValueOnce({
         s3BucketName: 'test-egressStoreBucketName',

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -220,7 +220,7 @@ class DataEgressService extends Service {
         true,
       );
     } else if (egressStoreStatus.toUpperCase() === PROCESSED_STATUS_CODE || isEgressStoreNotTouched) {
-      // ONLY terminate the egress store if it has been processed or the egress store is not touched when trying to terminate the egress store
+      // ONLY terminate the egress store if it has been processed or the egress store is empty
 
       try {
         await s3Service.clearPath(egressStoreInfo.s3BucketName, egressStoreInfo.s3BucketPath);
@@ -267,7 +267,10 @@ class DataEgressService extends Service {
       await lockService.tryWriteLockAndRun({ id: lockId }, async () => {
         await this.removeEgressStoreBucketPolicy(requestContext, egressStore, memberAccountId);
       });
-      await this.audit(requestContext, { action: 'terminated-egress-store', body: egressStore });
+      await this.audit(requestContext, {
+        action: 'terminated-egress-store',
+        body: egressStore,
+      });
     }
     return egressStoreInfo;
   }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -211,14 +211,16 @@ class DataEgressService extends Service {
 
     const s3Service = await this.service('s3Service');
     const egressStoreStatus = egressStoreInfo.status;
+    const isEgressStoreNotTouched =
+      egressStoreStatus.toUpperCase() === CREATED_STATUS_CODE && egressStoreInfo.isAbleToSubmitEgressRequest === false;
 
     if (egressStoreStatus.toUpperCase() === PROCESSING_STATUS_CODE) {
       throw this.boom.forbidden(
         `Egress store: ${egressStoreInfo.id} is still in processing. The egress store is not terminated and the workspce can not be terminated before egress request is processed.`,
         true,
       );
-    } else if (egressStoreStatus.toUpperCase() === PROCESSED_STATUS_CODE) {
-      // ONLY terminate the egress store if it has been processed
+    } else if (egressStoreStatus.toUpperCase() === PROCESSED_STATUS_CODE || isEgressStoreNotTouched) {
+      // ONLY terminate the egress store if it has been processed or the egress store is not touched when trying to terminate the egress store
 
       try {
         await s3Service.clearPath(egressStoreInfo.s3BucketName, egressStoreInfo.s3BucketPath);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
@@ -57,7 +57,7 @@ async function updateS3BucketPolicy(s3Client, s3BucketName, s3Policy, revisedSta
     throw this.boom.badRequest(
       `Failed updating  bucket policy: ${JSON.stringify(
         s3Policy,
-      )} for bucket: ${bucketName}. Check if original bucket policy is too large`,
+      )} for bucket: ${s3BucketName}. Check if original bucket policy is too large`,
       true,
     );
   }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
@@ -55,7 +55,9 @@ async function updateS3BucketPolicy(s3Client, s3BucketName, s3Policy, revisedSta
     await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy: JSON.stringify(s3Policy) }).promise();
   } catch (error) {
     throw this.boom.badRequest(
-      `Error in putting bucket policy: ${JSON.stringify(s3Policy)} into bucket: ${s3BucketName}`,
+      `Failed updating  bucket policy: ${JSON.stringify(
+        s3Policy,
+      )} for bucket: ${bucketName}. Check if original bucket policy is too large`,
       true,
     );
   }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
@@ -51,8 +51,15 @@ async function updateS3BucketPolicy(s3Client, s3BucketName, s3Policy, revisedSta
       s3Policy.Statement.push(statement);
     }
   });
+  try {
+    await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy: JSON.stringify(s3Policy) }).promise();
+  } catch (error) {
+    throw this.boom.badRequest(
+      `Error in putting bucket policy: ${JSON.stringify(s3Policy)} into bucket: ${bucketName}`,
+      true,
+    );
+  }
   // Update S3 bucket policy
-  await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy: JSON.stringify(s3Policy) }).promise();
 }
 
 function createAllowStatement(statementId, actions, resource, condition) {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
@@ -55,7 +55,7 @@ async function updateS3BucketPolicy(s3Client, s3BucketName, s3Policy, revisedSta
     await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy: JSON.stringify(s3Policy) }).promise();
   } catch (error) {
     throw this.boom.badRequest(
-      `Error in putting bucket policy: ${JSON.stringify(s3Policy)} into bucket: ${bucketName}`,
+      `Error in putting bucket policy: ${JSON.stringify(s3Policy)} into bucket: ${s3BucketName}`,
       true,
     );
   }


### PR DESCRIPTION
Issue #, if available:
The original issue: When there are too many workspaces with Egress store enabled, it causes the Egress store bucket policy gets too large. Therefore launching a new workspace will give us this error “Normalized policy document exceeds the maximum allowed size of 20480 bytes”

Description of changes:
The fix applied here: when egress store is not touched after workspace creation, there is no need to keep egress store, so terminate it. With more egress store is terminated, the egress store bucket policy will be updated with removing the existing policy which should help to resolve this "Normalized policy document exceeds the maximum allowed size of 20480 bytes" issue.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.