### PR TITLE
fix: update error message in util function

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/helpers/utils.js
@@ -54,12 +54,12 @@ async function updateS3BucketPolicy(s3Client, s3BucketName, s3Policy, revisedSta
   try {
     await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy: JSON.stringify(s3Policy) }).promise();
   } catch (error) {
-    throw this.boom.badRequest(
-      `Failed updating  bucket policy: ${JSON.stringify(
+    console.error(
+      `Failed updating bucket policy: ${JSON.stringify(
         s3Policy,
       )} for bucket: ${s3BucketName}. Check if original bucket policy is too large`,
-      true,
     );
+    console.error(error);
   }
   // Update S3 bucket policy
 }


### PR DESCRIPTION
Issue #, if available:
`this.boom` is not available for util functions.
Description of changes:
Change `this.boom` to `console.error` now.
Checklist:


AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.