### PR TITLE
Feat: Pre-populate variable values in input section of new workspace configuration

### DIFF
--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
@@ -63,6 +63,39 @@ class DropDown extends React.Component {
     this.optionsInState = _.concat({ text: data.value, value: data.value }, this.optionsInState);
   };
 
+  /**
+   * Uses the dropdown options to extract the placeholder variable values for the parameters when configuring
+   * a new workspace configuration.
+   * @param currentValue: holds the current value of the dropdown
+   * @param dropdownOptions: holds the options given in the droopdown
+   * @param field: the current field to find a defautl variable for
+   * @returns either the same currentValue or the variable value default to be displayed
+   */
+  getDefaultValue(currentValue, dropdownOptions, field) {
+    // if there is not a current value and there are valid dropdown options and the field is valid
+    if (currentValue === '' && dropdownOptions[0].key !== undefined && field.key !== undefined) {
+      // first element has no values
+      const currentValueIndex = dropdownOptions.slice(1).findIndex(option => {
+        const currentKeyOriginal = option.key;
+        const currentKey = currentKeyOriginal.charAt(0).toUpperCase() + currentKeyOriginal.slice(1);
+        const fieldKey = field.key;
+        return (
+          currentKey === fieldKey ||
+          (fieldKey.toLowerCase().includes(currentKeyOriginal) && currentKeyOriginal !== 'name') ||
+          currentKeyOriginal.slice(0, -2) === fieldKey.toLowerCase() ||
+          currentKeyOriginal === `admin${fieldKey.slice(0, 3)}Pair${fieldKey.slice(-4)}`
+        );
+      });
+      // if no value was found
+      if (currentValueIndex < 0) {
+        return '';
+      }
+      // offset of one because we sliced the first element out in our search
+      return dropdownOptions[currentValueIndex + 1].value;
+    }
+    return currentValue;
+  }
+
   render() {
     const {
       field,
@@ -119,7 +152,7 @@ class DropDown extends React.Component {
 
     const attrs = {
       id,
-      value,
+      value: this.getDefaultValue(value, mergeOptions, field),
 
       // applicable only when allowAdditions = true
       onAddItem: this.onAddItem,

--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
@@ -68,11 +68,10 @@ class DropDown extends React.Component {
    * Uses the dropdown options to extract the placeholder variable values for the parameters when configuring
    * a new workspace configuration.
    * @param currentValue: holds the current value of the dropdown
-   * @param dropdownOptions: holds the options given in the dropdown
    * @param field: the current field to find a default variable for
    * @returns either the same currentValue or the variable value default to be displayed
    */
-  getDefaultValue(currentValue, dropdownOptions, field) {
+  getDefaultValue(currentValue, field) {
     // Make a dict of the field values to the proper variables
     const fieldToVariableMap = {
       EncryptionKeyArn: '${encryptionKeyArn}',
@@ -148,7 +147,7 @@ class DropDown extends React.Component {
 
     const attrs = {
       id,
-      value: this.getDefaultValue(value, mergeOptions, field),
+      value: this.getDefaultValue(value, field),
 
       // applicable only when allowAdditions = true
       onAddItem: this.onAddItem,

--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
@@ -84,7 +84,7 @@ class DropDown extends React.Component {
       EnvironmentInstanceFiles: '${environmentInstanceFiles}',
       Subnet: '${subnetId}',
     };
-    // if there is not a current value and the field is a key in the above dict
+    // if current value is empty and the field is a key in the above dict
     if (currentValue === '' && field.key in fieldToVariableMap) {
       return fieldToVariableMap[field.key];
     }

--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/DropDown.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 /*
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -67,31 +68,26 @@ class DropDown extends React.Component {
    * Uses the dropdown options to extract the placeholder variable values for the parameters when configuring
    * a new workspace configuration.
    * @param currentValue: holds the current value of the dropdown
-   * @param dropdownOptions: holds the options given in the droopdown
-   * @param field: the current field to find a defautl variable for
+   * @param dropdownOptions: holds the options given in the dropdown
+   * @param field: the current field to find a default variable for
    * @returns either the same currentValue or the variable value default to be displayed
    */
   getDefaultValue(currentValue, dropdownOptions, field) {
-    // if there is not a current value and there are valid dropdown options and the field is valid
-    if (currentValue === '' && dropdownOptions[0].key !== undefined && field.key !== undefined) {
-      // first element has no values
-      const currentValueIndex = dropdownOptions.slice(1).findIndex(option => {
-        const currentKeyOriginal = option.key;
-        const currentKey = currentKeyOriginal.charAt(0).toUpperCase() + currentKeyOriginal.slice(1);
-        const fieldKey = field.key;
-        return (
-          currentKey === fieldKey ||
-          (fieldKey.toLowerCase().includes(currentKeyOriginal) && currentKeyOriginal !== 'name') ||
-          currentKeyOriginal.slice(0, -2) === fieldKey.toLowerCase() ||
-          currentKeyOriginal === `admin${fieldKey.slice(0, 3)}Pair${fieldKey.slice(-4)}`
-        );
-      });
-      // if no value was found
-      if (currentValueIndex < 0) {
-        return '';
-      }
-      // offset of one because we sliced the first element out in our search
-      return dropdownOptions[currentValueIndex + 1].value;
+    // Make a dict of the field values to the proper variables
+    const fieldToVariableMap = {
+      EncryptionKeyArn: '${encryptionKeyArn}',
+      VPC: '${vpcId}',
+      AccessFromCIDRBlock: '${cidr}',
+      S3Mounts: '${s3Mounts}',
+      Namespace: '${namespace}',
+      KeyName: '${adminKeyPairName}',
+      IamPolicyDocument: '${iamPolicyDocument}',
+      EnvironmentInstanceFiles: '${environmentInstanceFiles}',
+      Subnet: '${subnetId}',
+    };
+    // if there is not a current value and the field is a key in the above dict
+    if (currentValue === '' && field.key in fieldToVariableMap) {
+      return fieldToVariableMap[field.key];
     }
     return currentValue;
   }

--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/__tests__/DropDown.test.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/__tests__/DropDown.test.js
@@ -1,0 +1,285 @@
+/* eslint-disable no-template-curly-in-string */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import DropDown from '../DropDown';
+
+const options = [
+  { key: 'awsRegion', value: '${awsRegion}', text: '${awsRegion}' },
+  { key: 'namespace', value: '${namespace}', text: '${namespace}' },
+  { key: 'envId', value: '${envId}', text: '${envId}' },
+  { key: 'envTypeId', value: '${envTypeId}', text: '${envTypeId}' },
+  { key: 'envTypeConfigId', value: '${envTypeConfigId}', text: '${envTypeConfigId}' },
+  { key: 'name', value: '${name}', text: '${name}' },
+  { key: 'description', value: '${description}', text: '${description}' },
+  { key: 'adminKeyPairName', value: '${adminKeyPairName}', text: '${adminKeyPairName}' },
+  { key: 'accountId', value: '${accountId}', text: '${accountId}' },
+  { key: 'projectId', value: '${projectId}', text: '${projectId}' },
+  { key: 'indexId', value: '${indexId}', text: '${indexId}' },
+  { key: 'cidr', value: '${cidr}', text: '${cidr}' },
+  { key: 'vpcId', value: '${vpcId}', text: '${vpcId}' },
+  { key: 'subnetId', value: '${subnetId}', text: '${subnetId}' },
+  { key: 'encryptionKeyArn', value: '${encryptionKeyArn}', text: '${encryptionKeyArn}' },
+  { key: 'xAccEnvMgmtRoleArn', value: '${xAccEnvMgmtRoleArn}', text: '${xAccEnvMgmtRoleArn}' },
+  { key: 'externalId', value: '${externalId}', text: '${externalId}' },
+  { key: 'studyIds', value: '${studyIds}', text: '${studyIds}' },
+  { key: 's3Mounts', value: '${s3Mounts}', text: '${s3Mounts}' },
+  { key: 'iamPolicyDocument', value: '${iamPolicyDocument}', text: '${iamPolicyDocument}' },
+  { key: 'environmentInstanceFiles', value: '${environmentInstanceFiles}', text: '${environmentInstanceFiles}' },
+  { key: 'uid', value: '${uid}', text: '${uid}' },
+  { key: 'username', value: '${username}', text: '${username}' },
+  { key: 'userNamespace', value: '${userNamespace}', text: '${userNamespace}' },
+];
+
+describe('DropDown', () => {
+  let wrapper = null;
+  let component = null;
+
+  describe('getDefaultValue', () => {
+    it('should get Encyption Key ARN', () => {
+      // BUILD
+      const field = { key: 'EncryptionKeyArn', value: 'encryptionkeyarn' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${encryptionKeyArn}');
+    });
+
+    it('should get IAM Policy Document', () => {
+      // BUILD
+      const field = { key: 'IamPolicyDocument', value: 'iampolicydocument' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${iamPolicyDocument}');
+    });
+
+    it('should get Access From CIDR Block', () => {
+      // BUILD
+      const field = { key: 'AccessFromCIDRBlock', value: 'accessfromcidrblock' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${cidr}');
+    });
+
+    it('should get VPC', () => {
+      // BUILD
+      const field = { key: 'VPC', value: 'vpc' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${vpcId}');
+    });
+
+    it('should get Environment Instance Files', () => {
+      // BUILD
+      const field = { key: 'EnvironmentInstanceFiles', value: 'environmentinstancefiles' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${environmentInstanceFiles}');
+    });
+
+    it('should get Subnet', () => {
+      // BUILD
+      const field = { key: 'Subnet', value: 'subnet' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${subnetId}');
+    });
+
+    it('should get S3 Mounts', () => {
+      // BUILD
+      const field = { key: 'S3Mounts', value: 's3mounts' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${s3Mounts}');
+    });
+
+    it('should get Namespace', () => {
+      // BUILD
+      const field = { key: 'Namespace', value: 'namespace' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${namespace}');
+    });
+
+    it('should get KeyName', () => {
+      // BUILD
+      const field = { key: 'KeyName', value: 'keyname' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue('', options, field);
+
+      // CHECK
+      expect(defaultValue).toBe('${adminKeyPairName}');
+    });
+
+    it('should not change a custom Namespace', () => {
+      // BUILD
+      const field = { key: 'Namespace', value: 'namespace' };
+      wrapper = shallow(
+        <DropDown key={field.key} field options={options} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+      const myNamespace = 'myNamespace';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(myNamespace, options, field);
+
+      // CHECK
+      expect(defaultValue).not.toBe('${namespace}');
+      expect(defaultValue).toBe(myNamespace);
+    });
+
+    it('should not prepopulate when the field has no key attribute', () => {
+      // the method would try to do things to undefined variables if there is no key attribute
+      // in the field
+      // BUILD
+      const field = { name: 'someField', value: 'someFieldValue' };
+      wrapper = shallow(<DropDown field options={options} disabled search selection fluid allowAdditions clearable />);
+      component = wrapper.instance();
+      const someValue = 'someValue';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(someValue, options, field);
+
+      // CHECK
+      expect(defaultValue).toBe(someValue);
+    });
+
+    it('should not prepopulate when the field has no key attribute even though value passed is empty', () => {
+      // the method would try to do things to undefined variables if there is no key attribute
+      // in the field
+      // BUILD
+      const field = { name: 'someField', value: 'someFieldValue' };
+      wrapper = shallow(<DropDown field options={options} disabled search selection fluid allowAdditions clearable />);
+      component = wrapper.instance();
+      const someValue = '';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(someValue, options, field);
+
+      // CHECK
+      expect(defaultValue).toBe(someValue);
+    });
+
+    it('should not prepopulate when the options has no key attribute', () => {
+      // the method would try to do things to undefined variables if there is no key attribute
+      // in the options list's elements
+      // BUILD
+      const field = { key: 'someKey', value: 'someFieldValue' };
+      const noKeyOption = [{ name: 'someField' }];
+      wrapper = shallow(
+        <DropDown field options={noKeyOption} disabled search selection fluid allowAdditions clearable />,
+      );
+      component = wrapper.instance();
+      const someValue = 'someValue';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(someValue, options, field);
+
+      // CHECK
+      expect(defaultValue).toBe(someValue);
+    });
+
+    it('should not prepopulate when the options is empty', () => {
+      // BUILD
+      const field = { key: 'someKey', value: 'someFieldValue' };
+      // const noKeyOption = [{ name: 'someField' }];
+      wrapper = shallow(<DropDown field options={[]} disabled search selection fluid allowAdditions clearable />);
+      component = wrapper.instance();
+      const someValue = 'someValue';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(someValue, options, field);
+
+      // CHECK
+      expect(defaultValue).toBe(someValue);
+    });
+
+    it('should not prepopulate when the field has a key that does not match the option (i.e. not the config setup)', () => {
+      // BUILD
+      const field = { key: 'someKey', value: 'someFieldValue' };
+      wrapper = shallow(<DropDown field options={options} disabled search selection fluid allowAdditions clearable />);
+      component = wrapper.instance();
+      const someValue = 'someValue';
+
+      // OPERATE
+      const defaultValue = component.getDefaultValue(someValue, options, field);
+
+      // CHECK
+      expect(defaultValue).toBe(someValue);
+    });
+  });
+});

--- a/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/__tests__/DropDown.test.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/helpers/fields/__tests__/DropDown.test.js
@@ -59,7 +59,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${encryptionKeyArn}');
@@ -74,7 +74,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${iamPolicyDocument}');
@@ -89,7 +89,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${cidr}');
@@ -104,7 +104,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${vpcId}');
@@ -119,7 +119,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${environmentInstanceFiles}');
@@ -134,7 +134,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${subnetId}');
@@ -149,7 +149,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${s3Mounts}');
@@ -164,7 +164,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${namespace}');
@@ -179,7 +179,7 @@ describe('DropDown', () => {
       component = wrapper.instance();
 
       // OPERATE
-      const defaultValue = component.getDefaultValue('', options, field);
+      const defaultValue = component.getDefaultValue('', field);
 
       // CHECK
       expect(defaultValue).toBe('${adminKeyPairName}');
@@ -195,7 +195,7 @@ describe('DropDown', () => {
       const myNamespace = 'myNamespace';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(myNamespace, options, field);
+      const defaultValue = component.getDefaultValue(myNamespace, field);
 
       // CHECK
       expect(defaultValue).not.toBe('${namespace}');
@@ -212,7 +212,7 @@ describe('DropDown', () => {
       const someValue = 'someValue';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(someValue, options, field);
+      const defaultValue = component.getDefaultValue(someValue, field);
 
       // CHECK
       expect(defaultValue).toBe(someValue);
@@ -228,7 +228,7 @@ describe('DropDown', () => {
       const someValue = '';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(someValue, options, field);
+      const defaultValue = component.getDefaultValue(someValue, field);
 
       // CHECK
       expect(defaultValue).toBe(someValue);
@@ -247,7 +247,7 @@ describe('DropDown', () => {
       const someValue = 'someValue';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(someValue, options, field);
+      const defaultValue = component.getDefaultValue(someValue, field);
 
       // CHECK
       expect(defaultValue).toBe(someValue);
@@ -262,7 +262,7 @@ describe('DropDown', () => {
       const someValue = 'someValue';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(someValue, options, field);
+      const defaultValue = component.getDefaultValue(someValue, field);
 
       // CHECK
       expect(defaultValue).toBe(someValue);
@@ -276,7 +276,7 @@ describe('DropDown', () => {
       const someValue = 'someValue';
 
       // OPERATE
-      const defaultValue = component.getDefaultValue(someValue, options, field);
+      const defaultValue = component.getDefaultValue(someValue, field);
 
       // CHECK
       expect(defaultValue).toBe(someValue);

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeCard.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeCard.js
@@ -50,6 +50,7 @@ class EnvTypeCard extends Component {
 
     const defaultMgmtActions = [
       <Button
+        data-testid={`editbutton-${envType.name}`}
         key="env-type-mgmt-action-edit"
         basic
         color="blue"
@@ -94,7 +95,7 @@ class EnvTypeCard extends Component {
     );
 
     return (
-      <Card key={`et-${envType.id}`} raised className="mb3">
+      <Card data-testid="envtypecard" key={`et-${envType.id}`} raised className="mb3">
         <Card.Content>
           <Header as="h4">{envType.name}</Header>
           <Card.Meta className="flex">

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeEditor.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeEditor.js
@@ -165,6 +165,7 @@ class EnvTypeEditor extends React.Component {
       case 'configurations':
         return (
           <ConfigStep
+            data-testid="configstep"
             envType={this.envType}
             envTypeConfigsStore={this.getEnvTypeConfigsStore()}
             wizardModel={this.wizardModel}

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/AccessControlStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/AccessControlStep.js
@@ -34,7 +34,15 @@ class AccessControlStep extends BaseEnvTypeConfigStep {
     );
     return (
       <>
-        <DropDown field={allowRoleIdsField} options={userRoleOptions} selection multiple fluid disabled={processing} />
+        <DropDown
+          dataTestId="allowdropdown"
+          field={allowRoleIdsField}
+          options={userRoleOptions}
+          selection
+          multiple
+          fluid
+          disabled={processing}
+        />
         <DropDown field={denyRoleIdsField} options={userRoleOptions} selection multiple fluid disabled={processing} />
       </>
     );

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/BaseEnvTypeConfigStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/BaseEnvTypeConfigStep.js
@@ -67,7 +67,7 @@ class BaseEnvTypeConfigStep extends React.Component {
             onClick={this.props.onPrevious}
           />
         )}
-        <Button basic color="grey" disabled={processing} onClick={onCancel} floated="left">
+        <Button data-testid="cancelbutton" basic color="grey" disabled={processing} onClick={onCancel} floated="left">
           Cancel
         </Button>
       </div>

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/BasicInfoStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/BasicInfoStep.js
@@ -30,9 +30,9 @@ class BasicInfoStep extends BaseEnvTypeConfigStep {
 
     return (
       <>
-        {!isUpdating && <Input field={idField} disabled={processing} />}
-        <Input field={nameField} disabled={processing} />
-        <TextArea field={descField} disabled={processing} />
+        {!isUpdating && <Input dataTestId="configidinput" field={idField} disabled={processing} />}
+        <Input dataTestId="confignameinput" field={nameField} disabled={processing} />
+        <TextArea dataTestId="configdescinput" field={descField} disabled={processing} />
         <TextArea field={estimatedCostInfoField} disabled={processing} />
       </>
     );

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/InputParamsStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-config/env-type-config-steps/InputParamsStep.js
@@ -104,6 +104,7 @@ class InputParamsStep extends BaseEnvTypeConfigStep {
       );
       return (
         <DropDown
+          dataTestId={field.key}
           key={field.key}
           field={field}
           options={options}

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-editor-steps/ConfigStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-editor-steps/ConfigStep.js
@@ -168,7 +168,7 @@ class ConfigStep extends React.Component {
     return (
       <div className="mt3">
         <div className="right-align">
-          <Button basic color="grey" onClick={onCancel}>
+          <Button data-testid="cancelbutton" basic color="grey" onClick={onCancel}>
             Cancel
           </Button>
           <Button className="ml2" primary content="Done" disabled={processing} onClick={this.onNext} />

--- a/main/end-to-end-tests/README.md
+++ b/main/end-to-end-tests/README.md
@@ -14,8 +14,10 @@ To run the E2E tests, you will need the following items:
 - A project set up for that researcher that can launch EC2 workspaces and Sagemaker workspaces
 	- Within that project, a study where the researcher is admin
 	- Within that project, a study where the researcher is not an admin
-- A configured EC2 workspace
+- A configured EC2 Linux workspace
 - A configured Sagemaker workspace
+- A configured EC2 Windows workspace
+- A configured EMR workspace
 
 Once you've confirmed that you have the items above setup, you can create a `cypress.dev.json` and a `cypress.local.json` file with the configurations needed for your tests. You can use `cypress.json` as a template for your new configuration files. An example file is included as `cypress.local.example.json`
 

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -20,6 +20,11 @@
         "workspaceTypeName": "EMR-v5",
         "configuration": "emr-e2e",
         "projectId": "e2eTestProject"
+      },
+      "ec2windows": {
+        "workspaceTypeName": "EC2 Linux-v3",
+        "configuration": "ec2-windows-e2e",
+        "projectId": "e2eTestProject"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress.json
+++ b/main/end-to-end-tests/cypress.json
@@ -24,6 +24,11 @@
         "workspaceTypeName": "<NAME OF EMR WORKSPACE TYPE>",
         "configuration": "<EMR WORKSPACE CONFIGURATION>",
         "projectId": "<PROJECT TO LAUNCH EMR WORKSPACE IN>"
+      },
+      "ec2windows": {
+        "workspaceTypeName": "<NAME OF EC2 WINDOWS WORKSPACE TYPE>",
+        "configuration": "<EC2 WINDOWS WORKSPACE CONFIGURATION>",
+        "projectId": "<PROJECT TO LAUNCH EC2 WINDOWS WORKSPACE IN>"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress/integration/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspaces.spec.js
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-describe('Launch a new sagemaker workspace', () => {
+describe('Launch a workspace', () => {
   before(() => {
     cy.login('researcher');
     navigateToWorkspaces();

--- a/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
@@ -16,7 +16,7 @@
 
 describe('Check that variables prepopulate when making a new configuration', () => {
   before(() => {
-    cy.login('researcher');
+    cy.login('admin');
     navigateToWorkspaceTypes();
   });
 

--- a/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
@@ -1,0 +1,114 @@
+/* eslint-disable no-template-curly-in-string */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+describe('Check that variables prepopulate when making a new configuration', () => {
+  before(() => {
+    cy.login('researcher');
+    navigateToWorkspaceTypes();
+  });
+
+  const navigateToWorkspaceTypes = () => {
+    cy.get('.left.menu')
+      .contains('Types')
+      .click();
+  };
+
+  it('should have the proper variables prepopulated-EMR', () => {
+    const workspaces = Cypress.env('workspaces');
+    const emr = workspaces.emr;
+    checkPrepopVariables(emr, 'EMR');
+  });
+
+  it('should have the proper variables prepopulated-EC2 Linux', () => {
+    const workspaces = Cypress.env('workspaces');
+    const ec2 = workspaces.ec2;
+    checkPrepopVariables(ec2, 'EC2 Linux');
+  });
+
+  it('should have the proper variables prepopulated-Sagemaker', () => {
+    const workspaces = Cypress.env('workspaces');
+    const ec2 = workspaces.ec2;
+    checkPrepopVariables(ec2, 'Sagemaker');
+  });
+
+  it('should have the proper variables prepopulated-EC2 Windows', () => {
+    const workspaces = Cypress.env('workspaces');
+    const ec2windows = workspaces.ec2windows;
+    checkPrepopVariables(ec2windows, 'EC2 Windows');
+  });
+
+  const checkPrepopVariables = (workspaceParam, workspaceType) => {
+    navigateToWorkspaceTypes();
+    // Get env type card and click edit for the right card
+    cy.get('[data-testid=envtypecard]')
+      .contains(workspaceParam.workspaceTypeName)
+      .parent()
+      .parent()
+      .get(`button[data-testid="editbutton-${workspaceParam.workspaceTypeName}"]`)
+      .click();
+
+    // switch to Configurations tab
+    cy.contains('Configurations').click();
+
+    // Add new configuration
+    cy.get('button')
+      .contains('Add Configuration')
+      .click();
+
+    // Input dummy values in necessary fields
+    cy.get('[data-testid=configidinput]').type('test');
+    cy.get('[data-testid=confignameinput]').type('test');
+    cy.get('[data-testid=configdescinput]').type('test');
+
+    // Click Next
+    cy.get('button')
+      .contains('Next')
+      .click();
+
+    // Select admin from dropdown (could be any valid value--just can't be blank)
+    cy.get('[data-testid=allowdropdown]')
+      .click()
+      .find('.item')
+      .contains('admin')
+      .click();
+
+    // Click Next
+    cy.get('button')
+      .contains('Next')
+      .click();
+
+    // Make sure the correct variables have the correct default values for the current workspace type
+    if (workspaceType !== 'Sagemaker' && workspaceType !== 'EC2 Linux') {
+      cy.get('[data-testid=KeyName]').contains('${adminKeyPairName}');
+    }
+    cy.get('[data-testid=EncryptionKeyArn]').contains('${encryptionKeyArn}');
+    cy.get('[data-testid=VPC]').contains('${vpcId}');
+    cy.get('[data-testid=AccessFromCIDRBlock]').contains('${cidr}');
+    cy.get('[data-testid=S3Mounts]').contains('${s3Mounts}');
+    cy.get('[data-testid=Namespace]').contains('${namespace}');
+    cy.get('[data-testid=IamPolicyDocument]').contains('${iamPolicyDocument}');
+    cy.get('[data-testid=EnvironmentInstanceFiles]').contains('${environmentInstanceFiles}');
+    cy.get('[data-testid=Subnet]').contains('${subnetId}');
+
+    // Back out of the configuration so no resources are made so this test is repeatable
+    cy.get('button[data-testid=cancelbutton]')
+      .contains('Cancel')
+      .click();
+    cy.get('button[data-testid=cancelbutton]')
+      .contains('Cancel')
+      .click();
+  };
+});


### PR DESCRIPTION
Issue #, if available: GALI-1092

Description of changes: pre-populated variables into the input section of creating a new workspace. Most people keep these default placeholder variables anyway so this will speedup making a new configuration for customers as well as reduce user error

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.