### PR TITLE
fix: externalId requirement for add account form

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js
@@ -31,6 +31,11 @@ const addUpdateBaseAwsAccountFormFields = {
     placeholder: 'Type description for this AWS account',
     rules: 'required|string',
   },
+  externalId: {
+    label: 'External ID',
+    placeholder: 'Type external ID for this AWS account',
+    rules: 'required|string|between:1,300',
+  },
 };
 
 const addUpdateAwsAccountAppStreamFormFields = {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddUpdateAwsAccount.test.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/accounts/__tests__/AddUpdateAwsAccount.test.js
@@ -62,6 +62,7 @@ describe('AddAwsAccount', () => {
       name: 'MyResearchProjectAccount',
       accountId: '012345678910',
       description: 'This is my research project account',
+      externalId: 'sampleExternalId',
     };
     awsAccountsStore.addAwsAccount.mockImplementationOnce(() => {
       return { ...component.awsAccount, id: 'mockID' };

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/__tests__/aws-accounts-service.test.js
@@ -191,6 +191,53 @@ describe('AwsAccountService', () => {
       }
     });
 
+    it('should not share appstream image if member account is same as main account', async () => {
+      // BUILD
+      const requestContext = {};
+      service.updateEnvironmentInstanceFilesBucketPolicy = jest.fn();
+      uuidMock.mockReturnValueOnce('abc-123-456');
+      settingsService.get = jest.fn(() => {
+        return awsAccount.accountId;
+      });
+      service.shareAppStreamImageWithMemberAccount = jest.fn();
+
+      // OPERATE
+      await service.create(requestContext, awsAccount);
+
+      // CHECK
+      expect(service.shareAppStreamImageWithMemberAccount).not.toHaveBeenCalled();
+    });
+
+    it('should share appstream image if member account is different than main account', async () => {
+      // BUILD
+      const requestContext = {};
+      service.updateEnvironmentInstanceFilesBucketPolicy = jest.fn();
+      uuidMock.mockReturnValueOnce('abc-123-456');
+      const mainAccountId = '0987654321';
+      settingsService.get = jest.fn(() => {
+        return mainAccountId;
+      });
+      settingsService.getBoolean = jest.fn(() => {
+        return true;
+      });
+      service.shareAppStreamImageWithMemberAccount = jest.fn();
+      const appstreamAwsAccount = {
+        name: 'my-aws-account',
+        accountId: '012345678998',
+        appStreamImageName: 'sampleAppStreamImageName',
+      };
+
+      // OPERATE
+      await service.create(requestContext, appstreamAwsAccount);
+
+      // CHECK
+      expect(service.shareAppStreamImageWithMemberAccount).toHaveBeenCalledWith(
+        requestContext,
+        appstreamAwsAccount.accountId,
+        appstreamAwsAccount.appStreamImageName,
+      );
+    });
+
     it('should save awsAccount in the database with a new uuid', async () => {
       // BUILD
       const requestContext = {};

--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-cfn-service.js
@@ -456,7 +456,7 @@ class AwsCfnService extends Service {
     };
 
     fieldsToUpdate.cfnStackId = stack.StackId;
-    fieldsToUpdate.externalId = accountEntity.externalId || 'workbench';
+    fieldsToUpdate.externalId = accountEntity.externalId;
     fieldsToUpdate.vpcId = findOutputValue('VPC');
     fieldsToUpdate.encryptionKeyArn = findOutputValue('EncryptionKeyArn');
     fieldsToUpdate.roleArn = findOutputValue('CrossAccountExecutionRoleArn');


### PR DESCRIPTION
Issue #, if available:
`externalId` not being stored in DDB when required.

Description of changes:
Adding `externalId` form field for aws accounts.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.