### PR TITLE
fix: fix BYOB studies to work with SageMaker and EC2 Linux when AppStream is enabled

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -225,6 +225,10 @@ Resources:
       SubnetId: !Ref Subnet
       SecurityGroupIds:
         - !Ref SecurityGroup
+        - !If
+          - AppStreamEnabled
+          - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+          - !Ref "AWS::NoValue"
       DirectInternetAccess:
         !If
         - AppStreamEnabled


### PR DESCRIPTION
Issue #, if available:

Description of changes:

1. Add environment variables for picking up STS regional endpoint which allows to connect with interface endpoint if available. By default BYOB studies weren't working under AppStream setting because AssumeRole API call was happening via global endpoint `https://sts.amazonaws.com` which wasn't accessible. Documentation: https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-sts_regional_endpoints.html
2. Also updated Goofys. I need to investigate why adding the suitable environment variables as I mentioned above wasn't enough but that is separate issue which I will investigate later
3. Also updated SageMaker template to include default Security Group which allows SageMaker instances to connect with STS endpoint

Testing done:

1. Tested BYOB and regular studies with AppStream flag enabled
2. Tested BYOB and regular studies with AppStream flag disabled  

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.