### PR TITLE
fix: account onboarding error

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
@@ -28,6 +28,7 @@ const settingKeys = {
   tableName: 'dbAwsAccounts',
   environmentInstanceFiles: 'environmentInstanceFiles',
   isAppStreamEnabled: 'isAppStreamEnabled',
+  swbMainAccount: 'mainAcct',
 };
 
 class AwsAccountsService extends Service {
@@ -171,9 +172,15 @@ class AwsAccountsService extends Service {
     });
 
     // Only try to shareAppStreamImage with member account if AppStream is enabled and appStreamImageName is provided
-    if (this.settings.getBoolean(settingKeys.isAppStreamEnabled) && rawData.appStreamImageName !== undefined) {
+    // and also that the main account ID is not equal to the member account being added
+    const mainAccountId = this.settings.get(settingKeys.swbMainAccount);
+    const accountId = rawData.accountId;
+    if (
+      this.settings.getBoolean(settingKeys.isAppStreamEnabled) &&
+      rawData.appStreamImageName !== undefined &&
+      mainAccountId !== accountId
+    ) {
       const appStreamImageName = rawData.appStreamImageName;
-      const accountId = rawData.accountId;
       await this.shareAppStreamImageWithMemberAccount(requestContext, accountId, appStreamImageName);
     }
 


### PR DESCRIPTION
Issue #, if available:
Sharing appstream image with member account causes issues if the account is the same as main account.

Description of changes:
Do not share image with main account.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.