### PR TITLE
fix: bypass develop protection when adding beta

### DIFF
--- a/.github/workflows/deploy-integ.yml
+++ b/.github/workflows/deploy-integ.yml
@@ -155,5 +155,26 @@ jobs:
         with:
           token: ${{ secrets.MERGE_TOKEN }}
           fetch-depth: 0
+      # There's no way for github actions to push to a protected branch. This is a workaround
+      # See https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/30
+      - name: Temporarily disable branch protection
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
+          owner: awslabs
+          repo: service-workbench-on-aws
+          branch: develop
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
       - name: Check if Beta is present and add if not
         run: ./scripts/check-and-add-beta.sh
+      - name: Enable branch protection
+        uses: octokit/request-action@v2.x
+        if: always() # Make sure to enable branch protection even if other steps fail
+        with:
+          route: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
+          owner: awslabs
+          repo: service-workbench-on-aws
+          branch: develop
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}


### PR DESCRIPTION
Issue #, if available: GALI-824

Description of changes: bypass develop protection in step to add beta so the bot can push to develop

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.