### PR TITLE
fix: Correct Appstream test command to pick up spec files

### DIFF
--- a/main/end-to-end-tests/package.json
+++ b/main/end-to-end-tests/package.json
@@ -8,14 +8,14 @@
   "scripts": {
     "cypress:open:local": "CYPRESS_BASE_URL=http://localhost:3000 cypress open -C cypress.dev.json",
     "cypress:open:dev": "cypress open -C cypress.dev.json",
-    "cypress:run-tests:local": "CYPRESS_BASE_URL=http://localhost:3000 cypress run -C cypress.dev.json --spec cypress/integration/{common,appstream-egress-disabled}/*",
-    "cypress:run-tests:dev": "cypress run -C cypress.dev.json --spec cypress/integration/{common,appstream-egress-disabled}/*",
-    "cypress:run-tests:github": "cypress run -C cypress.github.json --spec cypress/integration/{common,appstream-egress-disabled}/*",
+    "cypress:run-tests:local": "CYPRESS_BASE_URL=http://localhost:3000 cypress run -C cypress.dev.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-disabled/*",
+    "cypress:run-tests:dev": "cypress run -C cypress.dev.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-disabled/*",
+    "cypress:run-tests:github": "cypress run -C cypress.github.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-disabled/*",
     "cypress:open:local:appstream-egress-enabled": "CYPRESS_BASE_URL=http://localhost:3000 cypress open -C cypress.dev.appstream-egress.json",
     "cypress:open:dev:appstream-egress-enabled": "cypress open -C cypress.dev.appstream-egress.json",
-    "cypress:run-tests:local:appstream-egress-enabled": "CYPRESS_BASE_URL=http://localhost:3000 cypress run -C cypress.dev.appstream-egress.json --spec cypress/integration/{common,appstream-egress-enabled}/*",
-    "cypress:run-tests:dev:appstream-egress-enabled": "cypress run -C cypress.dev.appstream-egress.json --spec cypress/integration/{common,appstream-egress-enabled}/*",
-    "cypress:run-tests:github:appstream-egress-enabled": "cypress run -C cypress.github.appstream-egress.json --spec cypress/integration/{common,appstream-egress-enabled}/*"
+    "cypress:run-tests:local:appstream-egress-enabled": "CYPRESS_BASE_URL=http://localhost:3000 cypress run -C cypress.dev.appstream-egress.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-enabled/*",
+    "cypress:run-tests:dev:appstream-egress-enabled": "cypress run -C cypress.dev.appstream-egress.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-enabled/*",
+    "cypress:run-tests:github:appstream-egress-enabled": "cypress run -C cypress.github.appstream-egress.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-enabled/*"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
GH action for running AppStream tests fails because it doesn't recognize the glob pattern `cypress run -C cypress.github.appstream-egress.json --spec cypress/integration/{common,appstream-egress-enabled}/*`, therefore I'm breaking the pattern out to its component part with this expression `cypress run -C cypress.github.appstream-egress.json --spec cypress/integration/common/*,cypress/integration/appstream-egress-enabled/*`.

I tested running the new GH action code locally with [act](https://github.com/nektos/act) and it worked as expected.

For reference, it fixes this error
https://github.com/awslabs/service-workbench-on-aws/runs/3446864231


AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.