### PR TITLE
fix: Disable public IP address for Linux and Windows in AppStream

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -52,6 +52,7 @@ Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
   EgressStoreIamPolicyEmpty: !Equals [!Ref EgressStoreIamPolicyDocument, '{}']
   AppStreamEnabled: !Equals [!Ref IsAppStreamEnabled, 'true']
+  AppStreamDisabled: !Equals [!Ref IsAppStreamEnabled, 'false']
 
 Resources:
   InstanceRolePermissionBoundary:
@@ -198,15 +199,20 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
-        - AssociatePublicIpAddress: 'true'
-          DeviceIndex: '0'
-          GroupSet:
-            - !Ref SecurityGroup
-            - !If
-              - AppStreamEnabled
+        - !If
+          - AppStreamEnabled
+          -
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-              - !Ref "AWS::NoValue"
-          SubnetId: !Ref Subnet
+            SubnetId: !Ref Subnet
+          -
+            AssociatePublicIpAddress: 'true'
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
+            SubnetId: !Ref Subnet
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-linux']]
@@ -230,6 +236,7 @@ Outputs:
 
   Ec2WorkspacePublicIp:
     Description: Public IP address of the EC2 workspace instance
+    Condition: AppStreamDisabled
     Value: !GetAtt [EC2Instance, PublicIp]
 
   Ec2WorkspaceInstanceId:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -199,7 +199,8 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
-        - DeviceIndex: '0'
+        - AssociatePublicIpAddress: !If [ AppStreamEnabled, 'false', 'true' ]
+          DeviceIndex: '0'
           GroupSet:
             - !Ref SecurityGroup
             - !If
@@ -207,10 +208,6 @@ Resources:
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
-        - !If
-          - AppStreamEnabled
-          - AssociatePublicIpAddress: false
-          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-linux']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -199,20 +199,18 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
+        - DeviceIndex: '0'
+          GroupSet:
+            - !Ref SecurityGroup
+            - !If
+              - AppStreamEnabled
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - !Ref "AWS::NoValue"
+          SubnetId: !Ref Subnet
         - !If
           - AppStreamEnabled
-          -
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-            SubnetId: !Ref Subnet
-          -
-            AssociatePublicIpAddress: 'true'
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-            SubnetId: !Ref Subnet
+          - AssociatePublicIpAddress: false
+          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-linux']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -213,20 +213,18 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
+        - DeviceIndex: '0'
+          GroupSet:
+            - !Ref SecurityGroup
+            - !If
+              - AppStreamEnabled
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - !Ref "AWS::NoValue"
+          SubnetId: !Ref Subnet
         - !If
           - AppStreamEnabled
-          -
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-            SubnetId: !Ref Subnet
-          -
-            AssociatePublicIpAddress: 'true'
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-            SubnetId: !Ref Subnet
+          - AssociatePublicIpAddress: false
+          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-rstudio']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -55,6 +55,7 @@ Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
   EgressStoreIamPolicyEmpty: !Equals [!Ref EgressStoreIamPolicyDocument, '{}']
   AppStreamEnabled: !Equals [!Ref IsAppStreamEnabled, 'true']
+  AppStreamDisabled: !Equals [!Ref IsAppStreamEnabled, 'false']
 
 Resources:
   InstanceRolePermissionBoundary:
@@ -212,15 +213,20 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
-        - AssociatePublicIpAddress: 'true'
-          DeviceIndex: '0'
-          GroupSet:
-            - !Ref SecurityGroup
-            - !If
-              - AppStreamEnabled
+        - !If
+          - AppStreamEnabled
+          -
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-              - !Ref "AWS::NoValue"
-          SubnetId: !Ref Subnet
+            SubnetId: !Ref Subnet
+          -
+            AssociatePublicIpAddress: 'true'
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
+            SubnetId: !Ref Subnet
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-rstudio']]
@@ -244,10 +250,11 @@ Outputs:
 
   Ec2WorkspacePublicIp:
     Description: Public IP address of the EC2 workspace instance
+    Condition: AppStreamDisabled
     Value: !GetAtt [EC2Instance, PublicIp]
 
   Ec2WorkspacePrivateIp:
-    Description: Public IP address of the EC2 workspace instance
+    Description: Private IP address of the EC2 workspace instance
     Value: !GetAtt [EC2Instance, PrivateIp]
 
   Ec2WorkspaceInstanceId:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -213,7 +213,8 @@ Resources:
             Encrypted: true
             KmsKeyId: !Ref EncryptionKeyArn
       NetworkInterfaces:
-        - DeviceIndex: '0'
+        - AssociatePublicIpAddress: !If [ AppStreamEnabled, 'false', 'true' ]
+          DeviceIndex: '0'
           GroupSet:
             - !Ref SecurityGroup
             - !If
@@ -221,10 +222,6 @@ Resources:
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
-        - !If
-          - AppStreamEnabled
-          - AssociatePublicIpAddress: false
-          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-rstudio']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -266,7 +266,8 @@ Resources:
             KmsKeyId: !Ref EncryptionKeyArn
             DeleteOnTermination: true
       NetworkInterfaces:
-        - DeviceIndex: '0'
+        - AssociatePublicIpAddress: !If [ AppStreamEnabled, 'false', 'true' ]
+          DeviceIndex: '0'
           GroupSet:
             - !Ref SecurityGroup
             - !If
@@ -274,10 +275,6 @@ Resources:
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
-        - !If
-          - AppStreamEnabled
-          - AssociatePublicIpAddress: false
-          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-windows']]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -74,6 +74,7 @@ Conditions:
   IamPolicyEmpty: !Equals [!Ref IamPolicyDocument, '{}']
   EgressStoreIamPolicyEmpty: !Equals [!Ref EgressStoreIamPolicyDocument, '{}']
   AppStreamEnabled: !Equals [!Ref IsAppStreamEnabled, 'true']
+  AppStreamDisabled: !Equals [!Ref IsAppStreamEnabled, 'false']
 
 Resources:
   InstanceRolePermissionBoundary:
@@ -265,15 +266,20 @@ Resources:
             KmsKeyId: !Ref EncryptionKeyArn
             DeleteOnTermination: true
       NetworkInterfaces:
-        - AssociatePublicIpAddress: true
-          DeviceIndex: '0'
-          GroupSet:
-            - !Ref SecurityGroup
-            - !If
-              - AppStreamEnabled
+        - !If
+          - AppStreamEnabled
+          -
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
               - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-              - !Ref "AWS::NoValue"
-          SubnetId: !Ref Subnet
+            SubnetId: !Ref Subnet
+          -
+            AssociatePublicIpAddress: true
+            DeviceIndex: '0'
+            GroupSet:
+              - !Ref SecurityGroup
+            SubnetId: !Ref Subnet
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-windows']]
@@ -376,6 +382,7 @@ Outputs:
 
   Ec2WorkspacePublicIp:
     Description: Public IP address of the EC2 workspace instance
+    Condition: AppStreamDisabled
     Value: !GetAtt [EC2Instance, PublicIp]
 
   Ec2WorkspaceInstanceId:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -266,20 +266,18 @@ Resources:
             KmsKeyId: !Ref EncryptionKeyArn
             DeleteOnTermination: true
       NetworkInterfaces:
+        - DeviceIndex: '0'
+          GroupSet:
+            - !Ref SecurityGroup
+            - !If
+              - AppStreamEnabled
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - !Ref "AWS::NoValue"
+          SubnetId: !Ref Subnet
         - !If
           - AppStreamEnabled
-          -
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
-            SubnetId: !Ref Subnet
-          -
-            AssociatePublicIpAddress: true
-            DeviceIndex: '0'
-            GroupSet:
-              - !Ref SecurityGroup
-            SubnetId: !Ref Subnet
+          - AssociatePublicIpAddress: false
+          - AssociatePublicIpAddress: true
       Tags:
         - Key: Name
           Value: !Join ['-', [Ref: Namespace, 'ec2-windows']]


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: Disable public IP address for Linux and Windows in AppStream


**Test**
* AppStream Enabled
   * Checked in the AWS console that Linux and Windows instances does NOT have public IP addresses
   * Log into windows, egress store there, egress write succeed
   * Log into Linux, egress store there, egress write succeed
* AppStream Disabled
   * Checked in the AWS console that Linux and Windows instance does have public IP Addresses 
   * Log into Windows, read/write from study succeed
   * Log into Linux, read/write from study succeed
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?


AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.