### PR TITLE
feat: Create dedicated SGs for environment and interface endpoints

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -748,28 +748,28 @@ Resources:
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
 
-  EnvironmentSecurityGroup:
+  WorkspaceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
       GroupDescription: 'Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints'
-      GroupName: 'Environment-SG'
+      GroupName: 'Workspace-SG'
       VpcId: !Ref VPC
 
-  EnvironmentSecurityGroupIngress:
+  WorkspaceSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: isAppStream
     Properties:
-      GroupId: !Ref EnvironmentSecurityGroup
+      GroupId: !Ref WorkspaceSecurityGroup
       SourceSecurityGroupId: !Ref AppStreamSecurityGroup
       Description: 'Allow AppStream ingress from environments'
       IpProtocol: '-1'
 
-  EnvironmentSecurityGroupEgress:
+  WorkspaceSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Condition: isAppStream
     Properties:
-      GroupId: !Ref EnvironmentSecurityGroup
+      GroupId: !Ref WorkspaceSecurityGroup
       DestinationSecurityGroupId: !Ref InterfaceEndpointSecurityGroup
       Description: 'Allow Interface Endpoint egress from environments'
       IpProtocol: '-1'
@@ -787,7 +787,7 @@ Resources:
     Condition: isAppStream
     Properties:
       GroupId: !Ref InterfaceEndpointSecurityGroup
-      SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
+      SourceSecurityGroupId: !Ref WorkspaceSecurityGroup
       Description: 'Allow environment ingress from interface endpoints'
       IpProtocol: '-1'
 
@@ -839,7 +839,7 @@ Resources:
       GroupName: 'Sagemaker-API-SG'
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        - SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
+        - SourceSecurityGroupId: !Ref WorkspaceSecurityGroup
           IpProtocol: '-1'
 
   SageMakerSecurityGroup:
@@ -863,7 +863,7 @@ Resources:
       SecurityGroupEgress:
         - CidrIp: 127.0.0.1/32
           IpProtocol: '-1'
-        - DestinationSecurityGroupId: !Ref EnvironmentSecurityGroup
+        - DestinationSecurityGroupId: !Ref WorkspaceSecurityGroup
           IpProtocol: '-1'
 
   AppStreamSecurityGroupEgress:
@@ -1001,12 +1001,12 @@ Outputs:
     Export:
       Name: !Join ['', [Ref: Namespace, '-InterfaceEndpointSG']]
 
-  EnvironmentSG:
+  WorkspaceSG:
     Description: Default SG for VPC
     Condition: isAppStream
-    Value: !Ref EnvironmentSecurityGroup
+    Value: !Ref WorkspaceSecurityGroup
     Export:
-      Name: !Join ['', [Ref: Namespace, '-EnvironmentSG']]
+      Name: !Join ['', [Ref: Namespace, '-WorkspaceSG']]
 
   AppStreamStackName:
     Description: Name of the stack created by AppStream

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -706,6 +706,8 @@ Resources:
       VpcEndpointType: Interface
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.kms'
       VpcId: !Ref VPC
+      SecurityGroupIds:
+        - !Ref InterfaceEndpointSecurityGroup
 
   STSEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
@@ -717,6 +719,8 @@ Resources:
       PrivateDnsEnabled: true
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.sts'
       VpcId: !Ref VPC
+      SecurityGroupIds:
+        - !Ref InterfaceEndpointSecurityGroup
 
   EC2Endpoint:
     Type: 'AWS::EC2::VPCEndpoint'
@@ -728,6 +732,8 @@ Resources:
       PrivateDnsEnabled: true
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ec2'
       VpcId: !Ref VPC
+      SecurityGroupIds:
+        - !Ref InterfaceEndpointSecurityGroup
 
   CfnEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
@@ -740,18 +746,50 @@ Resources:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.cloudformation'
       VpcId: !Ref VPC
       SecurityGroupIds:
-        - !Ref CfnEndpointSecurityGroup
+        - !Ref InterfaceEndpointSecurityGroup
 
-  CfnEndpointSecurityGroup:
+  EnvironmentSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: 'CFN Security Group for interface endpoint'
-      GroupName: 'CFN-SG'
+      GroupDescription: 'Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints'
+      GroupName: 'Environment-SG'
       VpcId: !Ref VPC
-      SecurityGroupIngress:
-        - SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
-          IpProtocol: '-1'
+
+  EnvironmentSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: isAppStream
+    Properties:
+      GroupId: !Ref EnvironmentSecurityGroup
+      SourceSecurityGroupId: !Ref AppStreamSecurityGroup
+      Description: 'Allow AppStream ingress from environments'
+      IpProtocol: '-1'
+
+  EnvironmentSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Condition: isAppStream
+    Properties:
+      GroupId: !Ref EnvironmentSecurityGroup
+      DestinationSecurityGroupId: !Ref InterfaceEndpointSecurityGroup
+      Description: 'Allow Interface Endpoint egress from environments'
+      IpProtocol: '-1'
+
+  InterfaceEndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: isAppStream
+    Properties:
+      GroupDescription: 'Security Group for interface endpoints'
+      GroupName: 'Interface-Endpoint-SG'
+      VpcId: !Ref VPC
+
+  InterfaceEndpointSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: isAppStream
+    Properties:
+      GroupId: !Ref InterfaceEndpointSecurityGroup
+      SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
+      Description: 'Allow environment ingress from interface endpoints'
+      IpProtocol: '-1'
 
   SSMEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
@@ -763,6 +801,8 @@ Resources:
       PrivateDnsEnabled: true
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ssm'
       VpcId: !Ref VPC
+      SecurityGroupIds:
+        - !Ref InterfaceEndpointSecurityGroup
 
     # https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-interface-endpoint.html
   SagemakerNotebookEndpoint:
@@ -799,7 +839,7 @@ Resources:
       GroupName: 'Sagemaker-API-SG'
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        - SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
+        - SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
           IpProtocol: '-1'
 
   SageMakerSecurityGroup:
@@ -823,7 +863,7 @@ Resources:
       SecurityGroupEgress:
         - CidrIp: 127.0.0.1/32
           IpProtocol: '-1'
-        - DestinationSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
+        - DestinationSecurityGroupId: !Ref EnvironmentSecurityGroup
           IpProtocol: '-1'
 
   AppStreamSecurityGroupEgress:
@@ -954,19 +994,19 @@ Outputs:
     Condition: isAppStream
     Value: !Ref AppStreamStack
 
-  CFNEndpointSG:
-    Description: Security group of CFN endpoint
+  InterfaceEndpointSG:
+    Description: Security group of Interface endpoints
     Condition: isAppStream
-    Value: !Ref CfnEndpointSecurityGroup
+    Value: !Ref InterfaceEndpointSecurityGroup
     Export:
-      Name: !Join ['', [Ref: Namespace, '-CfnEndpointSecurityGroup']]
+      Name: !Join ['', [Ref: Namespace, '-InterfaceEndpointSG']]
 
-  VPCDefaultSG:
+  EnvironmentSG:
     Description: Default SG for VPC
     Condition: isAppStream
-    Value: !GetAtt VPC.DefaultSecurityGroup
+    Value: !Ref EnvironmentSecurityGroup
     Export:
-      Name: !Join ['', [Ref: Namespace, '-SwbVPCDefaultSG']]
+      Name: !Join ['', [Ref: Namespace, '-EnvironmentSG']]
 
   AppStreamStackName:
     Description: Name of the stack created by AppStream

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -1002,7 +1002,7 @@ Outputs:
       Name: !Join ['', [Ref: Namespace, '-InterfaceEndpointSG']]
 
   WorkspaceSG:
-    Description: Default SG for VPC
+    Description: Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints
     Condition: isAppStream
     Value: !Ref WorkspaceSecurityGroup
     Export:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -197,7 +197,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-WorkspaceSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -146,18 +146,10 @@ Resources:
             FromPort: -1
             ToPort: -1
             CidrIp: !Ref AccessFromCIDRBlock
-        - !If
-          - AppStreamEnabled
-          - DestinationSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-CfnEndpointSecurityGroup"
-            IpProtocol: '-1'
-          - !Ref "AWS::NoValue"
       SecurityGroupIngress:
         - !If
           - AppStreamEnabled
-          - SourceSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
-            IpProtocol: '-1'
+          - !Ref "AWS::NoValue"
           - IpProtocol: tcp
             FromPort: 22
             ToPort: 22
@@ -205,7 +197,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -211,7 +211,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-WorkspaceSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-rstudio-instance.cfn.yml
@@ -159,18 +159,10 @@ Resources:
             FromPort: -1
             ToPort: -1
             CidrIp: !Ref AccessFromCIDRBlock
-        - !If
-          - AppStreamEnabled
-          - DestinationSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-CfnEndpointSecurityGroup"
-            IpProtocol: '-1'
-          - !Ref "AWS::NoValue"
       SecurityGroupIngress:
         - !If
           - AppStreamEnabled
-          - SourceSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
-            IpProtocol: '-1'
+          - !Ref "AWS::NoValue"
           - IpProtocol: tcp
             FromPort: 22
             ToPort: 22
@@ -219,7 +211,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -168,18 +168,10 @@ Resources:
             FromPort: -1
             ToPort: -1
             CidrIp: !Ref AccessFromCIDRBlock
-        - !If
-          - AppStreamEnabled
-          - DestinationSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-CfnEndpointSecurityGroup"
-            IpProtocol: '-1'
-          - !Ref "AWS::NoValue"
       SecurityGroupIngress:
         - !If
           - AppStreamEnabled
-          - SourceSecurityGroupId:
-              Fn::ImportValue: !Sub "${SolutionNamespace}-SwbAppStreamSG"
-            IpProtocol: '-1'
+          - !Ref "AWS::NoValue"
           - IpProtocol: tcp
             FromPort: 3389
             ToPort: 3389
@@ -272,7 +264,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -264,7 +264,7 @@ Resources:
             - !Ref SecurityGroup
             - !If
               - AppStreamEnabled
-              - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
+              - Fn::ImportValue: !Sub "${SolutionNamespace}-WorkspaceSG"
               - !Ref "AWS::NoValue"
           SubnetId: !Ref Subnet
       Tags:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -240,7 +240,7 @@ Resources:
         - !Ref SecurityGroup
         - !If
           - AppStreamEnabled
-          - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
+          - Fn::ImportValue: !Sub "${SolutionNamespace}-WorkspaceSG"
           - !Ref "AWS::NoValue"
       DirectInternetAccess:
         !If

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -75,6 +75,13 @@ Resources:
               Fn::ImportValue: !Sub "${SolutionNamespace}-SageMakerApiSecurityGroup"
             IpProtocol: '-1'
           - !Ref "AWS::NoValue"
+        - !If
+          - AppStreamEnabled
+          - IpProtocol: tcp
+            FromPort: 0
+            ToPort: 65535
+            CidrIp: 0.0.0.0/0
+          - !Ref "AWS::NoValue"
   PreSignedURLBoundary:
     Type: AWS::IAM::ManagedPolicy
     Condition: AppStreamEnabled
@@ -233,7 +240,7 @@ Resources:
         - !Ref SecurityGroup
         - !If
           - AppStreamEnabled
-          - Fn::ImportValue: !Sub "${SolutionNamespace}-SwbVPCDefaultSG"
+          - Fn::ImportValue: !Sub "${SolutionNamespace}-EnvironmentSG"
           - !Ref "AWS::NoValue"
       DirectInternetAccess:
         !If


### PR DESCRIPTION
Issue #, if available:
* Approach documented here: GALI-1151
* Implementation Issue: GALI-1152

Description of changes:

* Create a dedicated SG for Interface Endpoints and Environments
* Environment SG Egress allows them to connect to Interface Endpoints, and SG attached with environments during provisioning. Environment SG also allows ingress from AppStream SG
* AppStream SG is allowed egress to Environment SG to connect AppStream instances with all environments
* Similarly, Interface Endpoint SG allows Environment SG ingress and is attached to all the interface endpoints which are required connectivity from environments
* Removed the usage of Default SG
* SageMaker security group now explicitly adds all TCP access on egress side since we removed Default SG (this just means access to S3 services available via interface endpoints)

Testing done:
1. Spun up RStudio, SageMaker, Windows and Linux environments and verified connectivity from AppStream
2. Verified that environments do not have access of any kind. (I tried the `ping` command to verify that workspaces didn't have connectivity among themselves. The same command worked before these changes)
3. Verified that studies (organization and BYOB) worked as expected (I tried read access) from all the environments
4. Verified egress study worked as expected too. I wrote some files from all the environments.
5. Also verified SageMaker auto-stop feature

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.