### PR TITLE
fix: Bool to string bug

### DIFF
--- a/main/solution/post-deployment/__test__/bool-to-str.test.js
+++ b/main/solution/post-deployment/__test__/bool-to-str.test.js
@@ -1,0 +1,41 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const result = require('../bool-to-str');
+
+jest.mock('../config/settings/.settings');
+const mergeSettingsMock = require('../config/settings/.settings');
+
+describe('bool-to-str', () => {
+  it('should return "true" when enableEgressStore = true', async () => {
+    // BUILD
+    mergeSettingsMock.merged = jest.fn(async () => {
+      return { enableEgressStore: true };
+    });
+
+    // OPERATE n CHECK
+    expect(await result()).toEqual('true');
+  });
+
+  it('should return "false" when enableEgressStore = false', async () => {
+    // BUILD
+    mergeSettingsMock.merged = jest.fn(async () => {
+      return { enableEgressStore: false };
+    });
+
+    // OPERATE n CHECK
+    expect(await result()).toEqual('false');
+  });
+});

--- a/main/solution/post-deployment/bool-to-str.js
+++ b/main/solution/post-deployment/bool-to-str.js
@@ -4,7 +4,9 @@
 
 module.exports = async serverless => {
   // Get params details from serverless.yml
-  const enableEgressStore = serverless.service.custom.settings.enableEgressStore;
+  // eslint-disable-next-line global-require
+  const settings = await require('./config/settings/.settings').merged(serverless);
+  const enableEgressStore = settings.enableEgressStore;
 
   // Must be explicitly equal to true and not just a "truthy" value
   return enableEgressStore === true ? 'true' : 'false';


### PR DESCRIPTION
Issue #, if available: GALI-1160

Description of changes: Fixed the method of changing the boolean flag to a string for Serverless

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.