### PR TITLE
fix: count logic alb workspaces

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/plugins/env-provisioning-plugin.js
@@ -276,7 +276,7 @@ async function updateEnvOnProvisioningSuccess({
   return { requestContext, container, resolvedVars, status, outputs, provisionedProductId };
 }
 
-// This step calls "onEnvOnProvisioningFailure" in case of any errors.
+// This step calls "onEnvProvisioningFailure" in case of any errors.
 async function updateEnvOnProvisioningFailure({
   requestContext,
   container,

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/check-launch-dependency.test.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/__test__/check-launch-dependency.test.js
@@ -378,19 +378,6 @@ describe('CheckLaunchDependencyStep', () => {
   });
 
   describe('onPass', () => {
-    it('should not increase alb dependent workspace count when needsAlb is false', async () => {
-      jest.spyOn(step.payloadOrConfig, 'optionalBoolean').mockImplementationOnce(() => {
-        return false;
-      });
-      await step.onPass();
-      expect(albService.increaseAlbDependentWorkspaceCount).not.toHaveBeenCalled();
-    });
-
-    it('should increase alb dependent workspace count when needsAlb is true', async () => {
-      await step.onPass();
-      expect(albService.increaseAlbDependentWorkspaceCount).toHaveBeenCalled();
-    });
-
     it('should release lock when alb is present', async () => {
       try {
         await step.onPass();

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/check-launch-dependency/check-launch-dependency.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/check-launch-dependency/check-launch-dependency.js
@@ -95,7 +95,7 @@ class CheckLaunchDependency extends StepBase {
     const needsAlb = _.get(templateOutputs.NeedsALB, 'Value', false);
     if (!needsAlb) return null;
 
-    // Locking the ALB provisioning to avoid race condiitons on parallel provisioning.
+    // Locking the ALB provisioning to avoid race conditions on parallel provisioning.
     // expiresIn is set to 10 minutes. attemptsCount is set to 1200 to retry after 1 seconds for 20 minutes
     const awsAccountId = await albService.findAwsAccountId(requestContext, projectId);
     const lock = await lockService.tryWriteLock(

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/check-launch-dependency/check-launch-dependency.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/check-launch-dependency/check-launch-dependency.js
@@ -86,9 +86,18 @@ class CheckLaunchDependency extends StepBase {
       'envTypeConfigService',
     ]);
     const projectId = resolvedVars.projectId;
-    const awsAccountId = await albService.findAwsAccountId(requestContext, projectId);
-    // Locking the ALB provisioing to avoid race condiitons on parallel provisioning.
+    const envTypeConfig = await envTypeConfigService.mustFind(requestContext, envTypeId, { id: envTypeConfigId });
+
+    // Create dynamic namespace follows the existing pattern of namespace
+    resolvedVars.namespace = `analysis-${Date.now()}`;
+    const resolvedInputParams = await this.resolveVarExpressions(envTypeConfig.params, resolvedVars);
+    const templateOutputs = await this.getTemplateOutputs(requestContext, envTypeId);
+    const needsAlb = _.get(templateOutputs.NeedsALB, 'Value', false);
+    if (!needsAlb) return null;
+
+    // Locking the ALB provisioning to avoid race condiitons on parallel provisioning.
     // expiresIn is set to 10 minutes. attemptsCount is set to 1200 to retry after 1 seconds for 20 minutes
+    const awsAccountId = await albService.findAwsAccountId(requestContext, projectId);
     const lock = await lockService.tryWriteLock(
       { id: `alb-update-${awsAccountId}`, expiresIn: 1200 },
       { attemptsCount: 1200 },
@@ -99,35 +108,20 @@ class CheckLaunchDependency extends StepBase {
     if (_.isUndefined(lock)) throw new Error('Could not obtain a lock');
     this.state.setKey('ALB_LOCK', lock);
 
-    const envTypeConfig = await envTypeConfigService.mustFind(requestContext, envTypeId, { id: envTypeConfigId });
-
-    // Create dynamic namespace follows the existing pattern of namespace
-    resolvedVars.namespace = `analysis-${Date.now()}`;
-    const resolvedInputParams = await this.resolveVarExpressions(envTypeConfig.params, resolvedVars);
-    const templateOutputs = await this.getTemplateOutputs(requestContext, envTypeId);
-    const needsAlb = _.get(templateOutputs.NeedsALB, 'Value', false);
     const maxAlbWorkspacesCount = _.get(
       templateOutputs.MaxCountALBDependentWorkspaces,
       'Value',
       MAX_COUNT_ALB_DEPENDENT_WORKSPACES,
     );
-    if (needsAlb) {
-      // Sets needsAlb to payload so it can be used to decrease alb workspace count on product failure
-      await this.payload.setKey(outPayloadKeys.needsAlb, needsAlb);
-      // eslint-disable-next-line no-return-await
-      return await this.provisionAlb(
-        requestContext,
-        resolvedVars,
-        projectId,
-        resolvedInputParams,
-        maxAlbWorkspacesCount,
-      );
-    }
-    return null;
+
+    // Sets needsAlb to payload so it can be used to decrease alb workspace count on product failure
+    await this.payload.setKey(outPayloadKeys.needsAlb, needsAlb);
+    // eslint-disable-next-line no-return-await
+    return await this.provisionAlb(requestContext, resolvedVars, projectId, resolvedInputParams, maxAlbWorkspacesCount);
   }
 
   /**
-   * Method to provision ALB. The method checks if the max count of ALB possible exists and
+   * Method to provision ALB. The method checks if the max count of workspaces possible exist and
    * checks if there is an ALB aready exists for the AWS account and provisions if not exists.
    *
    * @param requestContext
@@ -474,26 +468,15 @@ class CheckLaunchDependency extends StepBase {
 
   async onPass() {
     // this method is automatically invoked by the workflow engine when the step is completed
-    const [requestContext, resolvedVars, needsAlb, albLock] = await Promise.all([
-      this.payloadOrConfig.object(inPayloadKeys.requestContext),
-      this.payloadOrConfig.object(inPayloadKeys.resolvedVars),
-      this.payloadOrConfig.optionalBoolean(outPayloadKeys.needsAlb, false),
-      this.state.optionalString('ALB_LOCK'),
-    ]);
-    const [albService, lockService] = await this.mustFindServices(['albService', 'lockService']);
-    // Increase ALB dependent workspace count when there is a flag needs ALB
-    if (albLock) {
-      if (needsAlb) {
-        await albService.increaseAlbDependentWorkspaceCount(requestContext, resolvedVars.projectId);
-      }
-    } else {
-      throw new Error(`Error provisioning environment. Reason: ALB lock does not exist or expired`);
-    }
+    const [albLock] = await Promise.all([this.state.optionalString('ALB_LOCK')]);
+    const [lockService] = await this.mustFindServices(['lockService']);
     // Release ALB lock if exists
-    await lockService.releaseWriteLock({ writeToken: albLock });
-    this.print({
-      msg: `ALB lock released successfully`,
-    });
+    if (albLock) {
+      await lockService.releaseWriteLock({ writeToken: albLock });
+      this.print({
+        msg: `ALB lock released successfully`,
+      });
+    }
   }
 
   /**

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
@@ -162,7 +162,7 @@ class TerminateLaunchDependency extends StepBase {
     if (!needsAlb) return null;
 
     const awsAccountId = await albService.findAwsAccountId(requestContext, projectId);
-    // Locking the ALB termination to avoid race condiitons on parallel provisioning.
+    // Locking the ALB termination to avoid race conditions on parallel provisioning.
     // expiresIn is set to 10 minutes. attemptsCount is set to 1200 to retry after 1 seconds for 20 minutes
     const lock = await lockService.tryWriteLock(
       { id: `alb-update-${awsAccountId}`, expiresIn: 1200 },


### PR DESCRIPTION
Issue #, if available:
Faulty ALB-workspace count logic.

Description of changes:
Get current count of listener rules directly from ALB and assign it as rules get created/deleted.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.