### PR TITLE
feat: dynamic version number from Changelog

### DIFF
--- a/.github/workflows/deploy-integ.yml
+++ b/.github/workflows/deploy-integ.yml
@@ -143,3 +143,17 @@ jobs:
           branch: mainline
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+  check-beta-in-changelog:
+    name: Check Beta status
+    # Trigger to check and add Beta header if the latest commit isn't a release from standard-version or the last Add Beta
+    # workflow run
+    if: "!contains(github.event.head_commit.message, 'chore(release):') && !contains(github.event.head_commit.message, 'Add Beta')"
+    needs: merge-develop-to-mainline
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
+          fetch-depth: 0
+      - name: Check if Beta is present and add if not
+        run: ./scripts/check-and-add-beta.sh

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -171,11 +171,5 @@ auditQldbName: ${self:custom.settings.namespace}-audit
 # Override and disable this setting if you wish to create your portfolio manually
 createServiceCatalogPortfolio: true
 
-# Version number of current release
-versionNumber: '3.4.0'
-
-# Release date of current release
-versionDate: '2021-09-16'
-
 # Metadata provided with AWS SDK calls
 customUserAgent: 'AwsLabs/SO0144/${self:custom.settings.versionNumber}'

--- a/scripts/check-and-add-beta.sh
+++ b/scripts/check-and-add-beta.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Get the first header (not Changelog) in CHANGELOG.md
-versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\.[0-9]\.[0-9]\|Beta")"
+versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\+\.[0-9]\+\.[0-9]\+\|Beta")"
 
 # Check if it contains the word Beta
 if (echo "$versionLine" | grep -q "Beta")
@@ -16,7 +16,7 @@ else
     # Add Beta header to changelog
     echo "Need to add to changelog"
     # Get latest release number
-    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)"
+    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | head -n 1)"
     # Create ed file
     echo "5i
 ## Beta
@@ -31,6 +31,6 @@ q" > add-beta.ed
     rm add-beta.ed
     # Commit and push new changelog
     git add CHANGELOG.md
-    git commit -m "Add Beta"
+    git commit -m "docs: Add Beta"
     git push origin develop
 fi

--- a/scripts/check-and-add-beta.sh
+++ b/scripts/check-and-add-beta.sh
@@ -20,7 +20,7 @@ else
     # Create ed file
     echo "5i
 ## Beta
-[This deployment is in beta. Click here to see changes since ${latestReleaseVersion}.](https://github.com/maghirardelli/service-workbench-on-aws-github-actions/compare/v${latestReleaseVersion}...mainline)
+[This branch is in beta. Click here to see changes since ${latestReleaseVersion}.](https://github.com/maghirardelli/service-workbench-on-aws-github-actions/compare/v${latestReleaseVersion}...mainline)
 
 .
 w

--- a/scripts/check-and-add-beta.sh
+++ b/scripts/check-and-add-beta.sh
@@ -15,9 +15,12 @@ else
     git checkout develop
     # Add Beta header to changelog
     echo "Need to add to changelog"
+    # Get latest release number
+    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)"
     # Create ed file
     echo "5i
 ## Beta
+[This deployment is in beta. Click here to see changes since ${latestReleaseVersion}.](https://github.com/maghirardelli/service-workbench-on-aws-github-actions/compare/v${latestReleaseVersion}...mainline)
 
 .
 w

--- a/scripts/check-and-add-beta.sh
+++ b/scripts/check-and-add-beta.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Get the first header (not Changelog) in CHANGELOG.md
+versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\.[0-9]\.[0-9]\|Beta")"
+
+# Check if it contains the word Beta
+if (echo "$versionLine" | grep -q "Beta")
+then
+    # Do nothing
+    echo "Nothing to change in changelog--still Beta"
+else
+    git config --local user.email "action@github.com"
+    git config --local user.name "GitHub Action"
+    git checkout develop
+    # Add Beta header to changelog
+    echo "Need to add to changelog"
+    # Create ed file
+    echo "5i
+## Beta
+
+.
+w
+q" > add-beta.ed
+    # Change CHANGELOG.md with ed file
+    ed CHANGELOG.md < add-beta.ed
+    # delete ed file
+    rm add-beta.ed
+    # Commit and push new changelog
+    git add CHANGELOG.md
+    git commit -m "Add Beta"
+    git push origin develop
+fi

--- a/scripts/check-and-add-beta.sh
+++ b/scripts/check-and-add-beta.sh
@@ -20,7 +20,7 @@ else
     # Create ed file
     echo "5i
 ## Beta
-[This branch is in beta. Click here to see changes since ${latestReleaseVersion}.](https://github.com/maghirardelli/service-workbench-on-aws-github-actions/compare/v${latestReleaseVersion}...mainline)
+[This release is in beta. Click here to see changes since ${latestReleaseVersion}.](https://github.com/maghirardelli/service-workbench-on-aws-github-actions/compare/v${latestReleaseVersion}...mainline)
 
 .
 w

--- a/scripts/environment-deploy.sh
+++ b/scripts/environment-deploy.sh
@@ -62,7 +62,10 @@ versionNumber="$(echo $versionLine | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head 
 # Get version date (or generate if beta)
 if [ "$versionNumber" == "Beta" ]
 then
-    versionDate="$(date +'%Y-%m-%d')"
+    # versionDate="$(date +'%Y-%m-%d')"
+    # instead of showing a date in the beta condition, show the latest release version
+    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)"
+    versionDate="Latest Release Version: $latestReleaseVersion"
 else
     versionDate="$(echo $versionLine | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]")"
 fi
@@ -76,12 +79,12 @@ then
     then
         # Yes-->Are they different from above?
         oldVersionNumber="$(cat "$FILE" | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head -n 1)"
-        oldVersionDate="$(cat "$FILE" | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]")"
+        oldVersionDate="$(cat "$FILE" | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]\|Latest Release Version: [0-9]\.[0-9]\.[0-9]")"
         if ([ "$oldVersionNumber" != "$versionNumber" ]) || ([ "$oldVersionDate" != "$versionDate" ])
         then
             # Yes-->Replace new with old
-            sed -i -e "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" $FILE
-            sed -i -e "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
+            sed -i '' "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" $FILE
+            sed -i '' "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
         fi
     else
         # No-->Append new

--- a/scripts/environment-deploy.sh
+++ b/scripts/environment-deploy.sh
@@ -53,6 +53,54 @@ pushd "$SOLUTION_DIR/post-deployment" > /dev/null
 $EXEC sls invoke -f postDeployment -l -s "$STAGE"
 popd > /dev/null
 
+# Get the first header (not Changelog) in CHANGELOG.md
+versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\.[0-9]\.[0-9]\|Beta")"
+
+# Get version number
+versionNumber="$(echo $versionLine | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head -n 1)"
+
+# Get version date (or generate if beta)
+if [ "$versionNumber" == "Beta" ]
+then
+    versionDate="$(date +'%Y-%m-%d')"
+else
+    versionDate="$(echo $versionLine | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]")"
+fi
+
+# Is there a stage.yml file?
+FILE=main/config/settings/${STAGE}.yml
+if [ -f "$FILE" ]
+then
+    # Yes-->Is there a versionDate and versionNumber key?
+    if (cat "$FILE" | grep -q "versionDate") && (cat "$FILE" | grep -q "versionNumber")
+    then
+        # Yes-->Are they different from above?
+        oldVersionNumber="$(cat "$FILE" | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head -n 1)"
+        oldVersionDate="$(cat "$FILE" | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]")"
+        if ([ "$oldVersionNumber" != "$versionNumber" ]) || ([ "$oldVersionDate" != "$versionDate" ])
+        then
+            # Yes-->Replace new with old
+            sed -i -e "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" $FILE
+            sed -i -e "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
+        fi
+    else
+        # No-->Append new
+        echo "
+# Version number of current release
+versionNumber: '${versionNumber}'
+
+# Release date of current release
+versionDate: '${versionDate}'" >> "$FILE"
+    fi
+else
+    # No-->Make file and append new
+    echo "# Version number of current release
+versionNumber: '${versionNumber}'
+
+# Release date of current release
+versionDate: '${versionDate}'" >> "$FILE"
+fi
+
 # Deploy UI
 pushd "$SOLUTION_DIR/ui" > /dev/null
 

--- a/scripts/environment-deploy.sh
+++ b/scripts/environment-deploy.sh
@@ -54,16 +54,15 @@ $EXEC sls invoke -f postDeployment -l -s "$STAGE"
 popd > /dev/null
 
 # Get the first header (not Changelog) in CHANGELOG.md
-versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\.[0-9]\.[0-9]\|Beta")"
+versionLine="$(cat CHANGELOG.md | grep -m 1 "[0-9]\+\.[0-9]\+\.[0-9]\+\|Beta")"
 
 # Get version number
-versionNumber="$(echo $versionLine | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head -n 1)"
+versionNumber="$(echo $versionLine | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+\|Beta" | head -n 1)"
 
 # Get version date (or generate if beta)
 if [ "$versionNumber" == "Beta" ]
 then
-    # instead of showing a date in the beta condition, show the latest release version
-    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)"
+    latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | head -n 1)"
     versionDate="Latest Release Version: $latestReleaseVersion"
 else
     versionDate="$(echo $versionLine | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]")"
@@ -77,13 +76,13 @@ then
     if (cat "$FILE" | grep -q "versionDate") && (cat "$FILE" | grep -q "versionNumber")
     then
         # Yes-->Are they different from above?
-        oldVersionNumber="$(cat "$FILE" | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head -n 1)"
+        oldVersionNumber="$(cat "$FILE" | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+\|Beta" | head -n 1)"
         oldVersionDate="$(cat "$FILE" | grep -o "[0-9][0-9][0-9][0-9]\-[0-9][0-9]\-[0-9][0-9]\|Latest Release Version: [0-9]\.[0-9]\.[0-9]")"
         if ([ "$oldVersionNumber" != "$versionNumber" ]) || ([ "$oldVersionDate" != "$versionDate" ])
         then
             # Yes-->Replace new with old
-            sed -i '' "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" $FILE
-            sed -i '' "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
+            sed -i -e "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" $FILE
+            sed -i -e "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
         fi
     else
         # No-->Append new

--- a/scripts/environment-deploy.sh
+++ b/scripts/environment-deploy.sh
@@ -62,7 +62,6 @@ versionNumber="$(echo $versionLine | grep -o "[0-9]\.[0-9]\.[0-9]\|Beta" | head 
 # Get version date (or generate if beta)
 if [ "$versionNumber" == "Beta" ]
 then
-    # versionDate="$(date +'%Y-%m-%d')"
     # instead of showing a date in the beta condition, show the latest release version
     latestReleaseVersion="$(cat CHANGELOG.md | grep -o "[0-9]\.[0-9]\.[0-9]" | head -n 1)"
     versionDate="Latest Release Version: $latestReleaseVersion"


### PR DESCRIPTION
Issue #, if available: GALI-824

Description of changes: Now, instead of having the developer have to change the version number and version date in the .defaults.yml file for every release, as part of the deployment script, the version number and date will be added as parameters to the global stage file (location change suggestion from Sanket) as gotten from the CHANGELOG.md file. 

HOWEVER, Sanket would like to change our process a little bit for releases to allow for the version deployed in an environment to be flagged as "Beta." This would involve the developer cutting the release to, after the release has been published, push a change to the CHANGELOG file that is a new header "## Beta" at the top of the file ahead of the latest release information. Case matters (I can change that if you want but figured it was easier to keep it consistent). This way, anyone pulling from mainline will know that their version is not released and potentially unstable. In this case, the date next to Beta will be the date of deployment like this:
![Screen Shot 2021-09-20 at 1 12 50 PM](https://user-images.githubusercontent.com/43092418/134047127-7620bfdb-50ce-45f9-bb2e-80dcb475eda4.png)

I didn't make this an SSM param (which was one of Jeet's initial ideas when this ticket was created) because I think this change propagates the proper information to everything that it needs to.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.