### PR TITLE
fix: end2end test terminates existing workspaces from past end-to-end tests

### DIFF
--- a/main/end-to-end-tests/cypress/integration/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspaces.spec.js
@@ -28,6 +28,11 @@ describe('Launch a new sagemaker workspace', () => {
   };
 
   const terminatePrexistingWorkspaces = () => {
+    // Wait until the workspaces information renders
+    //  If there are workspaces, the cards will contain the word "Workspace" in the details table ("Workspace Type" in full)
+    //  If there are not any workspaces, the displayed message is "No research workspaces"
+    //  Both cases will be caught with this contains as it is case insensitive and doesn't match whole words
+    cy.get('[data-testid=workspaces]').contains('workspace', { matchCase: false });
     cy.get('#root').then($body => {
       if ($body.find('[data-testid=sc-env-terminate]').length > 0) {
         cy.get('#root')


### PR DESCRIPTION
Issue #, if available:

Description of changes: my code change from last week delayed the rendering of the terminate buttons in the workspaces page. Thus, the end-to-end tests did not wait and terminate those instances. Now, the tests will wait until those buttons appear or until the message that there are no workspaces (and thus none to terminate) to try to terminate old testing workspaces.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.