### PR TITLE
fix: Various bugfixes

### DIFF
--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -608,7 +608,6 @@ Resources:
 
   PolicyWorkflowLoopRunner:
     Type: AWS::IAM::ManagedPolicy
-    DependsOn: PermissionBoundaryPolicyStudyBucket
     Properties:
       Description: Allows main account to create resources required for SWB backend functionality
       PolicyDocument:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* When there is a preexisting non TRE account being upgraded to a TRE account, the `awsAccountService.update` method is called. This method should share AppStream with the member account just like how `awsAccountService.create` does.
* PolicyWorkFlowLoopRunner should not depend on PermissionBoundaryPolicyStudyBucket

**Test**
* AppStream image was shared with member account when updating AWS account
* Deploying latest code to CFN succeeded

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.