### PR TITLE
feat: Configurable open data filter

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -73,6 +73,7 @@ describe('EnvironmentSCService', () => {
   let awsAccountsService = null;
   let aws = null;
   let storageGatewayService = null;
+  let studyService = null;
   const error = { code: 'ConditionalCheckFailedException' };
   beforeEach(async () => {
     const container = new ServicesContainer();
@@ -106,6 +107,7 @@ describe('EnvironmentSCService', () => {
     wfService = await container.find('workflowTriggerService');
     aws = await container.find('aws');
     storageGatewayService = await container.find('storageGatewayService');
+    studyService = await container.find('studyService');
 
     // Skip authorization by default
     service.assertAuthorized = jest.fn();
@@ -183,6 +185,8 @@ describe('EnvironmentSCService', () => {
       dbService.table.update.mockImplementationOnce(() => {
         throw error;
       });
+      service.getInvalidOpenDataStudyIds = jest.fn().mockResolvedValue([]);
+
       // OPERATE
       try {
         await service.create(requestContext, newEnv);
@@ -214,6 +218,7 @@ describe('EnvironmentSCService', () => {
       });
       // don't want to test update in the create() tests
       service.update = jest.fn();
+      service.getInvalidOpenDataStudyIds = jest.fn().mockResolvedValue([]);
 
       // OPERATE
       try {
@@ -227,6 +232,31 @@ describe('EnvironmentSCService', () => {
         expect(service.boom.is(err, 'internalError')).toBe(true);
         expect(err.message).toContain(`Error triggering ${workflowIds.create} workflow`);
         expect(service.update).toHaveBeenCalled();
+      }
+    });
+
+    it('should fail because creating a workspace with an invalid Open Data study', async () => {
+      // BUILD
+      const requestContext = {
+        principal: {
+          isExternalUser: false,
+        },
+      };
+      const newEnv = {
+        name: 'exampleName',
+        envTypeId: 'exampleETI',
+        envTypeConfigId: 'exampleETCI',
+      };
+      service.getInvalidOpenDataStudyIds = jest.fn().mockResolvedValue(['abc']);
+
+      // OPERATE
+      try {
+        await service.create(requestContext, newEnv);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'badRequest')).toBe(true);
+        expect(err.message).toContain('Invalid open data studies. IDs: abc');
       }
     });
 
@@ -244,6 +274,7 @@ describe('EnvironmentSCService', () => {
       };
       service.audit = jest.fn();
       wfService.triggerWorkflow = jest.fn();
+      service.getInvalidOpenDataStudyIds = jest.fn().mockResolvedValue([]);
 
       // OPERATE
       await service.create(requestContext, newEnv);
@@ -1584,6 +1615,65 @@ Quisque egestas, eros nec feugiat venenatis, lorem turpis placerat tortor, ullam
       // CHECK
       await expect(ec2Updated).toEqual({ 'instance-name': 'Updated', 'instance-name-1': 'Updated' });
       await expect(Object.keys(ec2Updated).length).toEqual(Object.keys(ec2Instances).length);
+    });
+  });
+
+  describe('getInvalidOpenDataStudyIds', () => {
+    const requestContext = {
+      principal: {
+        isExternalUser: false,
+      },
+    };
+    const environment = {
+      studyIds: ['OpenData-1'],
+    };
+    beforeEach(() => {
+      studyService.mustFind = jest.fn().mockResolvedValue({
+        id: 'OpenData-1',
+        name: 'This is Open Data Study 1',
+        tags: ['genomic'],
+        category: 'Open Data',
+      });
+    });
+    it('should find invalid Open Data study', async () => {
+      // BUILD
+      // List of valid studies
+      studyService.list = jest.fn().mockResolvedValue([
+        {
+          id: 'OpenData-2',
+          name: 'This is Open Data Study 1',
+          tags: ['genomic'],
+          category: 'Open Data',
+        },
+      ]);
+
+      // OPERATE
+      // Attach study 'OpenData-1' to workspace
+      const invalidOpenDataStudyIds = await service.getInvalidOpenDataStudyIds(requestContext, environment);
+
+      // CHECK
+      // Valid study includes 'OpenData-2' but not 'OpenData-1' therefore OpenData-1 is an invalid study
+      expect(invalidOpenDataStudyIds).toEqual(['OpenData-1']);
+    });
+
+    it('should NOT find invalid Open Data study', async () => {
+      // BUILD
+      // List of valid studies
+      studyService.list = jest.fn().mockResolvedValue([
+        {
+          id: 'OpenData-1',
+          name: 'This is Open Data Study 1',
+          tags: ['genomic'],
+          category: 'Open Data',
+        },
+      ]);
+
+      // OPERATE
+      const invalidOpenDataStudyIds = await service.getInvalidOpenDataStudyIds(requestContext, environment);
+
+      // CHECK
+      // Valid study includes 'OpenData-1' therefore there are no invalid studies
+      expect(invalidOpenDataStudyIds).toEqual([]);
     });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
@@ -32,12 +32,6 @@
     "uploadLocationEnabled": {
       "type": "boolean"
     },
-    "sha": {
-      "type": "string",
-      "maxLength": 64,
-      "pattern": "^([A-Fa-f0-9]{40})$",
-      "description": "A unique identifier for Open Data in MD5 hash, hexadecimal"
-    },
     "tags": {
       "type": "array"
     },

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-study.json
@@ -38,6 +38,9 @@
       "pattern": "^([A-Fa-f0-9]{40})$",
       "description": "A unique identifier for Open Data in MD5 hash, hexadecimal"
     },
+    "tags": {
+      "type": "array"
+    },
     "resources": {
       "type": "array",
       "items": [

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
@@ -34,6 +34,9 @@
       "maxLength": 2048,
       "pattern": "^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:role[/]{1}[a-zA-Z0-9-]+)$"
     },
+    "tags": {
+      "type": "array"
+    },
     "resources": {
       "type": "array",
       "items": [

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-study.json
@@ -23,12 +23,6 @@
       "type": "string",
       "description": "Leaving length and pattern blank to accommodate open data"
     },
-    "sha": {
-      "type": "string",
-      "maxLength": 64,
-      "pattern": "^([A-Fa-f0-9]{40})$",
-      "description": "A unique identifier for Open Data in MD5 hash, hexadecimal"
-    },
     "appRoleArn": {
       "type": "string",
       "maxLength": 2048,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/__tests__/study-service.test.js
@@ -404,7 +404,7 @@ describe('studyService', () => {
             arn: 'arn:aws:s3:::study1',
           },
         ],
-        sha: '19d5b9c735712185ca1c691143e458a7aa2b7f69',
+        tags: ['genomic'],
         category: 'Open Data',
       };
       dbService.table.update.mockResolvedValueOnce(studyData);
@@ -424,10 +424,10 @@ describe('studyService', () => {
             arn: 'arn:aws:s3:::study1',
           },
         ],
-        sha: '19d5b9z735712185ca1c691143t458a7aa2b7f69',
+        tags: ['genomic'],
         category: 'Open Data',
+        invalidAttribute: 'abc',
       };
-
       // OPERATE
       try {
         await service.create(systemContext, studyData);
@@ -840,27 +840,6 @@ describe('studyService', () => {
         expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
       );
     });
-    it('should fail since the given study sha is invalid', async () => {
-      // BUILD
-      const uid = 'u-currentUserId';
-      const requestContext = {
-        principalIdentifier: { uid },
-        principal: { userRole: 'researcher', status: 'active' },
-      };
-      const dataIpt = {
-        id: 'id',
-        name: 'name',
-        category: 'Organization',
-        description: 'desc',
-        sha: 'fake',
-        resources: [{ arn: 'arn:aws:s3:::someRandomStudyArn' }],
-      };
-      // OPERATE
-      await expect(service.create(requestContext, dataIpt)).rejects.toThrow(
-        // CHECK
-        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
-      );
-    });
   });
 
   describe('update', () => {
@@ -876,8 +855,8 @@ describe('studyService', () => {
             arn: 'arn:aws:s3:::study1',
           },
         ],
-        sha: '19d5b9c735712185ca1c691143e458a7aa2b7f69',
         rev: 0,
+        tags: ['genomic'],
       };
       dbService.table.update.mockResolvedValueOnce(studyData);
       service.getStudyPermissions = jest.fn().mockResolvedValueOnce({
@@ -902,8 +881,9 @@ describe('studyService', () => {
             arn: 'arn:aws:s3:::study1',
           },
         ],
-        sha: '19d5b9z735712185ca1c691143t458a7aa2b7f69',
         rev: 0,
+        tags: ['genomic'],
+        invalidAttribute: 'abc',
       };
 
       // OPERATE
@@ -945,26 +925,6 @@ describe('studyService', () => {
         id: 'id',
         name: '<hack>',
         description: 'desc',
-        resources: [{ arn: 'arn:aws:s3:::someRandomStudyArn' }],
-      };
-      // OPERATE
-      await expect(service.update(requestContext, dataIpt)).rejects.toThrow(
-        // CHECK
-        expect.objectContaining({ boom: true, code: 'badRequest', safe: true, message: 'Input has validation errors' }),
-      );
-    });
-    it('should fail since the given sha is invalid', async () => {
-      // BUILD
-      const uid = 'u-currentUserId';
-      const requestContext = {
-        principalIdentifier: { uid },
-        principal: { userRole: 'researcher', status: 'active' },
-      };
-      const dataIpt = {
-        id: 'id',
-        name: 'name',
-        description: 'desc',
-        sha: 'fake',
         resources: [{ arn: 'arn:aws:s3:::someRandomStudyArn' }],
       };
       // OPERATE

--- a/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/study/study-service.js
@@ -497,17 +497,22 @@ class StudyService extends Service {
   }
 
   async list(requestContext, category, fields = []) {
+    const openDataTagFilters = await this.settings.get('openDataTagFilters').split(',');
     // Get studies allowed for user
     let result = [];
     switch (category) {
       case 'Open Data':
         // Readable by all
-        result = await this._query()
-          .index(this.categoryIndex)
-          .key('category', category)
-          .limit(1000)
-          .projection(fields)
-          .query();
+        result = (
+          await this._query()
+            .index(this.categoryIndex)
+            .key('category', category)
+            .limit(1000)
+            .projection(fields)
+            .query()
+        ).filter(study => {
+          return openDataTagFilters.some(filterTag => study.tags.includes(filterTag));
+        });
         break;
 
       default: {

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -175,4 +175,6 @@ createServiceCatalogPortfolio: true
 customUserAgent: 'AwsLabs/SO0144/${self:custom.settings.versionNumber}'
 
 # Available tags: https://github.com/awslabs/open-data-registry/blob/main/tags.yaml
+# Note: If an Open Data study is already mounted to a workspace, and new openDataTagFilters is set that does not include the mounted study, that mounted study will not be automatically unmounted from the workspace
+# The filters will only prevent new workspaces from being mounted with Open Data studies that do not have atleast one of these tags
 openDataTagFilters: 'genetic,genomic,life sciences,whole genome sequencing,STRIDES,cancer,population genetics,COVID-19,health,neuroimaging,neuroscience,cell biology,cell imaging,bioinformatics'

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -174,4 +174,5 @@ createServiceCatalogPortfolio: true
 # Metadata provided with AWS SDK calls
 customUserAgent: 'AwsLabs/SO0144/${self:custom.settings.versionNumber}'
 
+# Available tags: https://github.com/awslabs/open-data-registry/blob/main/tags.yaml
 openDataTagFilters: 'genetic,genomic,life sciences,whole genome sequencing,STRIDES,cancer,population genetics,COVID-19,health,neuroimaging,neuroscience,cell biology,cell imaging,bioinformatics'

--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -179,3 +179,5 @@ versionDate: '2021-09-16'
 
 # Metadata provided with AWS SDK calls
 customUserAgent: 'AwsLabs/SO0144/${self:custom.settings.versionNumber}'
+
+openDataTagFilters: 'genetic,genomic,life sciences,whole genome sequencing,STRIDES,cancer,population genetics,COVID-19,health,neuroimaging,neuroscience,cell biology,cell imaging,bioinformatics'

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -677,6 +677,14 @@ Resources:
                   - dynamodb:GetItem
                 Resource:
                   - !GetAtt [StudyPermissionsDb, Arn]
+        - PolicyName: s3-access
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - 'arn:aws:s3:::registry.opendata.aws/*'
 
   PolicyDataSourceReachabilityHandler:
     Type: AWS::IAM::ManagedPolicy

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -19,6 +19,7 @@ openDataScrapeHandler:
     APP_DB_STUDIES_ACCOUNTID_INDEX: ${self:custom.settings.dbStudiesAccountIdIndex}
     APP_STUDY_DATA_BUCKET_NAME: ${self:custom.settings.studyDataBucketName}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
+    APP_OPEN_DATA_TAG_FILTERS: ${self:custom.settings.openDataTagFilters}
 
   events:
     - schedule:

--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -158,6 +158,7 @@ apiHandler:
     APP_ENV_BOOTSTRAP_BUCKET_NAME: ${self:custom.settings.environmentsBootstrapBucketName}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
     APP_ROOT_USER_NAME: ${self:custom.settings.rootUserName}
+    APP_OPEN_DATA_TAG_FILTERS: ${self:custom.settings.openDataTagFilters}
 
 workflowLoopRunner:
   handler: src/lambdas/workflow-loop-runner/handler.handler

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -277,3 +277,5 @@ dbTableStudyPermissions: ${self:custom.settings.dbPrefix}-DbStudyPermissions
 
 # DynamoDB table name for KeyPairs
 dbTableKeyPairs: ${self:custom.settings.dbPrefix}-DbKeyPairs
+
+openDataTagFilters: 'genetic,genomic,life sciences,whole genome sequencing,STRIDES,cancer,population genetics,COVID-19,health,neuroimaging,neuroscience,cell biology,cell imaging,bioinformatics'

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -277,5 +277,3 @@ dbTableStudyPermissions: ${self:custom.settings.dbPrefix}-DbStudyPermissions
 
 # DynamoDB table name for KeyPairs
 dbTableKeyPairs: ${self:custom.settings.dbPrefix}-DbKeyPairs
-
-openDataTagFilters: 'genetic,genomic,life sciences,whole genome sequencing,STRIDES,cancer,population genetics,COVID-19,health,neuroimaging,neuroscience,cell biology,cell imaging,bioinformatics'

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/__tests__/handler-impl.test.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/__tests__/handler-impl.test.js
@@ -7,7 +7,7 @@ const Log = require('@aws-ee/base-services/lib/logger/logger-service');
 const { getSystemRequestContext } = require('@aws-ee/base-services/lib/helpers/system-context');
 
 const _ = require('lodash');
-const { fetchOpenData, saveOpenData } = require('../handler-impl');
+const { getOpenDataMetadata, saveOpenData } = require('../handler-impl');
 
 const consoleLogger = {
   info(...args) {
@@ -16,7 +16,7 @@ const consoleLogger = {
   },
 };
 
-describe('fetchAndSaveOpenData', () => {
+describe('saveOpenData', () => {
   const log = new Log();
   const studyService = new StudyService();
   const systemContext = getSystemRequestContext();
@@ -53,82 +53,98 @@ describe('fetchAndSaveOpenData', () => {
   });
 });
 
-describe('fetchOpenData', () => {
+describe('getOpenDataMetadata', () => {
   const validStudyOpenData = {
     description: 'Example study 1',
+    category: 'Open Data',
     id: 'study-2',
     name: 'Study 1',
     resources: [
       {
         arn: 'arn:aws:s3:::study1',
-        description: 'Description for Study 1',
-        region: 'us-east-1',
-        type: 'S3 Bucket',
       },
     ],
-    sha: 'abc2',
     tags: ['aws-pds', 'genetic', 'genomic', 'life sciences'],
   };
 
   const validStudy = {
-    name: 'Study 1',
-    description: 'Example study 1',
-    tags: ['aws-pds', 'genetic', 'genomic', 'life sciences'],
-    resources: [
+    Name: 'Study 1',
+    Description: 'Example study 1',
+    Tags: ['aws-pds', 'genetic', 'genomic', 'life sciences'],
+    Resources: [
       {
-        description: 'Description for Study 1',
-        arn: 'arn:aws:s3:::study1',
-        region: 'us-east-1',
-        type: 'S3 Bucket',
+        Description: 'Description for Study 1',
+        Arn: 'arn:aws:s3:::study1',
+        Region: 'us-east-1',
+        Type: 'S3 Bucket',
       },
     ],
-    id: 'study-2',
-    sha: 'abc2',
+    Slug: 'study-2',
   };
 
   const invalidStudy = {
-    name: 'Study 2',
-    description: 'Example study 2',
-    tags: ['aws-pds', 'genetic', 'genomic', 'life sciences'],
-    resources: [
+    Name: 'Study 2',
+    Description: 'Example study 2',
+    Tags: ['aws-pds', 'genetic', 'genomic', 'life sciences'],
+    Resources: [
       {
-        description: 'Description for Study 2',
-        arn: 'invalidArn',
-        region: 'us-east-1',
-        type: 'S3 Bucket',
+        Description: 'Description for Study 2',
+        Arn: 'invalidArn',
+        Region: 'us-east-1',
+        Type: 'S3 Bucket',
       },
     ],
-    id: 'study-2',
-    sha: 'abc2',
+    Slug: 'study-2',
   };
 
   it('has invalid study (Invalid ARN)', async () => {
-    const fileUrls = ['firstFileUrl'];
-    const requiredTags = ['genetic'];
-    const fetchFile = jest.fn();
-    fetchFile.mockReturnValueOnce(invalidStudy);
+    const openDataTagFilters = ['genetic'];
+    const getObject = jest.fn(() => ({
+      promise: () => {
+        const metadataNdJson = `${JSON.stringify(invalidStudy)}\n`;
+        return Promise.resolve({
+          Body: metadataNdJson,
+        });
+      },
+    }));
+    const S3 = {};
+    S3.getObject = getObject;
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await getOpenDataMetadata(S3, openDataTagFilters, consoleLogger);
     expect(result).toEqual([]);
   });
 
   it('has one valid study', async () => {
-    const fileUrls = ['firstFileUrl'];
-    const requiredTags = ['genetic'];
-    const fetchFile = jest.fn();
-    fetchFile.mockReturnValueOnce(validStudy);
+    const openDataTagFilters = ['genetic'];
+    const getObject = jest.fn(() => ({
+      promise: () => {
+        const metadataNdJson = `${JSON.stringify(validStudy)}\n`;
+        return Promise.resolve({
+          Body: metadataNdJson,
+        });
+      },
+    }));
+    const S3 = {};
+    S3.getObject = getObject;
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await getOpenDataMetadata(S3, openDataTagFilters, consoleLogger);
     expect(result).toEqual([validStudyOpenData]);
   });
 
   it('has one valid study and one invalid study (Invalid ARN)', async () => {
-    const fileUrls = ['firstFileUrl'];
-    const requiredTags = ['genetic'];
-    const fetchFile = jest.fn();
-    fetchFile.mockReturnValueOnce(validStudy).mockReturnValueOnce(invalidStudy);
+    const openDataTagFilters = ['genetic'];
+    const getObject = jest.fn(() => ({
+      promise: () => {
+        const metadataNdJson = `${JSON.stringify(validStudy)}\n${JSON.stringify(invalidStudy)}`;
+        return Promise.resolve({
+          Body: metadataNdJson,
+        });
+      },
+    }));
+    const S3 = {};
+    S3.getObject = getObject;
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await getOpenDataMetadata(S3, openDataTagFilters, consoleLogger);
     expect(result).toEqual([validStudyOpenData]);
   });
 });

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
@@ -14,11 +14,13 @@
  */
 
 //
-// 1. Get and parse yaml files from aws open data
+// 1. Get Open Source metadata
 // 2. Filter for the desired tags
 // 3. Write to study-service
 //
 const { getSystemRequestContext } = require('@aws-ee/base-services/lib/helpers/system-context');
+const _ = require('lodash');
+const { normalizeKeys, basicProjection } = require('./utilities');
 
 const consoleLogger = {
   info(...args) {
@@ -31,179 +33,15 @@ const consoleLogger = {
   },
 };
 
-const _ = require('lodash');
-let fetch = require('node-fetch');
-const yaml = require('js-yaml');
-
 const studyCategory = 'Open Data';
 
-// Webpack messes with the fetch function import and it breaks in lambda.
-if (typeof fetch !== 'function' && fetch.default && typeof fetch.default === 'function') {
-  fetch = fetch.default;
+async function fetchOpenData(aws, studyService, openDataTagFilters, log) {
+  const simplifiedStudyData = await getOpenDataMetadata(aws, openDataTagFilters, log);
+  return saveOpenData(log, simplifiedStudyData, studyService);
 }
 
-const newHandler = async ({ studyService, log = consoleLogger } = {}) => {
-  const scrape = {
-    githubApiUrl: 'https://api.github.com',
-    rawGithubUrl: 'https://raw.githubusercontent.com',
-    owner: 'awslabs',
-    repository: 'open-data-registry',
-    ref: 'main',
-    subtree: 'datasets',
-    filterTags: [
-      'genetic',
-      'genomic',
-      'life sciences',
-      'whole genome sequencing',
-      'STRIDES',
-      'cancer',
-      'population genetics',
-      'COVID-19',
-      'health',
-      'neuroimaging',
-      'neuroscience',
-      'cell biology',
-      'cell imaging',
-      'bioinformatics',
-    ],
-  };
-
-  function normalizeValue(value) {
-    if (_.isArray(value)) {
-      return value.map(normalizeValue);
-    }
-    if (_.isObject(value)) {
-      return normalizeKeys(value);
-    }
-    return value;
-  }
-
-  function normalizeKeys(obj) {
-    const normalized = Object.entries(obj).reduce((result, [key, value]) => {
-      // lowercase the first letter of the words in the key, unless the whole word is uppercase
-      // in which case lowercase the entire word
-      const normalizedKey = key
-        .split(' ')
-        .map(word => (/^[A-Z]*$/.test(word) ? word.toLowerCase() : `${word.slice(0, 1).toLowerCase()}${word.slice(1)}`))
-        .join(' ');
-      const normalizedValue = normalizeValue(value);
-      return { ...result, [normalizedKey]: normalizedValue };
-    }, {});
-
-    return normalized;
-  }
-
-  async function fetchDatasetFiles() {
-    const { githubApiUrl, rawGithubUrl, owner, repository, ref, subtree } = scrape;
-
-    log.info(`Fetching ${owner}/${repository}/${ref}/${subtree} file list`);
-    const refResponse = await fetch(`${githubApiUrl}/repos/${owner}/${repository}/git/refs/heads/${ref}`);
-
-    if (!refResponse.ok) {
-      throw new Error('Failed to fetch git refs');
-    }
-
-    const {
-      object: { url: commitUrl },
-    } = await refResponse.json();
-
-    const commitResponse = await fetch(commitUrl);
-
-    if (!commitResponse.ok) {
-      throw new Error('Failed to fetch git commit');
-    }
-
-    const {
-      tree: { url: treeUrl },
-    } = await commitResponse.json();
-
-    const baseTreeResponse = await fetch(treeUrl);
-
-    if (!baseTreeResponse.ok) {
-      throw new Error('Failed to fetch base git tree');
-    }
-
-    const { tree: baseTree } = await baseTreeResponse.json();
-
-    // The tree is an array of entries like:
-    // {
-    //   path: 'datasets',
-    //   mode: '040000',
-    //   type: 'tree',
-    //   sha: '82e29cc3cd11cdfedfbcfc756d132414f95dc8c2',
-    //   url:
-    //    'https://api.github.com/repos/awslabs/open-data-registry/git/trees/82e29cc3cd11cdfedfbcfc756d132414f95dc8c2'
-    // }
-    // Find and list the datasets tree, fetching all content
-    const datasetsDir = baseTree.find(({ path: p }) => p === subtree);
-
-    if (!(datasetsDir && datasetsDir.url)) {
-      throw new Error('Failed to find the datasets directory');
-    }
-
-    const datasetsTreeResponse = await fetch(datasetsDir.url);
-
-    if (!datasetsTreeResponse.ok) {
-      throw new Error('Failed to fetch datasets git tree');
-    }
-
-    const { tree } = await datasetsTreeResponse.json();
-
-    const blobs = tree.filter(({ type }) => type === 'blob');
-
-    const rawContentUrls = blobs.map(({ path, sha }) => ({
-      id: path.replace('.yaml', ''),
-      sha,
-      url: `${rawGithubUrl}/${owner}/${repository}/${ref}/${subtree}/${path}`,
-    }));
-
-    return rawContentUrls;
-  }
-
-  async function fetchFile({ url, id, sha }) {
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${url}`);
-    }
-
-    const text = await res.text();
-
-    const doc = yaml.safeLoad(text, { filename: url });
-
-    return normalizeKeys({ ...doc, id, sha });
-  }
-
-  function basicProjection({ id, sha, name, description, resources }) {
-    return {
-      id,
-      name,
-      description,
-      category: studyCategory,
-      sha,
-      resources: resources.map(({ arn }) => ({ arn })),
-    };
-  }
-
-  return async () => fetchAndSaveOpenData(fetchDatasetFiles, scrape, log, fetchFile, basicProjection, studyService);
-};
-
-const fetchOpenData = async ({ fileUrls, requiredTags, log, fetchFile }) => {
-  log.info(`Fetching ${fileUrls.length} metadata files`);
-  const metadata = await Promise.all(fileUrls.map(fetchFile));
-
-  log.info(`Filtering for ${requiredTags} tags and resources with valid ARNs`);
-  const validS3Arn = new RegExp(/^arn:aws:s3:.*:.*:.+$/);
-  const filtered = metadata.filter(({ tags, resources }) => {
-    return (
-      requiredTags.some(filterTag => tags.includes(filterTag)) &&
-      resources.every(resource => {
-        return resource.type === 'S3 Bucket' && validS3Arn.test(resource.arn);
-      })
-    );
-  });
-
-  return filtered;
+const newHandler = async ({ aws, studyService, openDataTagFilters, log = consoleLogger } = {}) => {
+  return async () => fetchOpenData(aws, studyService, openDataTagFilters, log);
 };
 
 async function saveOpenData(log, simplified, studyService) {
@@ -230,14 +68,38 @@ async function saveOpenData(log, simplified, studyService) {
   return simplified;
 }
 
-const fetchAndSaveOpenData = async (fetchDatasetFiles, scrape, log, fetchFile, basicProjection, studyService) => {
-  const fileUrls = await fetchDatasetFiles();
-  const openData = await fetchOpenData({ fileUrls, requiredTags: scrape.filterTags, log, fetchFile });
+async function getOpenDataMetadata(aws, requiredTags, log) {
+  const S3 = new aws.sdk.S3();
+  const getObjResponse = await S3.getObject({
+    Bucket: 'registry.opendata.aws',
+    Key: 'roda/ndjson/index.ndjson',
+  }).promise();
 
-  const simplifiedStudyData = openData.map(basicProjection);
+  const allMetaData = getObjResponse.Body.toString('utf-8')
+    .split('\n')
+    .filter(metadata => {
+      return metadata !== '';
+    })
+    .map(metadata => {
+      const md = JSON.parse(metadata);
+      return normalizeKeys({ ...md, id: md.Slug });
+    });
 
-  return saveOpenData(log, simplifiedStudyData, studyService);
-};
+  log.info(`Filtering for ${requiredTags} tags and resources with valid ARNs`);
+  const validS3Arn = new RegExp(/^arn:aws:s3:.*:.*:.+$/);
+  const filtered = allMetaData.filter(({ tags, resources }) => {
+    return (
+      requiredTags.some(filterTag => tags.includes(filterTag)) &&
+      resources.every(resource => {
+        return resource.type === 'S3 Bucket' && validS3Arn.test(resource.arn);
+      })
+    );
+  });
+
+  return filtered.map(metadata => {
+    return basicProjection({ ...metadata, studyCategory });
+  });
+}
 
 module.exports = {
   fetchOpenData,

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
@@ -14,7 +14,7 @@
  */
 
 //
-// 1. Get Open Source metadata
+// 1. Get Open Data metadata
 // 2. Filter for the desired tags
 // 3. Write to study-service
 //

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
@@ -27,9 +27,10 @@ const initHandler = (async () => {
   const studyService = await container.find('studyService');
   const log = await container.find('log');
   const aws = await container.find('aws');
+  const S3 = new aws.sdk.S3();
   const settings = await container.find('settings');
   const openDataTagFilters = (await settings.get('openDataTagFilters')).split(',');
-  return newHandler({ aws, studyService, openDataTagFilters, log });
+  return newHandler({ S3, studyService, openDataTagFilters, log });
 })();
 
 // eslint-disable-next-line import/prefer-default-export

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
@@ -26,7 +26,10 @@ const initHandler = (async () => {
   await container.initServices();
   const studyService = await container.find('studyService');
   const log = await container.find('log');
-  return newHandler({ studyService, log });
+  const aws = await container.find('aws');
+  const settings = await container.find('settings');
+  const openDataTagFilters = (await settings.get('openDataTagFilters')).split(',');
+  return newHandler({ aws, studyService, openDataTagFilters, log });
 })();
 
 // eslint-disable-next-line import/prefer-default-export

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/utilities.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/utilities.js
@@ -1,0 +1,40 @@
+const _ = require('lodash');
+
+function normalizeValue(value) {
+  if (_.isArray(value)) {
+    return value.map(normalizeValue);
+  }
+  if (_.isObject(value)) {
+    return normalizeKeys(value);
+  }
+  return value;
+}
+
+function normalizeKeys(obj) {
+  return Object.entries(obj).reduce((result, [key, value]) => {
+    // lowercase the first letter of the words in the key, unless the whole word is uppercase
+    // in which case lowercase the entire word
+    const normalizedKey = key
+      .split(' ')
+      .map(word => (/^[A-Z]*$/.test(word) ? word.toLowerCase() : `${word.slice(0, 1).toLowerCase()}${word.slice(1)}`))
+      .join(' ');
+    const normalizedValue = normalizeValue(value);
+    return { ...result, [normalizedKey]: normalizedValue };
+  }, {});
+}
+
+function basicProjection({ id, sha, name, description, resources, studyCategory }) {
+  return {
+    id,
+    name,
+    description,
+    category: studyCategory,
+    sha,
+    resources: resources.map(({ arn }) => ({ arn })),
+  };
+}
+
+module.exports = {
+  normalizeKeys,
+  basicProjection,
+};

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/utilities.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/utilities.js
@@ -23,13 +23,13 @@ function normalizeKeys(obj) {
   }, {});
 }
 
-function basicProjection({ id, sha, name, description, resources, studyCategory }) {
+function basicProjection({ id, tags, name, description, resources, studyCategory }) {
   return {
     id,
     name,
     description,
     category: studyCategory,
-    sha,
+    tags,
     resources: resources.map(({ arn }) => ({ arn })),
   };
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3393,10 +3393,10 @@ components:
           type: string
           maxLength: 2048
           example: 'An org study to test a few things'
-        sha:
-          type: string
-          maxLength: 64
-          description: sha is only used for open data study in system originated update, external request should leave this field empty
+        tags:
+          type: array
+          description: tags is only used for open data studies
+          example: ['genetic','genomic', 'life sciences']
         appRoleArn:
           type: string
           maxLength: 2048
@@ -3407,7 +3407,7 @@ components:
           {"arn": "arn:aws:s3:::123456789101-studydata/studies/Organization/org-study-2/"}
           ]
           items:
-            type: object
+            type: object'
             additionalProperties: false
             properties:
               arn:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3407,7 +3407,7 @@ components:
           {"arn": "arn:aws:s3:::123456789101-studydata/studies/Organization/org-study-2/"}
           ]
           items:
-            type: object'
+            type: object
             additionalProperties: false
             properties:
               arn:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3347,10 +3347,10 @@ components:
         uploadLocationEnabled:
           type: boolean
           example: false
-        sha:
-          type: string
-          maxLength: 64
-          description: sha is only used for open data study in system originated update, external request should leave this field empty
+        tags:
+          type: array
+          description: tags is only used for open data studies
+          example: ['genetic','genomic', 'life sciences']
         resources:
           type: array
           example: [


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Update `open-data-scrape-handler` to pull Open Data Tag Filters from `config` so customers can choose what Open Data set to include. The studies list API will also use the new filters
* Update `open-data-scrape-handler` to use the [Open Data Registry](https://registry.opendata.aws/registry-open-data/). This simplifies our code so we don't have to pull one S3 Metadata file for each Open Data.
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.