### PR TITLE
feat: Pull AppStream create connection test env id from config file

### DIFF
--- a/.github/workflows/deploy-integ-appstream-egress.yml
+++ b/.github/workflows/deploy-integ-appstream-egress.yml
@@ -75,7 +75,7 @@ jobs:
   integration-test:
     name: Integration test
     runs-on: ubuntu-18.04
-    needs: deploy
+    needs: infrastructure-test
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/main/integration-tests/__test__/api-tests/appstream-egress-enabled/workspace-service-catalog/connections/create-url-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/appstream-egress-enabled/workspace-service-catalog/connections/create-url-connection.test.js
@@ -34,7 +34,7 @@ describe('Create URL scenarios', () => {
   describe('Create AppStream URL', () => {
     it('should return AppStream URL: SageMaker', async () => {
       // BUILD
-      const envId = '36f22de5-fefb-4f62-8ab4-e99ac4387ad4';
+      const envId = setup.defaults.sagemakerEnvId;
       const connectionId = 'id-0';
       const applicationName = 'Firefox';
       const sagemakerUrlPrefix = 'https://basicnotebookinstance';
@@ -83,7 +83,7 @@ describe('Create URL scenarios', () => {
       [
         'Windows',
         {
-          envId: '5360d995-fa4b-44eb-b67d-a0586886e1a3',
+          envIdPath: 'windowsEnvId',
           connectionId: 'id-1',
           applicationName: 'MicrosoftRemoteDesktop',
           preAuthStreamingUrl: 'https://appstream2.us-east-1.aws.amazon.com/authenticate?parameters=',
@@ -95,7 +95,7 @@ describe('Create URL scenarios', () => {
       [
         'EC2 Linux',
         {
-          envId: '4ceb23c8-c80c-4ded-b948-c63b21ba5c72',
+          envIdPath: 'linuxEnvId',
           connectionId: 'id-1',
           applicationName: 'EC2Linux',
           preAuthStreamingUrl: 'https://appstream2.us-east-1.aws.amazon.com/authenticate?parameters=',
@@ -109,7 +109,7 @@ describe('Create URL scenarios', () => {
     it.each(testContexts)('should return AppStream URL: %s', async (_, testContext) => {
       // OPERATE
       const connectionUrlResponse = await adminSession.resources.workspaceServiceCatalogs
-        .workspaceServiceCatalog(testContext.envId)
+        .workspaceServiceCatalog(setup.defaults[testContext.envIdPath])
         .connections()
         .connection(testContext.connectionId)
         .createUrl();

--- a/main/integration-tests/config/settings/example.yml
+++ b/main/integration-tests/config/settings/example.yml
@@ -44,19 +44,29 @@ localApiEndpoint: http://localhost:4000
 # ec2LinuxConfigId: ""
 
 # Provide the id of the available EC2-Windows Service Catalog product
-# ec2WindowsEnvTypeId: "prod-sampleEC2Windows-pa-sampleEC2Windows"
+#ec2WindowsEnvTypeId: "prod-sampleEC2Windows-pa-sampleEC2Windows"
 # Provide the id of a configuration for an imported EC2-Windows environment
-# ec2WindowsConfigId: ""
+#ec2WindowsConfigId: ""
 
 # Provide the id of the available SageMaker Service Catalog product
-# sagemakerEnvTypeId: "prod-sampleSageMaker-pa-sampleSageMaker"
+#sagemakerEnvTypeId: "prod-sampleSageMaker-pa-sampleSageMaker"
 # Provide the id of a configuration for an imported SageMaker environment
-# sagemakerConfigId: ""
+#sagemakerConfigId: ""
 
 # Provide the id of the available EMR Service Catalog product
-# emrEnvTypeId: "prod-sampleEMR-pa-sampleEMR"
+#emrEnvTypeId: "prod-sampleEMR-pa-sampleEMR"
 # Provide the id of a configuration for an imported EMR environment
-# emrConfigId: ""
+#emrConfigId: ""
 
 # Provide the id of the external BYOB Data Source study
-# byobStudy: ""
+#byobStudy: ""
+
+# ------- CONFIG VALUES BELOW ONLY REQUIRED FOR TESTS IN "appstream-egress-enabled" FOLDER ------
+# Provide the id of a Sagemaker workspace actively running in SWB
+#sagemakerEnvId: ""
+
+# Provide the id of a Linux workspace actively running in SWB
+#linuxEnvId: ""
+
+# Provide the id of a Windows workspace actively running in SWB
+#windowsEnvId: ""

--- a/main/integration-tests/support/setup.js
+++ b/main/integration-tests/support/setup.js
@@ -127,7 +127,16 @@ class Setup {
       workflowTemplateId,
       envTypes,
       byobStudy,
+      ...(await this.getConfigForAppStreamEnabledTests()),
     };
+  }
+
+  async getConfigForAppStreamEnabledTests() {
+    const sagemakerEnvId = await this.settings.optional('sagemakerEnvId', '');
+    const linuxEnvId = await this.settings.optional('linuxEnvId', '');
+    const windowsEnvId = await this.settings.optional('windowsEnvId');
+
+    return { sagemakerEnvId, linuxEnvId, windowsEnvId };
   }
 
   async createAdminSession() {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This PR is related to GALI-1140. I've added the correct config file to S3 and the tests now run correctly and passes. I tested it by running the Github action locally used `act`.

For the tests to pass, we need to provide the correct workspace ids for the environment. This PR allows the workspace ids to be passed in from `config` file.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.