### PR TITLE
feat: Allow termination of non-appstream envs

### DIFF
--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/aws-account-mgmt-plugin.test.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/aws-account-mgmt-plugin.test.js
@@ -30,7 +30,7 @@ const IndexesServiceMock = require('@aws-ee/base-raas-services/lib/indexes/index
 
 const plugin = require('../aws-account-mgmt-plugin');
 
-// Tested Functions: getActiveNonAppStreamEnvs
+// CHECKed Functions: getActiveNonAppStreamEnvs
 describe('awsAccountMgmtPlugin', () => {
   let container;
   let settings;
@@ -63,7 +63,7 @@ describe('awsAccountMgmtPlugin', () => {
       // OPERATE
       const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
 
-      // TEST
+      // CHECK
       expect(retVal).toEqual(expected);
     });
 
@@ -96,7 +96,7 @@ describe('awsAccountMgmtPlugin', () => {
       // OPERATE
       const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
 
-      // TEST
+      // CHECK
       expect(retVal).toEqual(expected);
     });
 
@@ -128,7 +128,7 @@ describe('awsAccountMgmtPlugin', () => {
       // OPERATE
       const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
 
-      // TEST
+      // CHECK
       expect(retVal).toEqual(expected);
     });
 
@@ -158,7 +158,7 @@ describe('awsAccountMgmtPlugin', () => {
       // OPERATE
       const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
 
-      // TEST
+      // CHECK
       expect(retVal).toEqual(expected);
     });
   });

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/aws-account-mgmt-plugin.test.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/aws-account-mgmt-plugin.test.js
@@ -1,0 +1,165 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+jest.mock('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-service');
+const EnvironmentScServiceMock = require('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-service');
+
+jest.mock('@aws-ee/base-raas-services/lib/indexes/indexes-service');
+const IndexesServiceMock = require('@aws-ee/base-raas-services/lib/indexes/indexes-service');
+
+const plugin = require('../aws-account-mgmt-plugin');
+
+// Tested Functions: getActiveNonAppStreamEnvs
+describe('awsAccountMgmtPlugin', () => {
+  let container;
+  let settings;
+  let environmentScService;
+  let indexesService;
+  beforeEach(async () => {
+    // Initialize services container and register dependencies
+    container = new ServicesContainer();
+    container.register('pluginRegistryService', new PluginRegistryService());
+    container.register('settings', new SettingsServiceMock());
+    container.register('environmentScService', new EnvironmentScServiceMock());
+    container.register('indexesService', new IndexesServiceMock());
+
+    await container.initServices();
+    settings = await container.find('settings');
+    environmentScService = await container.find('environmentScService');
+    indexesService = await container.find('indexesService');
+  });
+
+  describe('getActiveNonAppStreamEnvs', () => {
+    const requestContext = { principalIdentifier: { uid: 'u-testuser' } };
+    it('should return empty list if AppStream is disabled', async () => {
+      // BUILD
+      const awsAccountId = 'sampleAwsAccountId';
+      settings.getBoolean = jest.fn(() => {
+        return false;
+      });
+      const expected = [];
+
+      // OPERATE
+      const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
+
+      // TEST
+      expect(retVal).toEqual(expected);
+    });
+
+    it('should return a list of active non-AppStream environments for an account if AppStream is enabled', async () => {
+      // BUILD
+      const awsAccountId = 'sampleAwsAccountId';
+      settings.getBoolean = jest.fn(() => {
+        return true;
+      });
+      const scEnvs = [
+        { id: 'env1', indexId: 'index1', isAppStreamConfigured: true, status: 'COMPLETED' },
+        { id: 'env2', indexId: 'index1', isAppStreamConfigured: false, status: 'COMPLETED' }, // This will be returned
+        { id: 'env3', indexId: 'index1', isAppStreamConfigured: false, status: 'FAILED' },
+        { id: 'env4', indexId: 'index1', isAppStreamConfigured: false, status: 'TERMINATED' },
+        { id: 'env5', indexId: 'index1', isAppStreamConfigured: false, status: 'UNKNOWN' },
+      ];
+      const indexes = [
+        { id: 'index1', awsAccountId },
+        { id: 'index2', awsAccountId: 'someOtherAccount' },
+      ];
+      environmentScService.list = jest.fn(() => {
+        return scEnvs;
+      });
+      indexesService.list = jest.fn(() => {
+        return indexes;
+      });
+
+      const expected = [{ id: 'env2', indexId: 'index1', isAppStreamConfigured: false, status: 'COMPLETED' }];
+
+      // OPERATE
+      const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
+
+      // TEST
+      expect(retVal).toEqual(expected);
+    });
+
+    it('should return an empty list if no active non-AppStream environments for an account are found', async () => {
+      // BUILD
+      const awsAccountId = 'sampleAwsAccountId';
+      settings.getBoolean = jest.fn(() => {
+        return true;
+      });
+      const scEnvs = [
+        { id: 'env1', indexId: 'index1', isAppStreamConfigured: true, status: 'COMPLETED' },
+        { id: 'env2', indexId: 'index1', isAppStreamConfigured: false, status: 'TERMINATED' },
+        { id: 'env3', indexId: 'index1', isAppStreamConfigured: false, status: 'FAILED' },
+        { id: 'env4', indexId: 'index1', isAppStreamConfigured: false, status: 'UNKNOWN' },
+      ];
+      const indexes = [
+        { id: 'index1', awsAccountId },
+        { id: 'index2', awsAccountId: 'someOtherAccount' },
+      ];
+      environmentScService.list = jest.fn(() => {
+        return scEnvs;
+      });
+      indexesService.list = jest.fn(() => {
+        return indexes;
+      });
+
+      const expected = [];
+
+      // OPERATE
+      const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
+
+      // TEST
+      expect(retVal).toEqual(expected);
+    });
+
+    it('should return an empty list if active non-AppStream environments exist but for a different account', async () => {
+      // BUILD
+      const awsAccountId = 'sampleAwsAccountId';
+      settings.getBoolean = jest.fn(() => {
+        return true;
+      });
+      const scEnvs = [
+        { id: 'env1', indexId: 'index1', isAppStreamConfigured: true, status: 'COMPLETED' },
+        { id: 'env2', indexId: 'index1', isAppStreamConfigured: false, status: 'STOPPED' },
+      ];
+      const indexes = [
+        { id: 'index1', awsAccountId: 'someOtherAccount' },
+        { id: 'index2', awsAccountId },
+      ];
+      environmentScService.list = jest.fn(() => {
+        return scEnvs;
+      });
+      indexesService.list = jest.fn(() => {
+        return indexes;
+      });
+
+      const expected = [];
+
+      // OPERATE
+      const retVal = await plugin.getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container });
+
+      // TEST
+      expect(retVal).toEqual(expected);
+    });
+  });
+});

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
@@ -33,7 +33,7 @@ const AppStreamScService = require('../../appstream/appstream-sc-service');
 
 const plugin = require('../env-sc-connection-url-plugin');
 
-// Tested Functions: create, update, delete
+// Tested Functions: createConnectionUrl
 describe('envScConnectionUrlPlugin', () => {
   let container;
   let appStreamScService;

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
@@ -60,7 +60,7 @@ describe('envScConnectionUrlPlugin', () => {
       // BUILD
       const connection = { scheme: 'http', operation: 'create' };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return false;
       });
 
@@ -75,7 +75,7 @@ describe('envScConnectionUrlPlugin', () => {
       // BUILD
       const connection = { scheme: 'http', operation: 'list' };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
 
@@ -90,7 +90,7 @@ describe('envScConnectionUrlPlugin', () => {
       // BUILD
       const connection = { scheme: 'random', operation: 'create' };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
       appStreamScService.getStreamingUrl = jest.fn();
@@ -110,7 +110,7 @@ describe('envScConnectionUrlPlugin', () => {
       const destinationUrl = 'originalPublicDestinationUrl';
       let connection = { scheme: 'http', operation: 'create', url: destinationUrl, type: 'SageMaker' };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
       environmentScConnectionService.createPrivateSageMakerUrl = jest.fn(() => {
@@ -152,7 +152,7 @@ describe('envScConnectionUrlPlugin', () => {
       const destinationUrl = 'destinationUrl';
       let connection = { scheme: 'http', operation: 'create', url: destinationUrl };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
       const streamingUrl = 'sampleAppStreamUrl';
@@ -185,7 +185,7 @@ describe('envScConnectionUrlPlugin', () => {
       const destinationUrl = 'destinationUrl';
       let connection = { scheme: 'ssh', operation: 'create', url: destinationUrl };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
       const streamingUrl = 'sampleAppStreamUrl';
@@ -216,7 +216,7 @@ describe('envScConnectionUrlPlugin', () => {
       // BUILD
       let connection = { scheme: 'rdp', operation: 'create', instanceId: 'sampleInstanceId' };
       const envId = 'sampleEnvId';
-      settings.optionalBoolean = jest.fn(() => {
+      settings.getBoolean = jest.fn(() => {
         return true;
       });
       const streamingUrl = 'sampleAppStreamUrl';

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/__tests__/env-sc-connection-url-plugin.test.js
@@ -25,11 +25,11 @@ const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry
 jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
 const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
 
-jest.mock('../../appstream/appstream-sc-service');
-const AppStreamScService = require('../../appstream/appstream-sc-service');
-
 jest.mock('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service');
 const EnvironmentScConnectionServiceMock = require('@aws-ee/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service');
+
+jest.mock('../../appstream/appstream-sc-service');
+const AppStreamScService = require('../../appstream/appstream-sc-service');
 
 const plugin = require('../env-sc-connection-url-plugin');
 

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+
+const settingKeys = {
+  isAppStreamEnabled: 'isAppStreamEnabled',
+};
+
+/**
+ * Returns a list of active non-AppStream environments linked to a given AWS Account ID
+ * This check is only performed when the deployment has AppStream enabled,
+ * and is triggered if the user attempts to update the AWS account using SWB APIs.
+ * A similar check is performed on the UI components as well.
+ */
+async function getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container }) {
+  const settings = await container.find('settings');
+  const isAppStreamEnabled = settings.getBoolean(settingKeys.isAppStreamEnabled);
+  if (!isAppStreamEnabled) return [];
+
+  const nonActiveStates = ['FAILED', 'TERMINATED', 'UNKNOWN'];
+  const environmentScService = await container.find('environmentScService');
+  const indexesService = await container.find('indexesService');
+
+  const indexes = await indexesService.list(requestContext);
+  const indexesIdsOfInterest = _.map(
+    _.filter(indexes, index => index.awsAccountId === awsAccountId),
+    'id',
+  );
+
+  const scEnvs = await environmentScService.list(requestContext);
+  const retVal = _.filter(
+    scEnvs,
+    scEnv =>
+      _.includes(indexesIdsOfInterest, scEnv.indexId) &&
+      !scEnv.isAppStreamConfigured &&
+      !_.includes(nonActiveStates, scEnv.status),
+  );
+
+  return retVal;
+}
+
+const plugin = { getActiveNonAppStreamEnvs };
+
+module.exports = plugin;

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin.js
@@ -23,7 +23,7 @@ const settingKeys = {
  * Returns a list of active non-AppStream environments linked to a given AWS Account ID
  * This check is only performed when the deployment has AppStream enabled,
  * and is triggered if the user attempts to update the AWS account using SWB APIs.
- * A similar check is performed on the UI components as well.
+ * A similar check is performed on the UI components (AccountUtils) as well.
  */
 async function getActiveNonAppStreamEnvs({ awsAccountId }, { requestContext, container }) {
   const settings = await container.find('settings');

--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
@@ -28,7 +28,7 @@ async function createConnectionUrl({ envId, connection }, { requestContext, cont
   const appStreamScService = await container.find('appStreamScService');
   const environmentScConnectionService = await container.find('environmentScConnectionService');
   const settings = await container.find('settings');
-  const isAppStreamEnabled = settings.optionalBoolean(settingKeys.isAppStreamEnabled, false);
+  const isAppStreamEnabled = settings.getBoolean(settingKeys.isAppStreamEnabled);
 
   // This plugin will only contribute to URL creation when AppStream is enabled
   // Since this plugin is also called upon during listConnections cycle

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironment.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironment.js
@@ -167,6 +167,7 @@ const ScEnvironment = types
     studyIds: types.frozen([]),
     cidr: types.frozen([]),
     outputs: types.frozen([]),
+    isAppStreamConfigured: types.optional(types.boolean, false),
   })
   .actions(self => ({
     setScEnvironment(rawEnvironment) {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AccountCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AccountCard.js
@@ -19,10 +19,9 @@ import { observer, inject } from 'mobx-react';
 import { withRouter } from 'react-router-dom';
 import { Header, Segment, Accordion, Icon, Label, Table, Button } from 'semantic-ui-react';
 import c from 'classnames';
-
 import { createLink } from '@aws-ee/base-ui/dist/helpers/routing';
-
 import { displayWarning } from '@aws-ee/base-ui/dist/helpers/notification';
+import { isAppStreamEnabled } from '../../helpers/settings';
 
 const { getAccountIdsOfActiveEnvironments } = require('./AccountUtils');
 
@@ -54,12 +53,8 @@ class AccountCard extends React.Component {
     return this.props.account;
   }
 
-  get isAppStreamEnabled() {
-    return process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
-  }
-
   get appStreamStatusMismatch() {
-    return this.isAppStreamEnabled && !this.account.isAppStreamConfigured;
+    return isAppStreamEnabled && !this.account.isAppStreamConfigured;
   }
 
   get awsAccountsStore() {
@@ -181,7 +176,7 @@ class AccountCard extends React.Component {
                 : `Service Workbench is waiting for the CFN stack to complete. 
                 Please wait a few minutes for provisioning to complete. 
                 If you did not create a CFN stack for this account, click
-                 &quot;Re-Onboard Account&quot; to return to the account onboarding page.`}
+                 "Re-Onboard Account" to return to the account onboarding page.`}
             </div>
           )}
         </Accordion.Content>

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AccountUtils.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AccountUtils.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
 function getAccountIdsOfActiveEnvironments(scEnvs, projects, indexes) {
-  const nonActivateStates = ['FAILED', 'TERMINATED', 'UNKNOWN'];
+  const nonActiveStates = ['FAILED', 'TERMINATED', 'UNKNOWN'];
   const activeEnvs = scEnvs.filter(env => {
-    return !nonActivateStates.includes(env.status);
+    return !nonActiveStates.includes(env.status);
   });
   const projectToActiveEnvs = _.groupBy(activeEnvs, 'projectId');
 

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
@@ -7,6 +7,7 @@ import { Header, Label, Popup, Icon, Divider, Message, Table, Grid, Segment } fr
 import TimeAgo from 'react-timeago';
 import { niceNumber } from '@aws-ee/base-ui/dist/helpers/utils';
 
+import { isAppStreamEnabled } from '../../helpers/settings';
 import By from '../helpers/By';
 import ScEnvironmentButtons from './parts/ScEnvironmentButtons';
 import ScEnvironmentCost from './parts/ScEnvironmentCost';
@@ -14,9 +15,14 @@ import ScEnvironmentCost from './parts/ScEnvironmentCost';
 // expected props
 // - scEnvironment (via prop)
 // - envTypesStore (via injection)
+// - indexesStore (via injection)
 class ScEnvironmentCard extends React.Component {
   get envTypesStore() {
     return this.props.envTypesStore;
+  }
+
+  get indexesStore() {
+    return this.props.indexesStore;
   }
 
   get environment() {
@@ -34,12 +40,15 @@ class ScEnvironmentCard extends React.Component {
   render() {
     const env = this.environment;
     const state = env.state;
+    const indexesStore = this.indexesStore;
+    const indexes = indexesStore.getIndexes();
 
     return (
       <>
         {this.renderStatus(state)}
         {this.renderTitle(env)}
         {this.renderError(env)}
+        {this.renderWarning(env, indexes)}
         <Divider className="mt1 mb1" />
         {this.renderButtons(env)}
         <Divider className="mt1" />
@@ -120,6 +129,20 @@ class ScEnvironmentCard extends React.Component {
     );
   }
 
+  renderWarning(env) {
+    if (isAppStreamEnabled && !env.isAppStreamConfigured && env.state.canTerminate) {
+      return (
+        <Message
+          icon="warning"
+          header="Non-AppStream workspace found"
+          content="Please terminate this workspace to avoid AppStream configuration issues for its hosting account"
+        />
+      );
+    }
+
+    return null;
+  }
+
   renderError(env) {
     if (_.isEmpty(env.error)) return null;
 
@@ -138,4 +161,4 @@ decorate(ScEnvironmentCard, {
   envType: computed,
 });
 
-export default inject('envTypesStore')(withRouter(observer(ScEnvironmentCard)));
+export default inject('envTypesStore', 'indexesStore')(withRouter(observer(ScEnvironmentCard)));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
@@ -15,14 +15,9 @@ import ScEnvironmentCost from './parts/ScEnvironmentCost';
 // expected props
 // - scEnvironment (via prop)
 // - envTypesStore (via injection)
-// - indexesStore (via injection)
 class ScEnvironmentCard extends React.Component {
   get envTypesStore() {
     return this.props.envTypesStore;
-  }
-
-  get indexesStore() {
-    return this.props.indexesStore;
   }
 
   get environment() {
@@ -40,15 +35,13 @@ class ScEnvironmentCard extends React.Component {
   render() {
     const env = this.environment;
     const state = env.state;
-    const indexesStore = this.indexesStore;
-    const indexes = indexesStore.getIndexes();
 
     return (
       <>
         {this.renderStatus(state)}
         {this.renderTitle(env)}
         {this.renderError(env)}
-        {this.renderWarning(env, indexes)}
+        {this.renderWarning(env)}
         <Divider className="mt1 mb1" />
         {this.renderButtons(env)}
         <Divider className="mt1" />
@@ -135,7 +128,7 @@ class ScEnvironmentCard extends React.Component {
         <Message
           icon="warning"
           header="Non-AppStream workspace found"
-          content="Please terminate this workspace to avoid AppStream configuration issues for its hosting account"
+          content="Please terminate this workspace as soon as possible. This workspace is not supported by AppStream."
         />
       );
     }
@@ -161,4 +154,4 @@ decorate(ScEnvironmentCard, {
   envType: computed,
 });
 
-export default inject('envTypesStore', 'indexesStore')(withRouter(observer(ScEnvironmentCard)));
+export default inject('envTypesStore')(withRouter(observer(ScEnvironmentCard)));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentsList.js
@@ -112,7 +112,7 @@ class ScEnvironmentsList extends React.Component {
     } else if (isStoreEmpty(store)) {
       content = this.renderEmpty();
     } else if (isStoreNotEmpty(store)) {
-      content = this.renderMain(appStreamProjectIds);
+      content = this.renderMain();
     } else {
       content = null;
     }
@@ -143,11 +143,10 @@ class ScEnvironmentsList extends React.Component {
     );
   }
 
-  renderMain(appStreamProjectIds) {
+  renderMain() {
     const store = this.envsStore;
     const selectedFilter = this.selectedFilter;
-    let list = store.filtered(selectedFilter);
-    list = this.isAppStreamEnabled ? _.filter(list, env => _.includes(appStreamProjectIds, env.projectId)) : list;
+    const list = store.filtered(selectedFilter);
     const isEmpty = _.isEmpty(list);
 
     return (

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
@@ -194,7 +194,11 @@ class ScEnvironmentButtons extends React.Component {
             </Button>
           )}
 
-          {canConnect && (
+          {/* Only let users connect to the environment if either of these conditions is true:
+            1. AppStream is not enabled and environment can be connected to
+            2. AppStream is enabled, environment is linked to an AppStream-configured account, and environment can be connected to 
+          */}
+          {canConnect && !(isAppStreamEnabled && !env.isAppStreamConfigured) && (
             <Button
               floated="left"
               basic

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
@@ -198,7 +198,7 @@ class ScEnvironmentButtons extends React.Component {
             1. AppStream is not enabled and environment can be connected to
             2. AppStream is enabled, environment is linked to an AppStream-configured account, and environment can be connected to 
           */}
-          {canConnect && !(isAppStreamEnabled && !env.isAppStreamConfigured) && (
+          {canConnect && (!isAppStreamEnabled || env.isAppStreamConfigured) && (
             <Button
               floated="left"
               basic

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -427,7 +427,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref PolicyCfnStatus
       PermissionsBoundary: !Ref PolicyCfnStatus
-  
+
   PolicyCfnStatus:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -440,8 +440,6 @@ Resources:
               - cloudformation:DescribeStacks
               - cloudformation:GetTemplate
             Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/initial-stack*'
-
-
 
   # VPC for launching EMR clusters into
   # Just one AZ as we're aiming for transient low-cost clusters rather than HA
@@ -805,11 +803,11 @@ Outputs:
   EncryptionKeyArn:
     Description: KMS Encryption Key Arn
     Value: !GetAtt [EncryptionKey, Arn]
-  
+
   OnboardStatusRoleArn:
     Description: The arn of the role SWB uses to check permissions status
     Value: !GetAtt [CfnStatusRole, Arn]
-    
+
   #------------AppStream Output Below-------
   PrivateAppStreamSubnet:
     Description: AppStream subnet

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
@@ -41,6 +41,9 @@ const S3ServiceMock = require('@aws-ee/base-services/lib/s3-service');
 jest.mock('@aws-ee/base-services/lib/aws/aws-service');
 const AwsServiceMock = require('@aws-ee/base-services/lib/aws/aws-service');
 
+jest.mock('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+
 const AwsAccountService = require('../aws-accounts-service');
 
 describe('AwsAccountService', () => {
@@ -58,6 +61,7 @@ describe('AwsAccountService', () => {
     container.register('settings', new SettingsServiceMock());
     container.register('lockService', new LockServiceMock());
     container.register('s3Service', new S3ServiceMock());
+    container.register('pluginRegistryService', new PluginRegistryService());
     container.register('awsAccountService', new AwsAccountService());
     container.register('aws', new AwsServiceMock());
     await container.initServices();

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-cfn-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-cfn-service.test.js
@@ -41,6 +41,9 @@ const Logger = require('@aws-ee/base-services/lib/logger/logger-service');
 jest.mock('@aws-ee/base-services/lib/aws/aws-service');
 const AwsService = require('@aws-ee/base-services/lib/aws/aws-service');
 
+jest.mock('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
+
 jest.mock('../aws-accounts-service');
 const AwsAccountsServiceMock = require('../aws-accounts-service');
 
@@ -152,6 +155,7 @@ describe('AwsAccountService', () => {
     container.register('cfnTemplateService', new CfnTemplateMock());
     container.register('aws', new AwsService());
     container.register('log', new Logger());
+    container.register('pluginRegistryService', new PluginRegistryService());
     container.register('awsAccountsService', new AwsAccountsServiceMock());
     container.register('awsCfnService', new AwsCfnService());
     await container.initServices();

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
@@ -262,7 +262,7 @@ class AwsAccountsService extends Service {
     return result;
   }
 
-  async checkActiveNonAppStreamEnvs(requestContext, awsAccountId) {
+  async checkForActiveNonAppStreamEnvs(requestContext, awsAccountId) {
     if (!this.settings.getBoolean(settingKeys.isAppStreamEnabled)) return;
 
     const pluginRegistryService = await this.service('pluginRegistryService');
@@ -302,7 +302,7 @@ class AwsAccountsService extends Service {
     const { id, rev } = rawData;
 
     // Verify active Non-AppStream environments do not exist
-    await this.checkActiveNonAppStreamEnvs(requestContext, id);
+    await this.checkForActiveNonAppStreamEnvs(requestContext, id);
 
     // Prepare the db object
     const dbObject = _.omit(this._fromRawToDbObject(rawData, { updatedBy: by }), ['rev']);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
@@ -185,7 +185,7 @@ class AwsCfnService extends Service {
     const s3Service = await this.service('s3Service');
 
     // Verify active Non-AppStream environments do not exist
-    await awsAccountsService.checkActiveNonAppStreamEnvs(requestContext, accountId);
+    await awsAccountsService.checkForActiveNonAppStreamEnvs(requestContext, accountId);
 
     const account = await awsAccountsService.mustFind(requestContext, { id: accountId });
     cfnTemplateInfo.template = await cfnTemplateService.getTemplate('onboard-account');

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
@@ -127,6 +127,7 @@ class AwsCfnService extends Service {
       'jsonSchemaValidationService',
       'authorizationService',
       'auditWriterService',
+      'pluginRegistryService',
       'cfnTemplateService',
       'awsAccountsService',
       's3Service',
@@ -182,6 +183,9 @@ class AwsCfnService extends Service {
     const awsAccountsService = await this.service('awsAccountsService');
     const cfnTemplateService = await this.service('cfnTemplateService');
     const s3Service = await this.service('s3Service');
+
+    // Verify active Non-AppStream environments do not exist
+    await awsAccountsService.checkActiveNonAppStreamEnvs(requestContext, accountId);
 
     const account = await awsAccountsService.mustFind(requestContext, { id: accountId });
     cfnTemplateInfo.template = await cfnTemplateService.getTemplate('onboard-account');

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -1399,8 +1399,8 @@ describe('EnvironmentSCService', () => {
     });
   });
 
-  describe('filterAppStreamProjectEnvs function', () => {
-    it('should filter out envs by AppStream config', async () => {
+  describe('markAppStreamConfig function', () => {
+    it('should mark envs by AppStream config', async () => {
       // BUILD
       const requestContext = {
         principal: {
@@ -1426,11 +1426,17 @@ describe('EnvironmentSCService', () => {
         {
           id: 'env-1',
           projectId: 'proj-1',
+          isAppStreamConfigured: true,
+        },
+        {
+          id: 'env-2',
+          projectId: 'proj-2',
+          isAppStreamConfigured: false,
         },
       ];
 
       // OPERATE
-      const retVal = await service.filterAppStreamProjectEnvs(requestContext, envs);
+      const retVal = await service.markAppStreamConfig(requestContext, envs);
 
       // CHECK
       expect(retVal).toEqual(expected);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -1399,7 +1399,7 @@ describe('EnvironmentSCService', () => {
     });
   });
 
-  describe('markAppStreamConfig function', () => {
+  describe('markAppStreamConfigured function', () => {
     it('should mark envs by AppStream config', async () => {
       // BUILD
       const requestContext = {
@@ -1436,7 +1436,7 @@ describe('EnvironmentSCService', () => {
       ];
 
       // OPERATE
-      const retVal = await service.markAppStreamConfig(requestContext, envs);
+      const retVal = await service.markAppStreamConfigured(requestContext, envs);
 
       // CHECK
       expect(retVal).toEqual(expected);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
@@ -92,10 +92,13 @@ class EnvironmentScConnectionService extends Service {
       'pluginRegistryService',
     ]);
     // The following will succeed only if the user has permissions to access the specified environment
-    const env = await environmentScService.mustFind(requestContext, { id: envId });
+    const { outputs, projectId } = await environmentScService.mustFind(requestContext, { id: envId });
+
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
     // TODO: Handle case when connection is about an auto scaling group instead of specific instance
-    const result = await cfnOutputsToConnections(env.outputs);
+    const result = await cfnOutputsToConnections(outputs);
 
     // Give plugins chance to adjust the connection (such as connection url etc)
     const adjustedConnections = await Promise.all(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -97,13 +97,13 @@ class EnvironmentScService extends Service {
       });
 
     if (this.isAppStreamEnabled()) {
-      envs = await this.markAppStreamConfig(requestContext, envs);
+      envs = await this.markAppStreamConfigured(requestContext, envs);
     }
 
     return this.augmentWithConnectionInfo(requestContext, envs);
   }
 
-  async markAppStreamConfig(requestContext, envs) {
+  async markAppStreamConfigured(requestContext, envs) {
     const projectService = await this.service('projectService');
     const projects = await projectService.list(requestContext);
     const appStreamProjectIds = _.map(

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -97,13 +97,13 @@ class EnvironmentScService extends Service {
       });
 
     if (this.isAppStreamEnabled()) {
-      envs = await this.filterAppStreamProjectEnvs(requestContext, envs);
+      envs = await this.markAppStreamConfig(requestContext, envs);
     }
 
     return this.augmentWithConnectionInfo(requestContext, envs);
   }
 
-  async filterAppStreamProjectEnvs(requestContext, envs) {
+  async markAppStreamConfig(requestContext, envs) {
     const projectService = await this.service('projectService');
     const projects = await projectService.list(requestContext);
     const appStreamProjectIds = _.map(
@@ -111,7 +111,10 @@ class EnvironmentScService extends Service {
       'id',
     );
 
-    return _.filter(envs, env => _.includes(appStreamProjectIds, env.projectId));
+    return _.map(envs, env => {
+      env.isAppStreamConfigured = _.includes(appStreamProjectIds, env.projectId);
+      return env;
+    });
   }
 
   async pollAndSyncWsStatus(requestContext) {
@@ -513,9 +516,6 @@ class EnvironmentScService extends Service {
       existingEnvironment,
     );
 
-    // Verify environment is linked to an AppStream project when application has AppStream enabled
-    await this.verifyAppStreamConfig(requestContext, existingEnvironment.projectId);
-
     const by = _.get(requestContext, 'principalIdentifier.uid');
     const { id, rev } = environment;
 
@@ -669,6 +669,9 @@ class EnvironmentScService extends Service {
     );
 
     const { status, outputs, projectId } = existingEnvironment;
+
+    // Verify environment is linked to an AppStream project when application has AppStream enabled
+    await this.verifyAppStreamConfig(requestContext, projectId);
 
     // expected environment run state based on operation
     let expectedStatus;

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -562,8 +562,8 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/swb-*'
               - 'arn:aws:iam::*:role/analysis-*'
-              - !Sub 'arn:aws:iam::*:role/*-cross-account-role' # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
-              - !Sub 'arn:aws:iam::*:role/*-xacc-env-mgmt'
+              - 'arn:aws:iam::*:role/*-cross-account-role' # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
+              - 'arn:aws:iam::*:role/*-xacc-env-mgmt'
               - 'arn:aws:iam::*:role/*-cfn-status-role'
           - Effect: Allow
             Action:
@@ -746,8 +746,9 @@ Resources:
               - 'arn:aws:iam::*:role/SC-*'
               - 'arn:aws:iam::*:role/analysis-*'
               - 'arn:aws:iam::*:role/swb-*'
-              - !Sub 'arn:aws:iam::*:role/*-cross-account-role' # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
-              - !Sub 'arn:aws:iam::*:role/*-xacc-env-mgmt'
+              - 'arn:aws:iam::*:role/*-cross-account-role' # This is required since when users onboard the main account as a member account, the onboard CFN stack would also reside there
+              - 'arn:aws:iam::*:role/*-xacc-env-mgmt'
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-prep-raas-master-MasterRole-*'
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
@@ -761,11 +762,6 @@ Resources:
               - xray:PutTelemetryRecords
             Resource:
               - '*'
-          - Effect: Allow
-            Action:
-              - sts:AssumeRole
-            Resource:
-              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-prep-raas-master-MasterRole-*'
           - Effect: Allow
             Action:
               - appstream:UpdateImagePermissions
@@ -911,7 +907,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref PolicyDataSourceReachabilityHandler
       PermissionsBoundary: !Ref PolicyDataSourceReachabilityHandler
-  
+
   PolicyAwsAccountOnboardingHandler:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/main/solution/backend/src/lambdas/api-handler/plugins/plugin-registry.js
+++ b/main/solution/backend/src/lambdas/api-handler/plugins/plugin-registry.js
@@ -34,6 +34,7 @@ const legacyStrategyPlugin = require('@aws-ee/base-raas-services/lib/plugins/leg
 const baseRaasAppstreamServicesPlugin = require('@aws-ee/base-raas-appstream-rest-api/lib/plugins/services-plugin');
 const baseRaasAppstreamEnvTypeVarsPlugin = require('@aws-ee/base-raas-appstream-services/lib/plugins/env-sc-provisioning-plugin');
 const baseRaasAppStreamConnectionUrlPlugin = require('@aws-ee/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin');
+const baseRaasAppStreamAwsAccountMgmtPlugin = require('@aws-ee/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin');
 
 const routesPlugin = require('./routes-plugin');
 
@@ -72,6 +73,7 @@ const extensionPoints = {
 
   'schema': [baseRaasSchemaPlugin],
   'env-sc-connection-url': [baseRaasAppStreamConnectionUrlPlugin],
+  'aws-account-mgmt': [baseRaasAppStreamAwsAccountMgmtPlugin],
   'study-access-strategy': [legacyStrategyPlugin, rolesOnlyStrategyPlugin],
 };
 


### PR DESCRIPTION
Issue #, if available:
GALI-1066

Description of changes:
Allow termination of non-AppStream instances if AppStream is enabled. Also disable the connect functionality from API and UI.

Disallow onboarding with AppStream at account level if there are existing non-AppStream workspaces around in that account
Note: This has been done on UI, but needs similar checks on the following APIs
PUT: api/aws-accounts/<accountId>
GET: api/aws-accounts/<accountId>get-template

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.