### PR TITLE
fix: AppDeployer needs perms to create new env

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -20,8 +20,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties: !If
       - SubscribeNotificationEmail
-      -
-        Subscription:
+      - Subscription:
           - Endpoint: ${self:custom.settings.emailForNotifications}
             Protocol: email
         KmsMasterKeyId: alias/aws/sns
@@ -229,7 +228,7 @@ Resources:
           - Action:
               - iam:PassRole
             Effect: Allow
-            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-cicd-pipeline-AppDeployerRole-*'
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-*'
           - Action:
               - iam:CreatePolicy
               - iam:GetPolicy

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -10,6 +10,7 @@ Conditions:
     - !Equals ['${self:custom.settings.sourceAccountId}', '']
   CreateStagingEnv: !Equals ['${self:custom.settings.createStagingEnv}', true]
   RunTestsAgainstTargetEnv: !Equals ['${self:custom.settings.runTestsAgainstTargetEnv}', true]
+  DeleteTargetEnv: !Equals ['${self:custom.settings.deleteAfterInstall}', true]
   AddManualApproval: !Equals ['${self:custom.settings.requireManualApproval}', true]
   SubscribeNotificationEmail: !Not
     - !Equals ['${self:custom.settings.emailForNotifications}', '']
@@ -20,8 +21,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties: !If
       - SubscribeNotificationEmail
-      -
-        Subscription:
+      - Subscription:
           - Endpoint: ${self:custom.settings.emailForNotifications}
             Protocol: email
         KmsMasterKeyId: alias/aws/sns
@@ -194,6 +194,7 @@ Resources:
                   - !GetAtt TestStgEnvProject.Arn
                   - !GetAtt TargetEnvDeployProject.Arn
                   - !GetAtt TestTargetEnvProject.Arn
+                  - !GetAtt DeleteTargetEnvProject.Arn
               - !If
                 - UseCodeCommit
                 - Action:
@@ -229,7 +230,7 @@ Resources:
           - Action:
               - iam:PassRole
             Effect: Allow
-            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-cicd-pipeline-AppDeployerRole-*'
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${self:custom.settings.namespace}-*'
           - Action:
               - iam:CreatePolicy
               - iam:GetPolicy
@@ -533,6 +534,23 @@ Resources:
                 InputArtifacts:
                   - Name: SourceArtifact
           - !Ref AWS::NoValue
+        # Add a stage for integration testing against target env if the RunTestsAgainstTargetEnv condition is true
+        - !If
+          - DeleteTargetEnv
+          - Name: Delete-Target-Env-${self:custom.settings.envName}
+            Actions:
+              - Name: Delete-Target-Env
+                RunOrder: 1
+                ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Provider: CodeBuild
+                  Version: '1'
+                Configuration:
+                  ProjectName: !Ref DeleteTargetEnvProject
+                InputArtifacts:
+                  - Name: SourceArtifact
+          - !Ref AWS::NoValue
 
   # A CodeBuild project to deploy solution to the staging environment before deploying it to target env
   # Create this CodeBuild project only if the condition CreateStagingEnv is set to true
@@ -626,6 +644,33 @@ Resources:
       Source:
         Type: CODEPIPELINE
         BuildSpec: main/cicd/cicd-pipeline/config/buildspec/buildspec-int-tests.yml
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Type: LINUX_CONTAINER
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+        EnvironmentVariables:
+          - Name: DEPLOYMENT_BUCKET
+            Value: ${self:provider.deploymentBucket}
+          - Name: ENV_NAME
+            Value: ${self:custom.settings.envName}
+      ServiceRole: !GetAtt AppDeployerRole.Arn
+      Cache:
+        # Use local caching to cache dirs specified in buildspec.yml (i.e., the node_modules dirs)
+        # See https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html for various build caching options
+        Type: LOCAL
+        Modes:
+          - LOCAL_SOURCE_CACHE
+          - LOCAL_CUSTOM_CACHE
+
+  # A CodeBuild project to test target environment solution
+  DeleteTargetEnvProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: main/cicd/cicd-pipeline/config/buildspec/buildspec-uninstall.yml
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
         Type: LINUX_CONTAINER

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -10,7 +10,6 @@ Conditions:
     - !Equals ['${self:custom.settings.sourceAccountId}', '']
   CreateStagingEnv: !Equals ['${self:custom.settings.createStagingEnv}', true]
   RunTestsAgainstTargetEnv: !Equals ['${self:custom.settings.runTestsAgainstTargetEnv}', true]
-  DeleteTargetEnv: !Equals ['${self:custom.settings.deleteAfterInstall}', true]
   AddManualApproval: !Equals ['${self:custom.settings.requireManualApproval}', true]
   SubscribeNotificationEmail: !Not
     - !Equals ['${self:custom.settings.emailForNotifications}', '']
@@ -194,7 +193,6 @@ Resources:
                   - !GetAtt TestStgEnvProject.Arn
                   - !GetAtt TargetEnvDeployProject.Arn
                   - !GetAtt TestTargetEnvProject.Arn
-                  - !GetAtt DeleteTargetEnvProject.Arn
               - !If
                 - UseCodeCommit
                 - Action:
@@ -534,23 +532,6 @@ Resources:
                 InputArtifacts:
                   - Name: SourceArtifact
           - !Ref AWS::NoValue
-        # Add a stage for integration testing against target env if the RunTestsAgainstTargetEnv condition is true
-        - !If
-          - DeleteTargetEnv
-          - Name: Delete-Target-Env-${self:custom.settings.envName}
-            Actions:
-              - Name: Delete-Target-Env
-                RunOrder: 1
-                ActionTypeId:
-                  Category: Build
-                  Owner: AWS
-                  Provider: CodeBuild
-                  Version: '1'
-                Configuration:
-                  ProjectName: !Ref DeleteTargetEnvProject
-                InputArtifacts:
-                  - Name: SourceArtifact
-          - !Ref AWS::NoValue
 
   # A CodeBuild project to deploy solution to the staging environment before deploying it to target env
   # Create this CodeBuild project only if the condition CreateStagingEnv is set to true
@@ -644,33 +625,6 @@ Resources:
       Source:
         Type: CODEPIPELINE
         BuildSpec: main/cicd/cicd-pipeline/config/buildspec/buildspec-int-tests.yml
-      Environment:
-        ComputeType: BUILD_GENERAL1_LARGE
-        Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
-        EnvironmentVariables:
-          - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
-          - Name: ENV_NAME
-            Value: ${self:custom.settings.envName}
-      ServiceRole: !GetAtt AppDeployerRole.Arn
-      Cache:
-        # Use local caching to cache dirs specified in buildspec.yml (i.e., the node_modules dirs)
-        # See https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html for various build caching options
-        Type: LOCAL
-        Modes:
-          - LOCAL_SOURCE_CACHE
-          - LOCAL_CUSTOM_CACHE
-
-  # A CodeBuild project to test target environment solution
-  DeleteTargetEnvProject:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      Artifacts:
-        Type: CODEPIPELINE
-      Source:
-        Type: CODEPIPELINE
-        BuildSpec: main/cicd/cicd-pipeline/config/buildspec/buildspec-uninstall.yml
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
         Type: LINUX_CONTAINER


### PR DESCRIPTION
Issue #, if available:
AppDeployer role was lacking permissions for creating a new SWB environment.

Description of changes:
Permissions needed were around being able to pass the AppDeployer role to SWB CFN stacks.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.