### PR TITLE
feat: Add user's email to JSON response of egress request

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -46,6 +46,7 @@ class DataEgressService extends Service {
       's3Service',
       'environmentScService',
       'lockService',
+      'userService',
     ]);
   }
 
@@ -337,6 +338,11 @@ class DataEgressService extends Service {
     egressStoreInfo.isAbleToSubmitEgressRequest = false;
     egressStoreInfo.egressStoreObjectListLocation = `arn:aws:s3:::${egressStoreObjectList.bucket}/${egressStoreObjectList.key}`;
     egressStoreInfo.ver = parseInt(egressStoreInfo.ver, 10) + 1; // parseInt(string, radix) string: The value to parse. radix: An integer between 2 and 36 that represents the radix of the string.
+
+    const userService = await this.service('userService');
+    const createdByUser = await userService.mustFindUser({ uid: egressStoreInfo.createdBy, fields: 'email' });
+    const updatedByUser = await userService.mustFindUser({ uid: egressStoreInfo.updatedBy, fields: 'email' });
+
     await this.lockAndUpdate(egressStoreDdbLockId, egressStoreInfo.id, egressStoreInfo);
 
     const message = {
@@ -346,12 +352,14 @@ class DataEgressService extends Service {
       egress_store_name: egressStoreInfo.egressStoreName,
       created_at: egressStoreInfo.createdAt,
       created_by: egressStoreInfo.createdBy,
+      created_by_email: createdByUser.email,
       workspace_id: egressStoreInfo.workspaceId,
       project_id: egressStoreInfo.projectId,
       s3_bucketname: egressStoreInfo.s3BucketName,
       s3_bucketpath: egressStoreInfo.s3BucketPath,
       status: egressStoreInfo.status,
       updated_by: egressStoreInfo.updatedBy,
+      updated_by_email: updatedByUser.email,
       updated_at: egressStoreInfo.updatedAt,
       ver: egressStoreInfo.ver,
     };


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Per new customer requirements I've added two new fields to the response of an Egress Data request. The new fields are `updated_by_email` and `created_by_email`.

**Testing**
I deployed the new code, submitted an egress request, and checked that the response has the newly added fields.

```
{
    "egress_store_object_list_location": "<REDACTED>/sagemaker-11-egress-store-ver1.json",
    "id": "<REDACTED>",
    "egress_store_id": "<REDACTED>",
    "egress_store_name": "sagemaker-11-egress-store",
    "created_at": "2021-10-15T19:03:09.367Z",
    "created_by": "<REDACTED>",
    "created_by_email": "<REDACTED>@amazon.com",
    "workspace_id": "<REDACTED>",
    "project_id": "proj-new-account-1",
    "s3_bucketname": "<REDACTED>",
    "s3_bucketpath": "<REDACTED>/",
    "status": "PENDING",
    "updated_by": "<REDACTED>",
    "updated_by_email": "<REDACTED>@amazon.com",
    "updated_at": "2021-10-25T18:45:02.883Z",
    "ver": 1
}
```
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.