### PR TITLE
fix: Fix AccountOnboardingHandler to correctly check for non-AppStream environments

### DIFF
--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -923,7 +923,11 @@ Resources:
               - dynamodb:UpdateItem
             Resource:
               - !GetAtt [AwsAccountsDb, Arn]
+              - !GetAtt [IndexesDb, Arn]
+              - !GetAtt [ProjectsDb, Arn]
+              - !GetAtt [EnvironmentsScDb, Arn]
               - !Join ['', [!GetAtt [AwsAccountsDb, Arn], '/index/*']]
+              - !Join ['', [!GetAtt [EnvironmentsScDb, Arn], '/index/*']]
           - Effect: Allow
             Action:
               - logs:CreateLogStream

--- a/main/solution/backend/src/lambdas/aws-account-onboarding/plugins/plugin-registry.js
+++ b/main/solution/backend/src/lambdas/aws-account-onboarding/plugins/plugin-registry.js
@@ -22,6 +22,7 @@ const baseRaasUserAuthzPlugin = require('@aws-ee/base-raas-services/lib/user/use
 const baseRaasSchemaPlugin = require('@aws-ee/base-raas-services/lib/plugins/schema-plugin');
 const environmentTypeServicesPlugin = require('@aws-ee/environment-type-mgmt-services/lib/plugins/services-plugin');
 const keyPairServicesPlugin = require('@aws-ee/key-pair-mgmt-services/lib/plugins/services-plugin');
+const baseRaasAppStreamAwsAccountMgmtPlugin = require('@aws-ee/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin');
 
 const servicesPlugin = require('services/lib/plugins/services-plugin');
 
@@ -45,6 +46,7 @@ const extensionPoints = {
   'aws-account-authz': [], // No plugins at this point. All aws-account authz is happening inline in 'aws-account-service'
   'cost-authz': [], // No plugins at this point. All cost authz is happening inline in 'costs-service'
   'schema': [baseRaasSchemaPlugin],
+  'aws-account-mgmt': [baseRaasAppStreamAwsAccountMgmtPlugin],
 };
 
 async function getPlugins(extensionPoint) {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: 
1. Added DynamoDB permissions for AccountOnboardingHandler
2. Also ensured that `aws-account-mgmt` plugin is correctly registered

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.