### PR TITLE
 fix BYOB to work for EC2 Windows when AppStream is enabled

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -351,6 +351,11 @@ Resources:
           $startS3SyncScriptContent = @'
           # enable AWS_SDK_LOAD_CONFIG to 1. This will allow S3 session to use .aws/profile and .aws/credentials file
           $env:AWS_SDK_LOAD_CONFIG = 1
+          # Use STS regional endpoint instead of global one. This allows external studies to connect with local interface endpoint if it exists.
+          # Refer https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-sts_regional_endpoints.html
+          $env:AWS_STS_REGIONAL_ENDPOINTS = "regional"
+          $env:AWS_DEFAULT_REGION = "${AWS::Region}"
+
           $defaultS3Mounts = '${S3Mounts}' | ConvertTo-Json
 
           $arguments = "-defaultS3Mounts=$defaultS3Mounts -destination=d:\ -region=${AWS::Region} -recurringDownloads=${RecurringDownloads} -downloadInterval=${DownloadInterval} -stopRecurringDownloadsAfter=${StopRecurringDownloadsAfter}"


### PR DESCRIPTION
Issue #, if available: GALI-1115

Description of changes:

* Add environment variables for picking up STS regional endpoint which allows to connect with interface endpoint if available. By default BYOB studies weren't working under AppStream setting because AssumeRole API call was happening via global endpoint `https://sts.amazonaws.com` which wasn't accessible. Documentation: https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-sts_regional_endpoints.html

Testing done:

1. Tested BYOB and regular studies with AppStream flag enabled
2. Tested BYOB and regular studies with AppStream flag disabled  

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.