### PR TITLE
fix: Correct stage name for deploying TRE SWB

### DIFF
--- a/.github/workflows/deploy-integ-appstream-egress.yml
+++ b/.github/workflows/deploy-integ-appstream-egress.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: ./
         env:
           DEPLOYMENT_BUCKET: ${{ secrets.DEPLOYMENT_BUCKET_APPSTREAM_EGRESS}}
-          STAGE_NAME: e2etestAppStreamEgress
+          STAGE_NAME: tre
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_APPSTREAM_EGRESS }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_APPSTREAM_EGRESS }}
           aws-region: us-east-1

--- a/.github/workflows/deploy-integ-appstream-egress.yml
+++ b/.github/workflows/deploy-integ-appstream-egress.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./scripts/build-all-packages.sh
       - name: Deploy
         env:
-          STAGE_NAME: e2etestAppStreamEgress
+          STAGE_NAME: tre
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_APPSTREAM_EGRESS}}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_APPSTREAM_EGRESS }}
         run: |


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Use the correct stage name for TRE test environment do we can run GH actions correctly. 

This resolve the error here
https://github.com/awslabs/service-workbench-on-aws/runs/3446210383
`Bucket name cannot contain uppercase letters. 824558622956-e2etestAppStreamEgress-va-swb-artifacts`



AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.