### PR TITLE
fix: remove test target from infrastructure tests as it is reserved for unit tests

### DIFF
--- a/main/infrastructure-tests/package.json
+++ b/main/infrastructure-tests/package.json
@@ -7,7 +7,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "testSpecific": "NODE_ENV=test jest --config jest.config.js --passWithNoTests --verbose",
-    "test": "NODE_ENV=test jest --config jest.config.js --passWithNoTests --verbose  --testPathPattern='./__test__/(common|appstream-egress-disabled)'",
     "testAppStreamEgressEnabled": "NODE_ENV=test jest --config jest.config.js --passWithNoTests --verbose  --testPathPattern='./__test__/(common|appstream-egress-enabled)'",
     "lint": "pnpm run lint:eslint && pnpm run lint:prettier",
     "lint:eslint": "eslint --ignore-path .gitignore . ",


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: 

Testing done:
1. Verified that cicd pipeline works didn't fail due to the same unit-test error. It still fails for me due some other error which I am verifying. I am determining if it is related to 4.0.0 release or not

edit: the tests passed, so I am planning on pushing this code and verifying in our common account if CICD pipeline was successful

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.