### PR TITLE
fix: namespace code works with configs with no namespace param

### DIFF
--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/launch-product.test.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/launch-product.test.js
@@ -25,7 +25,7 @@ describe('LaunchProduct', () => {
     workflowPayload: new WorkflowPayload({ meta, input, workflowInstance: { steps: [] } }),
   });
 
-  describe('checkNamespace', () => {
+  describe('getNamespaceAndIndexIfNecessary', () => {
     it('Static name should be transformed to start with analysis- and end with number string and be unique between calls', async () => {
       // Build
       const resolvedInputParams = [{ Key: 'Namespace', Value: 'staticname' }];
@@ -112,6 +112,18 @@ describe('LaunchProduct', () => {
 
       // Check
       expect(namespaceParam).not.toBe(resolvedInputParams[namespaceIndex]);
+    });
+
+    it('There is no namespace parameter', async () => {
+      // Build
+      const datetime = Date.now();
+      const resolvedInputParams = [{ Key: 'SomeParam', Value: 'somevalue' }];
+
+      // Operate
+      const { namespaceIndex } = lp.getNamespaceAndIndexIfNecessary(resolvedInputParams, datetime);
+
+      // Check
+      expect(namespaceIndex).toEqual(-1);
     });
   });
 });

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/launch-product/launch-product.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/launch-product/launch-product.js
@@ -97,7 +97,7 @@ class LaunchProduct extends StepBase {
     // Additional layer to check the namespace is valid and unique. If not, make new namespace from
     // static and get index of namespace param to change
     const { namespaceParam, namespaceIndex } = this.getNamespaceAndIndexIfNecessary(resolvedInputParams, datetime);
-    resolvedInputParams[namespaceIndex].Value = namespaceParam;
+    if (namespaceIndex >= 0) resolvedInputParams[namespaceIndex].Value = namespaceParam;
     // Read tags specified in the environment type configuration
     // The tags may include variable expressions, resolve the expressions by using the resolveVars
     const resolvedTags = await this.resolveVarExpressions(envTypeConfig.tags, resolvedVars);
@@ -375,7 +375,7 @@ class LaunchProduct extends StepBase {
    */
   getNamespaceAndIndexIfNecessary(resolvedInputParams, datetime) {
     const namespaceIndex = resolvedInputParams.findIndex(element => element.Key === 'Namespace');
-    let namespaceParam = resolvedInputParams[namespaceIndex].Value;
+    let namespaceParam = namespaceIndex < 0 ? '' : resolvedInputParams[namespaceIndex].Value;
 
     // Check to make sure the resolved namespace variable begins with 'analysis-' so our templates will allow it
     if (!namespaceParam.startsWith('analysis-')) {


### PR DESCRIPTION
Issue #, if available:

Description of changes: Allows workspace types with no namespace parameter to work with the static namespace code

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.