### PR TITLE
fix: Use bucket region if available while mounting BYOB studies

### DIFF
--- a/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
+++ b/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
@@ -78,19 +78,26 @@ do
             printf 'Mounting internal study "%s" at "%s"\n' "$study_id" "$study_dir"
             goofys --region $region --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
         else
+            bucket_region="$(printf "%s" "$mounts" | jq -r ".[$study_idx].region" -)"
+            # BYOB studies have a region specified, but in case it isn't use the default region
+            if [[ $bucket_region == "null" ]]; then
+              printf 'Bucket region is not specified. Defaulting to "%s" for mounting \n' "$region"
+              bucket_region=$region
+            fi;
+
             # make .aws dir if it doesn't already exist and add credentials
             mkdir -p $AWS_CONFIG_DIR
             append_role_to_credentials $study_id $s3_role_arn
             if [ "$kms_arn" == "null" ]
             then
-                printf 'Mounting external study "%s" at "%s" using role "%s" \n' "$study_id" "$study_dir" \
-                "$s3_role_arn"
-                goofys --region $region --profile $study_id --acl "bucket-owner-full-control" \
+                printf 'Mounting external study "%s" at "%s" using role "%s" and region "%s" \n' "$study_id" "$study_dir" \
+                "$s3_role_arn" "$bucket_region"
+                goofys --region $bucket_region --profile $study_id --acl "bucket-owner-full-control" \
                 "${s3_bucket}:${s3_prefix}" "$study_dir"
             else
-                printf 'Mounting external study "%s" at "%s" using role "%s" and kms arn "%s" \n' "$study_id" "$study_dir" \
-                "$s3_role_arn" "$kms_arn"
-                goofys --region $region --profile $study_id --sse-kms $kms_arn --acl "bucket-owner-full-control" \
+                printf 'Mounting external study "%s" at "%s" using role "%s", kms arn "%s" and region "%s" \n' "$study_id" "$study_dir" \
+                "$s3_role_arn" "$kms_arn" "$bucket_region"
+                goofys --region $bucket_region --profile $study_id --sse-kms $kms_arn --acl "bucket-owner-full-control" \
                 "${s3_bucket}:${s3_prefix}" "$study_dir"
             fi
         fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Note that this change only works when isAppStream is false. When AppStream is enabled cross-region studies will not work since access to S3 happens via a private gateway endpoint. According to [S3 documentation](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) private endpoint cannot be used to access buckets cross-region

> Endpoints currently do not support cross-Region requests—ensure that you create your endpoint in the same Region as your bucket. You can find the location of your bucket by using the Amazon S3 console, or by using the get-bucket-location command. Use a Region-specific Amazon S3 endpoint to access your bucket; for example, mybucket.s3.us-west-2.amazonaws.com. For more information about Region-specific endpoints for Amazon S3, see Amazon Simple Storage Service (S3) in Amazon Web Services General Reference. If you use the AWS CLI to make requests to Amazon S3, set your default Region to the same Region as your bucket, or use the --region parameter in your requests.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.