### PR TITLE
Rstudio AppStream integration

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -97,6 +97,11 @@ Parameters:
     AllowedValues: [ALWAYS_ON, ON_DEMAND]
     Default: ON_DEMAND
 
+  DomainName:
+    Description: Optional custom Domain name to be created in Route53
+    Type: String
+    Default: ''
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -119,7 +124,20 @@ Conditions:
     - !Ref EnableAppStream
     - true
   isNotAppStream: !Not [Condition: isAppStream]
+  isAppStreamAndCustomDomain: !And
+    - !Not [!Equals [!Ref "DomainName", ""]]
+    - !Condition isAppStream
+
 Resources:
+  Route53HostedZone:
+    Type: AWS::Route53::HostedZone
+    Condition: isAppStreamAndCustomDomain
+    Properties:
+      Name: !Ref DomainName
+      VPCs:
+        - VPCId: !Ref VPC
+          VPCRegion: !Ref "AWS::Region"
+
   # A role used for launching environments using AWS Service Catalog
   # This is the role that code (ApiHandlerLambda and WorkflowLoopRunnerLambda) in central account
   # assumes before performing any AWS Service Catalog interactions in this account (the on-boarded account)
@@ -244,6 +262,17 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${LaunchConstraintRolePrefix}LaunchConstraint'
                   - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role'
+        - !If
+          - isAppStreamAndCustomDomain
+          - PolicyName: route53-access
+            PolicyDocument:
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - route53:ChangeResourceRecordSets
+                  Resource:
+                    - !Sub 'arn:aws:route53:::hostedzone/${Route53HostedZone}'
+          - !Ref 'AWS::NoValue'
       PermissionsBoundary: !Ref CrossAccountEnvMgmtPermissionsBoundary
 
   CrossAccountEnvMgmtPermissionsBoundary:
@@ -317,6 +346,14 @@ Resources:
               - iam:ListRoles
               - iam:ListUsers
             Resource: '*' # These non-mutating IAM actions cover the permissions in managed policy AWSServiceCatalogAdminFullAccess
+          - !If
+            - isAppStreamAndCustomDomain
+            - Effect: Allow
+              Action:
+                - route53:ChangeResourceRecordSets
+              Resource:
+                - !Sub 'arn:aws:route53:::hostedzone/${Route53HostedZone}'
+            - !Ref 'AWS::NoValue'
 
   PolicyCrossAccountExecution:
     Type: AWS::IAM::ManagedPolicy
@@ -675,6 +712,17 @@ Resources:
         - SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
           IpProtocol: '-1'
 
+  SSMEndpoint:
+    Type: 'AWS::EC2::VPCEndpoint'
+    Condition: isAppStream
+    Properties:
+      SubnetIds:
+        - !Ref PrivateWorkspaceSubnet
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ssm'
+      VpcId: !Ref VPC
+
     # https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-interface-endpoint.html
   SagemakerNotebookEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
@@ -866,3 +914,8 @@ Outputs:
     Value: !Ref SagemakerNotebookEndpoint
     Export:
       Name: !Join ['', [Ref: Namespace, '-SageMakerVPCE']]
+
+  Route53HostedZone:
+    Description: Route53 hosted zone
+    Condition: isAppStreamAndCustomDomain
+    Value: !Ref Route53HostedZone

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -714,7 +714,7 @@ Resources:
 
   SSMEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
-    Condition: isAppStream
+    Condition: isAppStreamAndCustomDomain
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -26,6 +26,7 @@ Parameters:
   AccessFromCIDRBlock:
     Type: String
     Description: The CIDR used to access the ec2 instances.
+    Default: 10.0.0.0/19
   S3Mounts:
     Type: String
     Description: A JSON array of objects with name, bucket, and prefix properties used to mount data
@@ -150,10 +151,13 @@ Resources:
           FromPort: 0
           ToPort: 65535
           CidrIp: 0.0.0.0/0
-        - IpProtocol: icmp
-          FromPort: -1
-          ToPort: -1
-          CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: icmp
+            FromPort: -1
+            ToPort: -1
+            CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - DestinationSecurityGroupId:
@@ -161,24 +165,29 @@ Resources:
             IpProtocol: '-1'
           - !Ref "AWS::NoValue"
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref AccessFromCIDRBlock
-        - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: !Ref AccessFromCIDRBlock
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !Ref AccessFromCIDRBlock
         - !If
           - AppStreamEnabled
           - SourceSecurityGroupId:
               Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
             IpProtocol: '-1'
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
           - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 80
+            ToPort: 80
+            CidrIp: !Ref AccessFromCIDRBlock
+        - !If
+          - AppStreamEnabled
+          - !Ref "AWS::NoValue"
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: !Ref AccessFromCIDRBlock
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-sg']]
@@ -236,6 +245,10 @@ Outputs:
   Ec2WorkspacePublicIp:
     Description: Public IP address of the EC2 workspace instance
     Value: !GetAtt [EC2Instance, PublicIp]
+
+  Ec2WorkspacePrivateIp:
+    Description: Public IP address of the EC2 workspace instance
+    Value: !GetAtt [EC2Instance, PrivateIp]
 
   Ec2WorkspaceInstanceId:
     Description: Instance Id for the EC2 workspace instance

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
@@ -207,6 +207,23 @@ describe('AwsAccountService', () => {
       expect(dbService.table.update).toHaveBeenCalled();
     });
 
+    it('should save awsAccount if it has hostedzone', async () => {
+      // BUILD
+      const requestContext = {};
+      awsAccount.route53HostedZone = 'HOSTEDZONE123';
+      service.updateEnvironmentInstanceFilesBucketPolicy = jest.fn();
+      uuidMock.mockReturnValueOnce('abc-123-456');
+
+      // OPERATE
+      await service.create(requestContext, awsAccount);
+
+      // CHECK
+      expect(dbService.table.condition).toHaveBeenCalledWith('attribute_not_exists(id)');
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'abc-123-456' });
+      expect(dbService.table.item).toHaveBeenCalledWith(expect.objectContaining(awsAccount));
+      expect(dbService.table.update).toHaveBeenCalled();
+    });
+
     it('should update the bucket policy', async () => {
       // BUILD
       const requestContext = {};
@@ -347,6 +364,21 @@ describe('AwsAccountService', () => {
 
     it('should update awsAccount in the database', async () => {
       // BUILD
+      const requestContext = { username: 'oneUser' };
+      service.updateEnvironmentInstanceFilesBucketPolicy = jest.fn();
+
+      // OPERATE
+      await service.update(requestContext, awsAccount);
+
+      // CHECK
+      expect(dbService.table.condition).toHaveBeenCalledWith('attribute_exists(id)');
+      expect(dbService.table.key).toHaveBeenCalledWith({ id: 'xyz' });
+      expect(dbService.table.update).toHaveBeenCalled();
+    });
+
+    it('should update awsAccount with HostedZone', async () => {
+      // BUILD
+      awsAccount.route53HostedZone = 'HOSTEDZONE123';
       const requestContext = { username: 'oneUser' };
       service.updateEnvironmentInstanceFilesBucketPolicy = jest.fn();
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-dns-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/__tests__/environment-dns-service.test.js
@@ -1,0 +1,146 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const ServicesContainer = require('@aws-ee/base-services-container/lib/services-container');
+
+// Mocked dependencies
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
+
+const Aws = require('@aws-ee/base-services/lib/aws/aws-service');
+
+jest.mock('../service-catalog/environment-sc-service');
+const EnvironmentScService = require('../service-catalog/environment-sc-service');
+
+const EnvironmentDnsService = require('../environment-dns-service');
+
+describe('EnvironmentDnsService', () => {
+  let service = null;
+  let environmentScService = null;
+  let settings = null;
+
+  beforeEach(async () => {
+    const container = new ServicesContainer();
+    container.register('settings', new SettingsServiceMock());
+    container.register('environmentScService', new EnvironmentScService());
+    container.register('environmentDnsService', new EnvironmentDnsService());
+    container.register('aws', new Aws());
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('environmentDnsService');
+    environmentScService = await container.find('environmentScService');
+    settings = await container.find('settings');
+  });
+
+  describe('Test changePrivateRecordSet', () => {
+    it('should call changeResourceRecordSets', async () => {
+      const requestContext = { principalIdentifier: { uid: 'u-testuser' } };
+      const route53Client = jest.fn();
+      service.changeResourceRecordSets = jest.fn();
+      environmentScService.getClientSdkWithEnvMgmtRole = jest.fn(() => {
+        return route53Client;
+      });
+      settings.get = jest.fn(key => {
+        if (key === 'domainName') {
+          return 'test.aws';
+        }
+        throw Error(`${key} not found`);
+      });
+      await service.changePrivateRecordSet(requestContext, 'CREATE', 'rstudio', 'test-id', '10.1.1.1', 'HOSTEDZONE123');
+      expect(service.changeResourceRecordSets).toHaveBeenCalledWith(
+        route53Client,
+        'HOSTEDZONE123',
+        'CREATE',
+        'rstudio-test-id.test.aws',
+        'A',
+        '10.1.1.1',
+      );
+      expect(service.changeResourceRecordSets).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test changeResourceRecordSets', () => {
+    it('should call Route53 changeResourceRecordSets', async () => {
+      const route53Client = {
+        client: 'route53Mock',
+        changeResourceRecordSets: jest.fn(() => {
+          return {
+            promise: () => {},
+          };
+        }),
+      };
+      await service.changeResourceRecordSets(
+        route53Client,
+        'HOSTEDZONE123',
+        'CREATE',
+        'rstudio-test-id.test.aws',
+        'A',
+        '10.1.1.1',
+      );
+      expect(route53Client.changeResourceRecordSets).toHaveBeenCalledTimes(1);
+      expect(route53Client.changeResourceRecordSets).toHaveBeenCalledWith({
+        HostedZoneId: 'HOSTEDZONE123',
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: 'CREATE',
+              ResourceRecordSet: {
+                Name: 'rstudio-test-id.test.aws',
+                Type: 'A',
+                TTL: 300,
+                ResourceRecords: [{ Value: '10.1.1.1' }],
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('Test createPrivateRecord', () => {
+    it('should call changePrivateRecordSet', async () => {
+      const requestContext = { principalIdentifier: { uid: 'u-testuser' } };
+      service.changePrivateRecordSet = jest.fn();
+      await service.createPrivateRecord(requestContext, 'rstudio', 'test-id', '10.1.1.1', 'HOSTEDZONE123');
+      expect(service.changePrivateRecordSet).toHaveBeenCalledTimes(1);
+      expect(service.changePrivateRecordSet).toHaveBeenCalledWith(
+        requestContext,
+        'CREATE',
+        'rstudio',
+        'test-id',
+        '10.1.1.1',
+        'HOSTEDZONE123',
+      );
+    });
+  });
+
+  describe('Test deletePrivateRecord', () => {
+    it('should call changePrivateRecordSet', async () => {
+      const requestContext = { principalIdentifier: { uid: 'u-testuser' } };
+      service.changePrivateRecordSet = jest.fn();
+      await service.deletePrivateRecord(requestContext, 'rstudio', 'test-id', '10.1.1.1', 'HOSTEDZONE123');
+      expect(service.changePrivateRecordSet).toHaveBeenCalledTimes(1);
+      expect(service.changePrivateRecordSet).toHaveBeenCalledWith(
+        requestContext,
+        'DELETE',
+        'rstudio',
+        'test-id',
+        '10.1.1.1',
+        'HOSTEDZONE123',
+      );
+    });
+  });
+});

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/__tests__/env-provisioning-plugin.test.js
@@ -23,6 +23,7 @@ jest.mock('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
 const PluginRegistryService = require('@aws-ee/base-services/lib/plugin-registry/plugin-registry-service');
 
 jest.mock('../../environment/service-catalog/environment-sc-service');
+const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
 const EnvironmentScService = require('../../environment/service-catalog/environment-sc-service');
 
 jest.mock('../../environment/environment-dns-service');
@@ -30,6 +31,8 @@ const EnvironmentDNSService = require('../../environment/environment-dns-service
 
 jest.mock('../../environment/service-catalog/environment-sc-keypair-service');
 const EnvironmentSCKeyPairService = require('../../environment/service-catalog/environment-sc-keypair-service');
+
+jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
 
 const plugin = require('../env-provisioning-plugin');
 
@@ -40,6 +43,7 @@ describe('envProvisioningPlugin', () => {
   let environmentScService;
   let pluginRegistryService;
   let environmentDnsService;
+  let settings;
   beforeEach(async () => {
     // Initialize services container and register dependencies
     container = new ServicesContainer();
@@ -48,8 +52,10 @@ describe('envProvisioningPlugin', () => {
     container.register('environmentDnsService', new EnvironmentDNSService());
     container.register('environmentScKeypairService', new EnvironmentSCKeyPairService());
     container.register('log', new Logger());
+    container.register('settings', new SettingsServiceMock());
 
     await container.initServices();
+    settings = await container.find('settings');
     environmentScService = await container.find('environmentScService');
     pluginRegistryService = await container.find('pluginRegistryService');
     environmentDnsService = await container.find('environmentDnsService');
@@ -272,9 +278,15 @@ describe('envProvisioningPlugin', () => {
       );
     });
 
-    it('should create environmentDNS record if it is RSdutio environment', async () => {
+    it('should create environmentDNS record if it is RStudio environment', async () => {
       // BUILD
       environmentScService.mustFind = jest.fn().mockResolvedValueOnce({ id: 'env-id' });
+      settings.getBoolean = jest.fn(key => {
+        if (key === 'isAppStreamEnabled') {
+          return false;
+        }
+        throw Error(`${key} not found`);
+      });
       // OPERATE
       await plugin.onEnvProvisioningSuccess({
         requestContext,
@@ -308,6 +320,59 @@ describe('envProvisioningPlugin', () => {
         },
       );
       expect(environmentDnsService.createRecord).toHaveBeenCalledWith('rstudio', 'env-id', 'some-dns-name');
+    });
+
+    it('should create private DNS record if it is RStudio environment when AppStream enabled', async () => {
+      // BUILD
+      environmentScService.mustFind = jest.fn().mockResolvedValueOnce({ id: 'env-id' });
+      environmentScService.getMemberAccount = jest.fn().mockResolvedValueOnce({ route53HostedZone: 'HOSTEDZONE123' });
+      settings.getBoolean = jest.fn(key => {
+        if (key === 'isAppStreamEnabled') {
+          return true;
+        }
+        throw Error(`${key} not found`);
+      });
+      // OPERATE
+      await plugin.onEnvProvisioningSuccess({
+        requestContext,
+        container,
+        resolvedVars: { envId: 'env-id' },
+        status: 'SUCCEED',
+        outputs: [
+          { OutputKey: 'MetaConnection1Type', OutputValue: 'RStudio' },
+          { OutputKey: 'Ec2WorkspaceDnsName', OutputValue: 'some-dns-name' },
+          { OutputKey: 'Ec2WorkspacePrivateIp', OutputValue: '10.0.0.1' },
+        ],
+        provisionedProductId: 'provisioned-product-id',
+      });
+      // TEST
+      expect(environmentScService.update).toHaveBeenCalledWith(
+        {
+          principal: {
+            isAdmin: true,
+            status: 'active',
+          },
+        },
+        {
+          id: 'env-id',
+          rev: 0,
+          status: 'SUCCEED',
+          inWorkflow: 'false',
+          outputs: [
+            { OutputKey: 'MetaConnection1Type', OutputValue: 'RStudio' },
+            { OutputKey: 'Ec2WorkspaceDnsName', OutputValue: 'some-dns-name' },
+            { OutputKey: 'Ec2WorkspacePrivateIp', OutputValue: '10.0.0.1' },
+          ],
+          provisionedProductId: 'provisioned-product-id',
+        },
+      );
+      expect(environmentDnsService.createPrivateRecord).toHaveBeenCalledWith(
+        requestContext,
+        'rstudio',
+        'env-id',
+        '10.0.0.1',
+        'HOSTEDZONE123',
+      );
     });
   });
 
@@ -378,8 +443,14 @@ describe('envProvisioningPlugin', () => {
       );
     });
 
-    it('should remove environmentDNS record if it is RSdutio environment', async () => {
+    it('should remove environmentDNS record if it is RStudio environment', async () => {
       // BUILD
+      settings.getBoolean = jest.fn(key => {
+        if (key === 'isAppStreamEnabled') {
+          return false;
+        }
+        throw Error(`${key} not found`);
+      });
       environmentScService.mustFind = jest
         .fn()
         .mockResolvedValueOnce({ id: 'env-id' })
@@ -414,6 +485,94 @@ describe('envProvisioningPlugin', () => {
       });
       // TEST
       expect(environmentDnsService.deleteRecord).toHaveBeenCalledWith('rstudio', 'env-id', 'some-dns-name');
+      expect(environmentScService.update).toHaveBeenCalledWith(
+        {
+          principal: {
+            isAdmin: true,
+            status: 'active',
+          },
+        },
+        {
+          id: 'env-id',
+          rev: 0,
+          status: 'SUCCEED',
+          inWorkflow: 'false',
+        },
+        { action: 'REMOVE' },
+      );
+      expect(pluginRegistryService.visitPlugins).toHaveBeenCalledWith(
+        'study-access-strategy',
+        'deallocateEnvStudyResources',
+        {
+          payload: expect.objectContaining({
+            container,
+            environmentScEntity: {
+              id: 'env-id',
+            },
+            memberAccountId: '1234567',
+            requestContext: {
+              principal: {
+                isAdmin: true,
+                status: 'active',
+              },
+            },
+            studies: ['study1', 'study2'],
+          }),
+          continueOnError: true,
+        },
+      );
+    });
+
+    it('should remove private environmentDNS record if it is RStudio environment when AppStream is enabled', async () => {
+      // BUILD
+      settings.getBoolean = jest.fn(key => {
+        if (key === 'isAppStreamEnabled') {
+          return true;
+        }
+        throw Error(`${key} not found`);
+      });
+      environmentScService.mustFind = jest
+        .fn()
+        .mockResolvedValueOnce({ id: 'env-id' })
+        .mockResolvedValueOnce({ id: 'env-id' });
+      environmentScService.getStudies = jest.fn().mockResolvedValueOnce(['study1', 'study2']);
+      environmentScService.getMemberAccount = jest.fn().mockResolvedValue({
+        accountId: '1234567',
+        route53HostedZone: 'HOSTEDZONE123',
+      });
+      environmentScService.update = jest.fn().mockResolvedValueOnce({
+        id: 'env-id',
+        outputs: [
+          { OutputKey: 'MetaConnection1Type', OutputValue: 'RStudio' },
+          { OutputKey: 'Ec2WorkspaceDnsName', OutputValue: 'some-dns-name' },
+          { OutputKey: 'Ec2WorkspaceInstanceId', OutputValue: 'some-ec2-instance-id' },
+          { OutputKey: 'Ec2WorkspacePrivateIp', OutputValue: '10.0.0.1' },
+        ],
+      });
+      pluginRegistryService.visitPlugins = jest.fn().mockResolvedValueOnce({});
+      environmentScService.getClientSdkWithEnvMgmtRole = jest.fn().mockResolvedValueOnce({
+        deleteParameter: jest.fn().mockReturnThis(),
+        promise: jest.fn().mockReturnThis(),
+        catch: jest.fn(),
+      });
+
+      // OPERATE
+      await plugin.onEnvTerminationSuccess({
+        requestContext,
+        container,
+        resolvedVars: { envId: 'env-id' },
+        status: 'SUCCEED',
+        envId: 'env-id',
+        record: {},
+      });
+      // TEST
+      expect(environmentDnsService.deletePrivateRecord).toHaveBeenCalledWith(
+        requestContext,
+        'rstudio',
+        'env-id',
+        '10.0.0.1',
+        'HOSTEDZONE123',
+      );
       expect(environmentScService.update).toHaveBeenCalledWith(
         {
           principal: {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -15,6 +15,10 @@
 
 const _ = require('lodash');
 
+const settingKeys = {
+  isAppStreamEnabled: 'isAppStreamEnabled',
+};
+
 /**
  * A plugin method to contribute to the list of available variables for usage in variable expressions in
  * Environment Type Configurations. This plugin method just provides metadata about the variables such as list of
@@ -218,7 +222,10 @@ async function updateEnvOnProvisioningSuccess({
   const environmentScService = await container.find('environmentScService');
   const envId = resolvedVars.envId;
 
-  const existingEnvRecord = await environmentScService.mustFind(requestContext, { id: envId, fields: ['rev'] });
+  const existingEnvRecord = await environmentScService.mustFind(requestContext, {
+    id: envId,
+    fields: ['rev', 'indexId'],
+  });
 
   // Create DNS record for RStudio workspaces
   const connectionType = _.find(outputs, o => o.OutputKey === 'MetaConnection1Type');
@@ -226,9 +233,16 @@ async function updateEnvOnProvisioningSuccess({
   if (connectionType) {
     connectionTypeValue = connectionType.OutputValue;
     if (connectionTypeValue.toLowerCase() === 'rstudio') {
-      const dnsName = _.find(outputs, o => o.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
       const environmentDnsService = await container.find('environmentDnsService');
-      await environmentDnsService.createRecord('rstudio', envId, dnsName);
+      const settings = await container.find('settings');
+      if (settings.getBoolean(settingKeys.isAppStreamEnabled)) {
+        const privateIp = _.find(outputs, o => o.OutputKey === 'Ec2WorkspacePrivateIp').OutputValue;
+        const hostedZoneId = await getHostedZone(requestContext, environmentScService, existingEnvRecord);
+        await environmentDnsService.createPrivateRecord(requestContext, 'rstudio', envId, privateIp, hostedZoneId);
+      } else {
+        const dnsName = _.find(outputs, o => o.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
+        await environmentDnsService.createRecord('rstudio', envId, dnsName);
+      }
     }
   }
 
@@ -329,7 +343,7 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
 
   const existingEnvRecord = await environmentScService.mustFind(requestContext, {
     id: envId,
-    fields: ['rev', 'outputs'],
+    fields: ['rev', 'outputs', 'indexId'],
   });
 
   log.debug({ msg: `Updating environment record after successful termination`, envId });
@@ -370,7 +384,7 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
   }
 
   // Delete DNS record for RStudio workspaces
-  await rstudioCleanup(requestContext, updatedEnvironment, container);
+  await rstudioCleanup(requestContext, updatedEnvironment, container, existingEnvRecord);
 
   // --- Cleanup - EC2 KeyPairs (the main admin key created specifically for this environment for SSH or RDP) from other account
   log.debug({ msg: `Cleaning up admin key pairs`, envId });
@@ -389,17 +403,30 @@ async function updateEnvOnTerminationSuccess({ requestContext, container, status
 // This method checks if the environment being terminated is an RStudio.
 // If yes, this will delete the CNAME record in Route 53 service and the
 // SSM public kay parameter created during environment's provisioning
-async function rstudioCleanup(requestContext, updatedEnvironment, container) {
+async function rstudioCleanup(requestContext, updatedEnvironment, container, existingEnvRecord) {
   const connectionType = _.find(updatedEnvironment.outputs, o => o.OutputKey === 'MetaConnection1Type');
   let connectionTypeValue;
   if (connectionType) {
     connectionTypeValue = connectionType.OutputValue;
     if (connectionTypeValue.toLowerCase() === 'rstudio') {
-      const dnsName = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
       const instanceId = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceInstanceId').OutputValue;
       const environmentDnsService = await container.find('environmentDnsService');
       const environmentScService = await container.find('environmentScService');
-      await environmentDnsService.deleteRecord('rstudio', updatedEnvironment.id, dnsName);
+      const settings = await container.find('settings');
+      if (settings.getBoolean(settingKeys.isAppStreamEnabled)) {
+        const privateIp = _.find(updatedEnvironment.outputs, o => o.OutputKey === 'Ec2WorkspacePrivateIp').OutputValue;
+        const hostedZoneId = await getHostedZone(requestContext, environmentScService, existingEnvRecord);
+        await environmentDnsService.deletePrivateRecord(
+          requestContext,
+          'rstudio',
+          updatedEnvironment.id,
+          privateIp,
+          hostedZoneId,
+        );
+      } else {
+        const dnsName = _.find(updatedEnvironment.outputs, x => x.OutputKey === 'Ec2WorkspaceDnsName').OutputValue;
+        await environmentDnsService.deleteRecord('rstudio', updatedEnvironment.id, dnsName);
+      }
 
       const ssm = await environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
@@ -417,6 +444,11 @@ async function rstudioCleanup(requestContext, updatedEnvironment, container) {
         });
     }
   }
+}
+
+async function getHostedZone(requestContext, environmentScService, existingEnvRecord) {
+  const memberAccount = await environmentScService.getMemberAccount(requestContext, existingEnvRecord);
+  return memberAccount.route53HostedZone;
 }
 
 // The "terminate-product' workflow call "onEnvTerminationFailure" in case of any errors

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-aws-accounts.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-aws-accounts.json
@@ -83,6 +83,9 @@
       "appStreamFleetType": {
         "type": "string"
       },
+      "route53HostedZone": {
+        "type": "string"
+      },
       "onboardStatusRoleArn": {
         "type": "string",
         "minLength": 10,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-aws-accounts.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-aws-accounts.json
@@ -96,6 +96,9 @@
     },
     "appStreamFleetType": {
       "type": "string"
+    },
+    "route53HostedZone": {
+      "type": "string"
     }
   },
   "required": [

--- a/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/provision-account/provision-account.js
+++ b/addons/addon-base-raas/packages/base-raas-workflow-steps/lib/steps/provision-account/provision-account.js
@@ -32,6 +32,7 @@ const settingKeys = {
   launchConstraintRolePrefix: 'launchConstraintRolePrefix',
   launchConstraintPolicyPrefix: 'launchConstraintPolicyPrefix',
   isAppStreamEnabled: 'isAppStreamEnabled',
+  domainName: 'domainName',
 };
 
 class ProvisionAccount extends StepBase {
@@ -223,6 +224,7 @@ class ProvisionAccount extends StepBase {
     addParam('LaunchConstraintRolePrefix', this.settings.get(settingKeys.launchConstraintRolePrefix));
     addParam('LaunchConstraintPolicyPrefix', this.settings.get(settingKeys.launchConstraintPolicyPrefix));
     addParam('EnableAppStream', this.settings.get(settingKeys.isAppStreamEnabled));
+    addParam('DomainName', this.settings.optional(settingKeys.domainName, ''));
 
     const input = {
       StackName: stackName,
@@ -306,7 +308,12 @@ class ProvisionAccount extends StepBase {
             appStreamSecurityGroupId: cfnOutputs.AppStreamSecurityGroup,
             appStreamFleetName: cfnOutputs.AppStreamFleet,
             subnetId: cfnOutputs.PrivateWorkspaceSubnet,
+            route53HostedZone: cfnOutputs.Route53HostedZone,
           };
+
+          if (this.settings.optional(settingKeys.domainName, '') !== '') {
+            additionalAccountData.route53HostedZone = cfnOutputs.Route53HostedZone;
+          }
         } else {
           additionalAccountData = {
             subnetId: cfnOutputs.VpcPublicSubnet1,

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/start-rstudio-environment/start-rstudio-environment-sc.js
@@ -16,6 +16,10 @@
 const _ = require('lodash');
 const StepBase = require('@aws-ee/base-workflow-core/lib/workflow/helpers/step-base');
 
+const settingKeys = {
+  isAppStreamEnabled: 'isAppStreamEnabled',
+};
+
 class StartRStudioEnvironmentSc extends StepBase {
   async start() {
     const environmentId = await this.payload.string('environmentId');
@@ -163,8 +167,10 @@ class StartRStudioEnvironmentSc extends StepBase {
 
   async updateCnameRecords(envId, oldDnsName, newDnsName) {
     const environmentDnsService = await this.mustFindServices('environmentDnsService');
-    await environmentDnsService.deleteRecord('rstudio', envId, oldDnsName);
-    await environmentDnsService.createRecord('rstudio', envId, newDnsName);
+    if (!this.settings.getBoolean(settingKeys.isAppStreamEnabled)) {
+      await environmentDnsService.deleteRecord('rstudio', envId, oldDnsName);
+      await environmentDnsService.createRecord('rstudio', envId, newDnsName);
+    }
   }
 
   async updateEnvironment(updatedAttributes, ipAllowListAction = {}) {

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -923,7 +923,11 @@ Resources:
               - dynamodb:UpdateItem
             Resource:
               - !GetAtt [AwsAccountsDb, Arn]
+              - !GetAtt [IndexesDb, Arn]
+              - !GetAtt [ProjectsDb, Arn]
+              - !GetAtt [EnvironmentsScDb, Arn]
               - !Join ['', [!GetAtt [AwsAccountsDb, Arn], '/index/*']]
+              - !Join ['', [!GetAtt [EnvironmentsScDb, Arn], '/index/*']]
           - Effect: Allow
             Action:
               - logs:CreateLogStream

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -83,6 +83,7 @@ awsAccountOnboardingHandler:
     APP_SM_WORKFLOW: ${self:custom.settings.workflowStateMachineArn}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
     APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}
+    APP_DOMAIN_NAME: ${self:custom.settings.domainName}
 
 apiHandler:
   timeout: 30 # in seconds, default is 6

--- a/main/solution/backend/src/lambdas/aws-account-onboarding/plugins/plugin-registry.js
+++ b/main/solution/backend/src/lambdas/aws-account-onboarding/plugins/plugin-registry.js
@@ -22,6 +22,7 @@ const baseRaasUserAuthzPlugin = require('@aws-ee/base-raas-services/lib/user/use
 const baseRaasSchemaPlugin = require('@aws-ee/base-raas-services/lib/plugins/schema-plugin');
 const environmentTypeServicesPlugin = require('@aws-ee/environment-type-mgmt-services/lib/plugins/services-plugin');
 const keyPairServicesPlugin = require('@aws-ee/key-pair-mgmt-services/lib/plugins/services-plugin');
+const baseRaasAppStreamAwsAccountMgmtPlugin = require('@aws-ee/base-raas-appstream-services/lib/plugins/aws-account-mgmt-plugin');
 
 const servicesPlugin = require('services/lib/plugins/services-plugin');
 
@@ -45,6 +46,7 @@ const extensionPoints = {
   'aws-account-authz': [], // No plugins at this point. All aws-account authz is happening inline in 'aws-account-service'
   'cost-authz': [], // No plugins at this point. All cost authz is happening inline in 'costs-service'
   'schema': [baseRaasSchemaPlugin],
+  'aws-account-mgmt': [baseRaasAppStreamAwsAccountMgmtPlugin],
 };
 
 async function getPlugins(extensionPoint) {

--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -88,6 +88,12 @@ case "$(env_type)" in
         echo "Finish installing jq"
         ;;
     "rstudio") # Add mount script to bash profile
+        export PATH="/usr/local/bin:$PATH"
+        set-password
+        echo "Installing jq"
+        cp "${FILES_DIR}/offline-packages/jq-1.5-linux64" "/usr/local/bin/jq"
+        chmod +x "/usr/local/bin/jq"
+        echo "Finish installing jq"
         ;;
 esac
 
@@ -124,7 +130,9 @@ case "$(env_type)" in
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/ec2-user/.bash_profile"
         ;;
     "rstudio") # Add mount script to bash profile
-        yum install -y fuse-2.9.2 #TODO Need to install package locally
+        echo "Installing fuse"
+        sudo yum localinstall -y "${FILES_DIR}/offline-packages/ec2-linux/fuse-2.9.2-11.amzn2.x86_64.rpm"
+        echo "Finish installing fuse"
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
         ;;
 esac

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2965,6 +2965,8 @@ components:
         description:
           type: string
           example: 'My test account'
+        route53HostedZone:
+          type: string
     UpdateAwsAccount:
       required:
         - id
@@ -3010,6 +3012,8 @@ components:
           $ref: '#/components/schemas/SubnetId'
         encryptionKeyArn:
           $ref: '#/components/schemas/EncryptionKeyArn'
+        route53HostedZone:
+          type: string
     UpdateAccountRequest:
       required:
         - id


### PR DESCRIPTION
Issue #, if available: GALI-1063

Description of changes:
1. Updated account onboarding template to create private hosted zone and SSM interface endpoint in case a custom domain is provided and AppStream is enabled. SSM is required for RStudio instances to publish secret that is used for creating a presigned URL.
2. Updated RStudio template to remove CIDR access when AppStream is enabled. Also output private IP here which is required for creating private DNS entries in Route53
3. Account onboarding workflow has been updated to include domainName in template if it exists. Also a new entry related to hosted zone id is being added in DynamoDB which is required for creating private entries in Route53 when provisioning RStudio instances
4. RStudio provisioning and termination workflow has been updated to ensure that we create/remove private DNS entries. Note that on start/stop we don't need to delete and recreate these entries since private IP address doesn't change unlike before in non-appstream case where public ip address changes when instance is restarted.

Testing done
1. Account onboarding updates
2. RStudio workspace provisioning when AppStream is enabled

Note: I will add a separate task for testing RStudio in non-AppStream case and use someone else's account since it would take quite a bit of time to set RStudio again.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.