### PR TITLE
fix: Allow Sagemaker Appstream workspaces to autostop

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AwsAccountUpdateContent.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/AwsAccountUpdateContent.js
@@ -124,10 +124,16 @@ class AwsAccountUpdateContent extends React.Component {
   };
 
   render() {
+    const { isUpdateStep } = this.getStep();
     let shouldDisableDoneButton = this.shouldShowWarning && !this.warningAcknowledged;
     if (isAppStreamEnabled) {
-      shouldDisableDoneButton =
-        shouldDisableDoneButton || !this.accessAppStreamAcknowledged || !this.startedAppStreamFleetAcknowledged;
+      // No acknowledgements is necessary if we're just updating the preexisting AppStream account
+      if (isUpdateStep) {
+        shouldDisableDoneButton = false;
+      } else {
+        shouldDisableDoneButton =
+          shouldDisableDoneButton || !this.accessAppStreamAcknowledged || !this.startedAppStreamFleetAcknowledged;
+      }
     }
     return (
       <Container className="mt3 animated fadeIn">
@@ -202,14 +208,20 @@ class AwsAccountUpdateContent extends React.Component {
     );
   }
 
-  renderSteps() {
+  getStep() {
     // We need to determine if this is for creating the stack or updating the stack
     const form = this.form;
     const stackInfo = this.stackInfo;
     const { hasUpdateStackUrl } = stackInfo;
     const field = form.$('createOrUpdate');
-    const update = field.value === 'update';
+    const isUpdateStep = field.value === 'update';
     const hasAdminAccess = form.$('managed').value === 'admin';
+
+    return { isUpdateStep, hasAdminAccess, hasUpdateStackUrl, field };
+  }
+
+  renderSteps() {
+    const { isUpdateStep, hasAdminAccess, hasUpdateStackUrl, field } = this.getStep();
 
     return (
       <>
@@ -219,9 +231,9 @@ class AwsAccountUpdateContent extends React.Component {
           </Header>
           {hasUpdateStackUrl && <YesNo field={field} className="mb0 mt0" />}
         </div>
-        {!update && hasAdminAccess && this.renderCreateSteps()}
-        {update && hasAdminAccess && this.renderUpdateSteps()}
-        {!hasAdminAccess && this.renderEmailTemplate(update)}
+        {!isUpdateStep && hasAdminAccess && this.renderCreateSteps()}
+        {isUpdateStep && hasAdminAccess && this.renderUpdateSteps()}
+        {!hasAdminAccess && this.renderEmailTemplate(isUpdateStep)}
       </>
     );
   }

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -160,9 +160,7 @@ Resources:
                 - ec2:DescribeInstances
                 - ec2:DescribeSecurityGroups
                 - ec2:RevokeSecurityGroupIngress
-#                - ec2:RevokeSecurityGroupEgress
                 - ec2:AuthorizeSecurityGroupIngress
-#                - ec2:AuthorizeSecurityGroupEgress
                 - ec2-instance-connect:SendSSHPublicKey
               Resource: '*'
         - PolicyName: cfn-access

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -160,7 +160,9 @@ Resources:
                 - ec2:DescribeInstances
                 - ec2:DescribeSecurityGroups
                 - ec2:RevokeSecurityGroupIngress
+#                - ec2:RevokeSecurityGroupEgress
                 - ec2:AuthorizeSecurityGroupIngress
+#                - ec2:AuthorizeSecurityGroupEgress
                 - ec2-instance-connect:SendSSHPublicKey
               Resource: '*'
         - PolicyName: cfn-access
@@ -689,6 +691,30 @@ Resources:
         - !Ref SageMakerSecurityGroup
       VpcId: !Ref VPC
 
+  SagemakerApiEndpoint:
+    Type: 'AWS::EC2::VPCEndpoint'
+    Condition: isAppStream
+    Properties:
+      SubnetIds:
+        - !Ref PrivateWorkspaceSubnet
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.sagemaker.api"
+      VpcId: !Ref VPC
+      SecurityGroupIds:
+        - !Ref SagemakerApiEndpointSecurityGroup
+
+  SagemakerApiEndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: isAppStream
+    Properties:
+      GroupDescription: 'Sagemaker Api Endpoint Security Group for interface endpoint'
+      GroupName: 'Sagemaker-API-SG'
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
+          IpProtocol: '-1'
+
   SageMakerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
@@ -866,3 +892,10 @@ Outputs:
     Value: !Ref SagemakerNotebookEndpoint
     Export:
       Name: !Join ['', [Ref: Namespace, '-SageMakerVPCE']]
+
+  SageMakerApiSG:
+    Description: SageMaker API SG
+    Condition: isAppStream
+    Value: !Ref SagemakerApiEndpointSecurityGroup
+    Export:
+      Name: !Join ['', [Ref: Namespace, '-SageMakerApiSecurityGroup']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -68,7 +68,13 @@ Resources:
             FromPort: 443
             ToPort: 443
             CidrIp: !Ref AccessFromCIDRBlock
-
+      SecurityGroupEgress:
+        - !If
+          - AppStreamEnabled
+          - DestinationSecurityGroupId:
+              Fn::ImportValue: !Sub "${SolutionNamespace}-SageMakerApiSecurityGroup"
+            IpProtocol: '-1'
+          - !Ref "AWS::NoValue"
   PreSignedURLBoundary:
     Type: AWS::IAM::ManagedPolicy
     Condition: AppStreamEnabled

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -37,6 +37,7 @@ envStatusPollHandler:
         description: 'Invokes the lambda function that polls and synchronize environment status.'
   environment:
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
+    APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}
 
 dataSourceReachabilityHandler:
   handler: src/lambdas/data-source-reachability/handler.handler

--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -335,6 +335,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ec2:AuthorizeSecurityGroupIngress
+                  - ec2:AuthorizeSecurityGroupEgress
                   - ec2:RevokeSecurityGroupEgress
                   - ec2:CreateSecurityGroup
                   - ec2:DeleteSecurityGroup


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Added Sagemaker API Endpoint so that Sagemaker instances can call it's own CLI to stop itself
   * API VPC Endpoint Security group allows ingress request from `default` Security Group. All Sagemaker instances has `default` security group attached to it.
   * All Sagemaker instances also have a custom SG attached to it. This security group allows egress request to Sagemaker API VPC Endpoint 
   
**Miscellaneous Bug Fixes**
* When updating an AWS account, we don't need to disable the `Done` button on the update screen. Users already have AppStream enabled so we don't need to ask for additional acknowledgment before they can click the `Done` button. 
* `envStatusPollHandler` is missing the `isAppStreamEnabled` parameter. This was causing the lambda to error out.
Checklist:


**Test:** New Sagemaker workspace was launched. Workspace autostop successfully.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.