### PR TITLE
fix: moving advanced integ tests in non-TRE folder

### DIFF
--- a/main/integration-tests/__test__/api-tests/appstream-egress-disabled/study-permissions/verify-linux-study-permissions.test.js
+++ b/main/integration-tests/__test__/api-tests/appstream-egress-disabled/study-permissions/verify-linux-study-permissions.test.js
@@ -14,8 +14,8 @@
  */
 const { sleep } = require('@aws-ee/base-services/lib/helpers/utils');
 const { NodeSSH } = require('node-ssh');
-const { mountStudies, readWrite } = require('../../../support/complex/run-shell-command');
-const { runSetup } = require('../../../support/setup');
+const { mountStudies, readWrite } = require('../../../../support/complex/run-shell-command');
+const { runSetup } = require('../../../../support/setup');
 
 describe('EC2 Linux scenarios', () => {
   let setup;


### PR DESCRIPTION
Issue #, if available:
Advanced integ tests were left out of pipelines after TRE release.

Description of changes:
Adding them back in appstream-egress-disabled folder.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.