### PR TITLE
fix: enableEgressStore flag is boolean, not string

### DIFF
--- a/addons/addon-base-pre-deployment/packages/base-pre-deployment/lib/steps/validate-byob-study-service.js
+++ b/addons/addon-base-pre-deployment/packages/base-pre-deployment/lib/steps/validate-byob-study-service.js
@@ -45,8 +45,8 @@ class ValidateByobStudyService extends Service {
     const [dataSourceAccountService, studyService] = await this.service(['dataSourceAccountService', 'studyService']);
 
     // try {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (!enableEgressStore) {
       this.log.info('Egress feature is not enabled, no need to validate BYOB Study access types.');
       return;
     }

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/settings.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/settings.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 const enableBuiltInWorkspaces = process.env.REACT_APP_ENABLE_BUILT_IN_WORKSPACES === 'true';
-const enableEgressStore = process.env.REACT_APP_ENABLE_EGRESS_STORE;
+const enableEgressStore = process.env.REACT_APP_ENABLE_EGRESS_STORE === 'true';
 const isAppStreamEnabled = process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
 
 export { enableBuiltInWorkspaces, enableEgressStore, isAppStreamEnabled };

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentEgressStoreDetailStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentEgressStoreDetailStore.js
@@ -39,7 +39,7 @@ const ScEnvironmentEgressStoreDetailStore = BaseStore.named('ScEnvironmentEgress
       },
 
       async egressNotifySns(id) {
-        if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+        if (enableEgressStore) {
           await egressNotifySns(id);
         }
       },

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironmentsStore.js
@@ -109,7 +109,7 @@ const ScEnvironmentsStore = BaseStore.named('ScEnvironmentsStore')
       },
 
       async terminateScEnvironment(id) {
-        if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+        if (enableEgressStore) {
           await deleteEgressStore(id);
         }
         await deleteScEnvironment(id);

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/data-sources/register/InputStep.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/data-sources/register/InputStep.js
@@ -347,7 +347,7 @@ class InputStep extends React.Component {
 
   renderStudyField({ field }) {
     const myStudies = field.$('category').value === 'My Studies';
-    const enableEgressStoreFeature = enableEgressStore.toUpperCase() === 'TRUE';
+    const enableEgressStoreFeature = enableEgressStore;
 
     return (
       <Segment key={field.key} clearing className="mt3 p3">

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentButtons.js
@@ -49,13 +49,12 @@ class ScEnvironmentButtons extends React.Component {
   };
 
   getEgressStoreDetailsStore = () => {
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE')
-      return this.props.scEnvironmentEgressStoreDetailStore;
+    if (enableEgressStore) return this.props.scEnvironmentEgressStoreDetailStore;
     return null;
   };
 
   handleTerminate = async () => {
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    if (enableEgressStore) {
       const egressStoreDetailsStore = this.getEgressStoreDetailsStore();
       if (!egressStoreDetailsStore) {
         await this.handleAction(async () => {
@@ -230,26 +229,21 @@ class ScEnvironmentButtons extends React.Component {
               Edit CIDRs
             </Button>
           )}
-          {enableEgressStore &&
-            enableEgressStore.toUpperCase() === 'TRUE' &&
-            state.canTerminate &&
-            !state.key.includes('FAILED') && (
-              <Button
-                floated="left"
-                basic
-                size="mini"
-                className="mt1 mb1 ml2"
-                toggle
-                active={egressStoreButtonActive}
-                onClick={this.handleEgressStoreToggle}
-              >
-                Egress Store
-              </Button>
-            )}
+          {enableEgressStore && state.canTerminate && !state.key.includes('FAILED') && (
+            <Button
+              floated="left"
+              basic
+              size="mini"
+              className="mt1 mb1 ml2"
+              toggle
+              active={egressStoreButtonActive}
+              onClick={this.handleEgressStoreToggle}
+            >
+              Egress Store
+            </Button>
+          )}
         </div>
-        {enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE' && egressStoreButtonActive && (
-          <ScEnvironmentEgressStoreDetail scEnvironment={env} />
-        )}
+        {enableEgressStore && egressStoreButtonActive && <ScEnvironmentEgressStoreDetail scEnvironment={env} />}
         {canConnect && connectionsButtonActive && <ScEnvironmentConnections scEnvironment={env} />}
         {editCidrButtonActive && <ScEnvironmentUpdateCidrs scEnvironment={env} onCancel={this.handleCidrEditToggle} />}
       </>

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/__test__/data-egress-service.test.js
@@ -119,9 +119,9 @@ describe('DataEgressService', () => {
   describe('create Egress Store', () => {
     it('should fail creating egress store without enable egress store feature', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'false';
+            return false;
           }
           return undefined;
         },
@@ -146,9 +146,9 @@ describe('DataEgressService', () => {
 
     it('should fail creating egress store with wrong schema', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
@@ -187,14 +187,17 @@ describe('DataEgressService', () => {
     it('should fail creating with create s3 path fail', async () => {
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -238,14 +241,17 @@ describe('DataEgressService', () => {
       const s3Policy = testS3PolicyFn();
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -329,9 +335,9 @@ describe('DataEgressService', () => {
   describe('delete Egress Store', () => {
     it('should fail deleting egress store without enable egress store feature', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'false';
+            return false;
           }
           return undefined;
         },
@@ -350,14 +356,17 @@ describe('DataEgressService', () => {
     it('should fail delete egress store with scanning the DDB table', async () => {
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -383,14 +392,17 @@ describe('DataEgressService', () => {
       dataEgressService.removeEgressStoreBucketPolicy = jest.fn();
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -407,14 +419,17 @@ describe('DataEgressService', () => {
     it('should fail delete egress store while egress store is in PROCESSING status', async () => {
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -447,14 +462,17 @@ describe('DataEgressService', () => {
       const s3Policy = testS3PolicyFn();
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -532,14 +550,17 @@ describe('DataEgressService', () => {
       const s3Policy = testS3PolicyFn();
       dataEgressService._settings = {
         get: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreKmsKeyAliasArn') {
             return 'test-egressStoreKmsKeyAliasArn';
           }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -853,8 +874,11 @@ describe('DataEgressService', () => {
           if (settingName === 'egressNotificationBucketName') {
             return 'test-egressNotificationBucketName';
           }
+          return undefined;
+        },
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'false';
+            return false;
           }
           return undefined;
         },
@@ -875,8 +899,11 @@ describe('DataEgressService', () => {
           if (settingName === 'egressNotificationBucketName') {
             return 'test-egressNotificationBucketName';
           }
+          return undefined;
+        },
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           return undefined;
         },
@@ -914,8 +941,11 @@ describe('DataEgressService', () => {
           if (settingName === 'egressNotificationBucketName') {
             return 'test-egressNotificationBucketName';
           }
+          return undefined;
+        },
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           return undefined;
         },
@@ -955,11 +985,14 @@ describe('DataEgressService', () => {
           if (settingName === 'egressNotificationBucketName') {
             return 'test-egressNotificationBucketName';
           }
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressNotificationSnsTopicArn') {
             return 'test-egressNotificationSnsTopicArn';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -1039,11 +1072,14 @@ describe('DataEgressService', () => {
           if (settingName === 'egressNotificationBucketName') {
             return 'test-egressNotificationBucketName';
           }
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressNotificationSnsTopicArn') {
             return 'test-egressNotificationSnsTopicArn';
+          }
+          return null;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return null;
         },
@@ -1143,9 +1179,9 @@ describe('DataEgressService', () => {
   describe('should get Egress Store objects', () => {
     it('should get Egress Store objects', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           return null;
         },
@@ -1195,9 +1231,9 @@ describe('DataEgressService', () => {
     });
     it('should error out without enable egress feature', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'false';
+            return false;
           }
           return null;
         },
@@ -1236,9 +1272,9 @@ describe('DataEgressService', () => {
 
     it('should error out with unauthorized user', async () => {
       dataEgressService._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           return null;
         },

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -97,10 +97,10 @@ class DataEgressService extends Service {
   }
 
   async createEgressStore(requestContext, environment) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
     const by = _.get(requestContext, 'principalIdentifier.uid');
 
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    if (!enableEgressStore) {
       throw this.boom.forbidden('Unable to create Egress store since this feature is disabled', true);
     }
 
@@ -187,9 +187,9 @@ class DataEgressService extends Service {
   }
 
   async terminateEgressStore(requestContext, environmentId) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
     const curUser = _.get(requestContext, 'principalIdentifier.uid');
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    if (!enableEgressStore) {
       throw this.boom.forbidden('Unable to terminate Egress store since this feature is disabled', true);
     }
 
@@ -276,8 +276,8 @@ class DataEgressService extends Service {
   }
 
   async getEgressStore(requestContext, environmentId) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (!enableEgressStore) {
       throw this.boom.forbidden('Unable to list objects in egress store since this feature is disabled', true);
     }
     const curUser = _.get(requestContext, 'principalIdentifier.uid');
@@ -362,9 +362,9 @@ class DataEgressService extends Service {
   }
 
   async notifySNS(requestContext, environmentId) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
     const curUser = _.get(requestContext, 'principalIdentifier.uid');
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    if (!enableEgressStore) {
       throw this.boom.forbidden('Unable to create Egress store since this feature is disabled', true);
     }
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
@@ -494,6 +494,23 @@ describe('EnvironmentResourceService', () => {
 
   describe('addToKmsKeyPolicy', () => {
     it('add new principal to KMS policy with no principals', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return false;
+          }
+          return undefined;
+        },
+      };
       AWSMock.mock('KMS', 'describeKey', (params, callback) => {
         expect(params).toMatchObject({
           KeyId: 'studyKmsKeyAlias',
@@ -545,9 +562,6 @@ describe('EnvironmentResourceService', () => {
           if (settingName === 'studyDataKmsKeyArn') {
             return 'studyKmsKeyAlias';
           }
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
           }
@@ -556,6 +570,12 @@ describe('EnvironmentResourceService', () => {
           }
           if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
             return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -604,9 +624,6 @@ describe('EnvironmentResourceService', () => {
           if (settingName === 'studyDataKmsKeyArn') {
             return 'studyKmsKeyAlias';
           }
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
           }
@@ -615,6 +632,12 @@ describe('EnvironmentResourceService', () => {
           }
           if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
             return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -638,6 +661,23 @@ describe('EnvironmentResourceService', () => {
     });
 
     it('add new principal to KMS policy with multiple principals', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return false;
+          }
+          return undefined;
+        },
+      };
       const oldKMSPolicy = {
         Statement: [
           {
@@ -693,6 +733,23 @@ describe('EnvironmentResourceService', () => {
 
   describe('removeFromKmsKeyPolicy', () => {
     it('remove last left principal from KMS policy', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
+            return 'KMS Policy';
+          }
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return false;
+          }
+          return undefined;
+        },
+      };
       const oldKMSPolicy = {
         Statement: [
           {
@@ -746,9 +803,6 @@ describe('EnvironmentResourceService', () => {
           if (settingName === 'studyDataKmsKeyArn') {
             return 'studyKmsKeyAlias';
           }
-          if (settingName === 'enableEgressStore') {
-            return 'true';
-          }
           if (settingName === 'egressStoreBucketName') {
             return 'test-egressStoreBucketName';
           }
@@ -757,6 +811,12 @@ describe('EnvironmentResourceService', () => {
           }
           if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
             return 'test-egressStoreKmsPolicyWorkspaceSid';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return true;
           }
           return undefined;
         },
@@ -800,6 +860,20 @@ describe('EnvironmentResourceService', () => {
     });
 
     it('remove one principal from KMS policy with multiple principals', async () => {
+      environmentResourceService._settings = {
+        get: settingName => {
+          if (settingName === 'studyDataKmsKeyArn') {
+            return 'studyKmsKeyAlias';
+          }
+          return undefined;
+        },
+        getBoolean: settingName => {
+          if (settingName === 'enableEgressStore') {
+            return false;
+          }
+          return undefined;
+        },
+      };
       const oldKMSPolicy = {
         Statement: [
           {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/__tests__/environment-resource-service.test.js
@@ -189,6 +189,12 @@ describe('EnvironmentResourceService', () => {
         }
         return undefined;
       },
+      getBoolean: settingName => {
+        if (settingName === 'enableEgressStore') {
+          return false;
+        }
+        return undefined;
+      },
     };
   });
 
@@ -494,23 +500,6 @@ describe('EnvironmentResourceService', () => {
 
   describe('addToKmsKeyPolicy', () => {
     it('add new principal to KMS policy with no principals', async () => {
-      environmentResourceService._settings = {
-        get: settingName => {
-          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
-            return 'KMS Policy';
-          }
-          if (settingName === 'studyDataKmsKeyArn') {
-            return 'studyKmsKeyAlias';
-          }
-          return undefined;
-        },
-        getBoolean: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return false;
-          }
-          return undefined;
-        },
-      };
       AWSMock.mock('KMS', 'describeKey', (params, callback) => {
         expect(params).toMatchObject({
           KeyId: 'studyKmsKeyAlias',
@@ -661,23 +650,6 @@ describe('EnvironmentResourceService', () => {
     });
 
     it('add new principal to KMS policy with multiple principals', async () => {
-      environmentResourceService._settings = {
-        get: settingName => {
-          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
-            return 'KMS Policy';
-          }
-          if (settingName === 'studyDataKmsKeyArn') {
-            return 'studyKmsKeyAlias';
-          }
-          return undefined;
-        },
-        getBoolean: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return false;
-          }
-          return undefined;
-        },
-      };
       const oldKMSPolicy = {
         Statement: [
           {
@@ -733,23 +705,6 @@ describe('EnvironmentResourceService', () => {
 
   describe('removeFromKmsKeyPolicy', () => {
     it('remove last left principal from KMS policy', async () => {
-      environmentResourceService._settings = {
-        get: settingName => {
-          if (settingName === 'studyDataKmsPolicyWorkspaceSid') {
-            return 'KMS Policy';
-          }
-          if (settingName === 'studyDataKmsKeyArn') {
-            return 'studyKmsKeyAlias';
-          }
-          return undefined;
-        },
-        getBoolean: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return false;
-          }
-          return undefined;
-        },
-      };
       const oldKMSPolicy = {
         Statement: [
           {
@@ -860,20 +815,6 @@ describe('EnvironmentResourceService', () => {
     });
 
     it('remove one principal from KMS policy with multiple principals', async () => {
-      environmentResourceService._settings = {
-        get: settingName => {
-          if (settingName === 'studyDataKmsKeyArn') {
-            return 'studyKmsKeyAlias';
-          }
-          return undefined;
-        },
-        getBoolean: settingName => {
-          if (settingName === 'enableEgressStore') {
-            return false;
-          }
-          return undefined;
-        },
-      };
       const oldKMSPolicy = {
         Statement: [
           {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/legacy/environment-resource-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/legacy/environment-resource-service.js
@@ -315,8 +315,8 @@ class EnvironmentResourceService extends Service {
   }
 
   async addToEgressKmsKeyPolicy(memberAccountId) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (enableEgressStore) {
       await this.updateEgressKMSPolicy(environmentStatement =>
         addAccountToStatement(environmentStatement, memberAccountId),
       );
@@ -329,8 +329,8 @@ class EnvironmentResourceService extends Service {
       removeAccountFromStatement(environmentStatement, memberAccountId),
     );
 
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (enableEgressStore) {
       await this.updateEgressKMSPolicy(environmentStatement =>
         removeAccountFromStatement(environmentStatement, memberAccountId),
       );

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/environment-resource-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/__tests__/environment-resource-service.test.js
@@ -221,14 +221,17 @@ describe('EnvironmentResourceService', () => {
   it('allocates egress resources only', async () => {
     service._settings = {
       get: settingName => {
-        if (settingName === 'enableEgressStore') {
-          return 'true';
-        }
         if (settingName === 'egressStoreKmsKeyArn') {
           return 'test-egressStoreKmsKeyArn';
         }
         if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
           return 'test-egressStoreKmsPolicyWorkspaceSid';
+        }
+        return undefined;
+      },
+      getBoolean: settingName => {
+        if (settingName === 'enableEgressStore') {
+          return true;
         }
         return undefined;
       },
@@ -254,14 +257,17 @@ describe('EnvironmentResourceService', () => {
   it('should update Egress KMS Policy', async () => {
     service._settings = {
       get: settingName => {
-        if (settingName === 'enableEgressStore') {
-          return 'true';
-        }
         if (settingName === 'egressStoreKmsKeyArn') {
           return 'test-egressStoreKmsKeyArn';
         }
         if (settingName === 'egressStoreKmsPolicyWorkspaceSid') {
           return 'test-egressStoreKmsPolicyWorkspaceSid';
+        }
+        return undefined;
+      },
+      getBoolean: settingName => {
+        if (settingName === 'enableEgressStore') {
+          return true;
         }
         return undefined;
       },

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-source/access-strategy/roles-only/environment-resource-service.js
@@ -278,8 +278,8 @@ class EnvironmentResourceService extends Service {
   }
 
   async addToEgressKmsKeyPolicy(memberAccountId) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (enableEgressStore) {
       await this.updateEgressKMSPolicy(environmentStatement =>
         addAccountToStatement(environmentStatement, memberAccountId),
       );

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-config-vars-service.test.js
@@ -128,6 +128,15 @@ describe('EnvironmentSCService', () => {
       });
       return retValue;
     });
+    settingsService.getBoolean = jest.fn(getKey => {
+      let retValue;
+      Object.keys(settings).forEach(key => {
+        if (key === getKey) {
+          retValue = settings[key];
+        }
+      });
+      return retValue;
+    });
   }
 
   describe('resolveEnvConfigVars', () => {
@@ -340,7 +349,7 @@ describe('EnvironmentSCService', () => {
         environmentInstanceFiles: '{}',
         isAppStreamEnabled: 'true',
         solutionNamespace: 'initial-stack-1625689755737',
-        enableEgressStore: 'true',
+        enableEgressStore: true,
       });
       const requestContext = 'sampleRequestContext';
       const envId = 'sampleEnvId';

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
@@ -237,8 +237,8 @@ class EnvironmentConfigVarsService extends Service {
     });
 
     let egressStoreIamPolicyDocument = {};
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (enableEgressStore) {
       const egressStoreMount = await this.getEgressStoreMount(requestContext, environment);
       s3Mounts.push(egressStoreMount);
       egressStoreIamPolicyDocument = await this.getEnvEgressStorePolicy(requestContext, {
@@ -417,8 +417,8 @@ class EnvironmentConfigVarsService extends Service {
   }
 
   async getEgressStoreMount(requestContext, environment) {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    if (!enableEgressStore || enableEgressStore.toUpperCase() !== 'TRUE') {
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    if (!enableEgressStore) {
       throw this.boom.forbidden('Unable to mount Egress store in workspace since this feature is disabled', true);
     }
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
@@ -391,9 +391,9 @@ describe('studyService', () => {
     it('should fail due to egress store feautre is enabled and access type is readwrite', async () => {
       // BUILD
       service._settings = {
-        get: settingName => {
+        getBoolean: settingName => {
           if (settingName === 'enableEgressStore') {
-            return 'true';
+            return true;
           }
           return undefined;
         },

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -191,9 +191,9 @@ class StudyService extends Service {
     // Validate input
     await validationService.ensureValid(rawStudyEntity, registerSchema);
 
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
 
-    if (enableEgressStore && enableEgressStore.toUpperCase() === 'TRUE') {
+    if (enableEgressStore) {
       const accessType = rawStudyEntity.accessType;
       if (accessType === 'readwrite') {
         throw this.boom.forbidden('Only READ access type is allowed when egress data feature is enabled', true);

--- a/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/update-cfn-stack-policy.test.js
+++ b/addons/addon-stack-policy/packages/stack-policy/lib/steps/__test__/update-cfn-stack-policy.test.js
@@ -49,15 +49,15 @@ describe('UpdateCfnStackPolicy', () => {
     service = await container.find('UpdateCfnStackPolicy');
     settings = await container.find('settings');
     settings.get = jest.fn(key => {
-      if (key === 'enableEgressStore') {
-        return 'true';
-      }
       if (key === 'backendStackName') {
         return 'backendStackName';
       }
       return undefined;
     });
     settings.getBoolean = jest.fn(key => {
+      if (key === 'enableEgressStore') {
+        return true;
+      }
       if (key === 'isAppStreamEnabled') {
         return true;
       }
@@ -369,15 +369,15 @@ describe('UpdateCfnStackPolicy', () => {
         ],
       };
       settings.get = jest.fn(key => {
-        if (key === 'enableEgressStore') {
-          return 'true';
-        }
         if (key === 'backendStackName') {
           return 'backendStackName';
         }
         return undefined;
       });
       settings.getBoolean = jest.fn(key => {
+        if (key === 'enableEgressStore') {
+          return true;
+        }
         if (key === 'isAppStreamEnabled') {
           return false;
         }
@@ -422,15 +422,15 @@ describe('UpdateCfnStackPolicy', () => {
         ],
       };
       settings.get = jest.fn(key => {
-        if (key === 'enableEgressStore') {
-          return 'false';
-        }
         if (key === 'backendStackName') {
           return 'backendStackName';
         }
         return undefined;
       });
       settings.getBoolean = jest.fn(key => {
+        if (key === 'enableEgressStore') {
+          return false;
+        }
         if (key === 'isAppStreamEnabled') {
           return true;
         }
@@ -453,15 +453,15 @@ describe('UpdateCfnStackPolicy', () => {
 
     it('should not update policy when Egress was disabled, but it was previously enabled', async () => {
       settings.get = jest.fn(key => {
-        if (key === 'enableEgressStore') {
-          return 'false';
-        }
         if (key === 'backendStackName') {
           return 'backendStackName';
         }
         return undefined;
       });
       settings.getBoolean = jest.fn(key => {
+        if (key === 'enableEgressStore') {
+          return false;
+        }
         if (key === 'isAppStreamEnabled') {
           return false;
         }
@@ -477,15 +477,15 @@ describe('UpdateCfnStackPolicy', () => {
 
     it('should not update policy when AppStream was disabled, but it was previously enabled', async () => {
       settings.get = jest.fn(key => {
-        if (key === 'enableEgressStore') {
-          return 'false';
-        }
         if (key === 'backendStackName') {
           return 'backendStackName';
         }
         return undefined;
       });
       settings.getBoolean = jest.fn(key => {
+        if (key === 'enableEgressStore') {
+          return false;
+        }
         if (key === 'isAppStreamEnabled') {
           return false;
         }

--- a/addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
+++ b/addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
@@ -56,8 +56,8 @@ class UpdateCfnStackPolicy extends Service {
   }
 
   async execute() {
-    const enableEgressStore = this.settings.get(settingKeys.enableEgressStore);
-    const isEgressStoreEnabled = enableEgressStore ? enableEgressStore.toUpperCase() === 'TRUE' : false;
+    const enableEgressStore = this.settings.getBoolean(settingKeys.enableEgressStore);
+    const isEgressStoreEnabled = enableEgressStore;
     const isAppStreamEnabled = this.settings.getBoolean(settingKeys.isAppStreamEnabled);
 
     if (!isEgressStoreEnabled && !isAppStreamEnabled) {

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -204,7 +204,7 @@ egressNotificationTopicName: ${self:custom.settings.namespace}-EgressTopic
 # =========================================================================================================
 
 # Determine whether workspace should be accessible only through AppStream
-# NOTE: Once the isAppStremEnabled is set to true, the AppStrem feature will be enabled and can NOT be toggled off.
+# NOTE: Once the isAppStreamEnabled is set to true, the AppStream feature will be enabled and can NOT be toggled off.
 # If you toggle the AppStream feature from true to false and redeploy the whole solution, the backend stack deployment shold error out with following message:
 # Error validating existing stack policy: Unknown logical id 'LogicalResourceId/AppStream*' in statement {} - stack policies can only be applied to logical ids referenced in the template
 # Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -184,11 +184,11 @@ customUserAgent: 'AwsLabs/SO0144/${self:custom.settings.versionNumber}'
 # NOTE: Following properties are ONLY allowed to change for the initial deployment. It's NOT recommended to change the following properties if you have enabled data egress feature.
 
 # Enable the Egress Store feature would allow researchers to securely egress data from lockdown Workspace
-# NOTE: Once the enableEgressStore is set to 'true', the egress store feature will be enabled and can NOT be toggled off.
+# NOTE: Once the enableEgressStore is set to true, the egress store feature will be enabled and can NOT be toggled off.
 # If you toggle the egress store from true to false and redeploy the whole solution, the backend stack deployment shold error out with following message:
 # Error validating existing stack policy: Unknown logical id 'LogicalResourceId/EgressStore*' in statement {} - stack policies can only be applied to logical ids referenced in the template
 # Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
-enableEgressStore: 'false'
+enableEgressStore: false
 
 # DynamoDB table name for Egress Store
 dbEgressStore: ${self:custom.settings.dbPrefix}-EgressStore
@@ -204,4 +204,8 @@ egressNotificationTopicName: ${self:custom.settings.namespace}-EgressTopic
 # =========================================================================================================
 
 # Determine whether workspace should be accessible only through AppStream
+# NOTE: Once the isAppStremEnabled is set to true, the AppStrem feature will be enabled and can NOT be toggled off.
+# If you toggle the AppStream feature from true to false and redeploy the whole solution, the backend stack deployment shold error out with following message:
+# Error validating existing stack policy: Unknown logical id 'LogicalResourceId/AppStream*' in statement {} - stack policies can only be applied to logical ids referenced in the template
+# Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
 isAppStreamEnabled: false

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -90,11 +90,15 @@
 #fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-example-idp-metadata.xml"]'
 
 # Enable the Egress Store feature would allow researchers to securely egress data from lockdown Workspace
-# NOTE: Once the enableEgressStore is set to 'true', the egress store feature will be enabled and can NOT be toggled off.
-# If you toggle the egress store from 'true' to 'false' and redeploy the whole solution, the backend stack deployment shold error out with following message:
+# NOTE: Once the enableEgressStore is set to true, the egress store feature will be enabled and can NOT be toggled off.
+# If you toggle the egress store from true to false and redeploy the whole solution, the backend stack deployment shold error out with following message:
 # Error validating existing stack policy: Unknown logical id 'LogicalResourceId/EgressStore*' in statement {} - stack policies can only be applied to logical ids referenced in the template
 # Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
-#enableEgressStore: 'false'
+#enableEgressStore: false
 
 # Determine whether workspace should be accessible only through AppStream
+# NOTE: Once the isAppStremEnabled is set to true, the AppStrem feature will be enabled and can NOT be toggled off.
+# If you toggle the AppStream feature from true to false and redeploy the whole solution, the backend stack deployment shold error out with following message:
+# Error validating existing stack policy: Unknown logical id 'LogicalResourceId/AppStream*' in statement {} - stack policies can only be applied to logical ids referenced in the template
+# Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
 #isAppStreamEnabled: false

--- a/main/end-to-end-tests/e2eGitHubConfig.AppStreamEgress.yml
+++ b/main/end-to-end-tests/e2eGitHubConfig.AppStreamEgress.yml
@@ -4,4 +4,4 @@ solutionName: swb
 envType: secure
 createServiceCatalogPortfolio: true
 isAppStreamEnabled: true
-enableEgressStore: 'true'
+enableEgressStore: true

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -1,6 +1,6 @@
 Conditions:
   IsDev: !Equals ['${self:custom.settings.envType}', 'dev']
-  EnableEgressStore: !Equals ['${self:custom.settings.enableEgressStore}', 'true']
+  EnableEgressStore: !Equals ['${self:custom.settings.enableEgressStore}', true]
   AppStreamEnabled: !Equals ['${self:custom.settings.isAppStreamEnabled}', true]
 
 Resources:

--- a/main/solution/post-deployment/bool-to-str.js
+++ b/main/solution/post-deployment/bool-to-str.js
@@ -1,0 +1,11 @@
+// Adapted from: https://stackoverflow.com/questions/65832576/converting-ssm-value-to-number
+
+// To convert a boolean value to a string to be used by the serverless framework
+
+module.exports = async serverless => {
+  // Get params details from serverless.yml
+  const enableEgressStore = serverless.service.custom.settings.enableEgressStore;
+
+  // Must be explicitly equal to true and not just a "truthy" value
+  return enableEgressStore === true ? 'true' : 'false';
+};

--- a/main/solution/post-deployment/serverless.yml
+++ b/main/solution/post-deployment/serverless.yml
@@ -65,7 +65,7 @@ custom:
       bucketPrefix: service-catalog-products/
       localDir: ../../../addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog
   serverlessIfElse:
-    - If: '"${self:custom.settings.enableEgressStore}" == "false"'
+    - If: '"${file(./bool-to-str.js)}" == "false"'
       Exclude:
         - functions.egressStoreObjectsHandler
 


### PR DESCRIPTION
Issue #, if available: GALI-1071

Description of changes: enableEgressStore flag in the configuration file for SWB is now a boolean and not a string. Serverless accepts this by invoking a script to convert the boolean and read the string value of "true" if it was true and "false" otherwise. This affected the logic of many files that used this flag as well as unit tests of those files. All are updated. Tested with unit tests as well as locally and through the API.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.