### PR TITLE
fix: add label to stop e2e tests timing out

### DIFF
--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-editor-steps/ConfigStep.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/env-type-editor-steps/ConfigStep.js
@@ -77,7 +77,7 @@ class ConfigStep extends React.Component {
                   Configurations are predefined set of Input Parameter values for the AWS Service Catalog Product. The
                   configurations are presented as preset options when launching workspaces of this type.
                 </p>
-                <Button basic color="blue" onClick={this.showEnvTypeConfigDialog}>
+                <Button data-testid="addconfigbutton" basic color="blue" onClick={this.showEnvTypeConfigDialog}>
                   Add Configuration
                 </Button>
               </Header.Subheader>
@@ -99,7 +99,14 @@ class ConfigStep extends React.Component {
       <>
         <Segment basic>
           {!this.shouldShowEnvTypeConfigDialog && (
-            <Button className="ml3" basic color="blue" floated="right" onClick={this.showEnvTypeConfigDialog}>
+            <Button
+              data-testid="addconfigbutton"
+              className="ml3"
+              basic
+              color="blue"
+              floated="right"
+              onClick={this.showEnvTypeConfigDialog}
+            >
               Add Configuration
             </Button>
           )}

--- a/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
+++ b/main/end-to-end-tests/cypress/integration/workspacetypes.spec.js
@@ -64,7 +64,7 @@ describe('Check that variables prepopulate when making a new configuration', () 
     cy.contains('Configurations').click();
 
     // Add new configuration
-    cy.get('button')
+    cy.get('[data-testid=addconfigbutton]')
       .contains('Add Configuration')
       .click();
 


### PR DESCRIPTION
Issue #, if available:

Description of changes: the e2e test timed out I think because it didn't wait for the proper button to render before it tried to find the button to click. I now named the button so it should wait for that button to render before it checks it's contents. This did not timeout in my local or dev tests so I hope it works in the pipeline so everything can get to mainline

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.