### PR TITLE
fix: display unavailable after config deletion

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
@@ -57,6 +57,9 @@ class ScEnvironmentCard extends React.Component {
   getConfiguration(envTypeConfigId) {
     const configsStore = this.getEnvTypeConfigsStore();
     const config = configsStore.getEnvTypeConfig(envTypeConfigId);
+    if (config === undefined) {
+      return { name: 'Unavailable', instanceType: 'Unavailable' };
+    }
     return config;
   }
 

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentCard.js
@@ -57,9 +57,6 @@ class ScEnvironmentCard extends React.Component {
   getConfiguration(envTypeConfigId) {
     const configsStore = this.getEnvTypeConfigsStore();
     const config = configsStore.getEnvTypeConfig(envTypeConfigId);
-    if (config === undefined) {
-      return { name: 'Unavailable', instanceType: 'Unavailable' };
-    }
     return config;
   }
 
@@ -120,8 +117,6 @@ class ScEnvironmentCard extends React.Component {
     const envType = this.envType || {};
 
     const config = this.getConfiguration(this.environment.envTypeConfigId);
-    const configName = config.name;
-    const instanceType = config.instanceType;
 
     const renderRow = (key, value) => (
       <Table.Row>
@@ -139,8 +134,8 @@ class ScEnvironmentCard extends React.Component {
           {renderRow('Studies', studyCount === 0 ? 'No studies linked to this workspace' : niceNumber(studyCount))}
           {renderRow('Project', _.isEmpty(env.projectId) ? 'N/A' : env.projectId)}
           {renderRow('Workspace Type', envType.name)}
-          {renderRow('Configuration Name', configName)}
-          {renderRow('Instance Type', instanceType)}
+          {renderRow('Configuration Name', config !== undefined ? config.name : 'Unavailable')}
+          {renderRow('Instance Type', config !== undefined ? config.instanceType : 'Unavailable')}
         </Table.Body>
       </Table>
     );


### PR DESCRIPTION
Issue #, if available:

Description of changes: Display "Unavailable" in the workspace details card for name and instance type when the configuration for that workspace has been deleted.

<img width="1056" alt="Screen Shot 2021-10-18 at 4 04 41 PM" src="https://user-images.githubusercontent.com/43092418/137799990-ca24a0df-a379-44c8-ab79-f3f0a83d7495.png">
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.