### PR TITLE
fix: s3 bucket versioning and https access

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -120,6 +120,25 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+
+  LogBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LogBucket
+      PolicyDocument:
+        Statement:
+          - Sid: Deny requests that do not use HTTPS/TLS
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !Join ['/', [!GetAtt LogBucket.Arn, '*']]
+              - !GetAtt LogBucket.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   MasterSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -140,6 +140,16 @@ Resources:
                   - UseCodeCommit
                   - ${self:custom.settings.sourceRoleArn}
                   - !Ref AWS::NoValue
+          - Sid: Deny requests that do not use HTTPS/TLS
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !Join ['/', [!GetAtt AppArtifactBucket.Arn, '*']]
+              - !GetAtt AppArtifactBucket.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   # The AWS IAM role to be assumed by the AWS CodePipeline.
   # The role specified in each stage is assumed for that specific stage in the pipeline.

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -90,11 +90,13 @@ Resources:
                 s3:x-amz-server-side-encryption: 'aws:kms'
               StringNotEqualsIfExists:
                 s3:x-amz-server-side-encryption-aws-kms-key-id: !GetAtt StudyDataEncryptionKey.Arn
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt StudyDataBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt StudyDataBucket.Arn, '*']]
+              - !GetAtt StudyDataBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -171,6 +173,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   ExternalCfnTemplatesBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -179,11 +183,13 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt ExternalCfnTemplatesBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt ExternalCfnTemplatesBucket.Arn, '*']]
+              - !GetAtt ExternalCfnTemplatesBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -210,6 +216,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   EnvironmentsBootstrapBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -219,11 +227,13 @@ Resources:
         Version: '2012-10-17'
         Id: PutObjectPolicy
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt EnvironmentsBootstrapBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt EnvironmentsBootstrapBucket.Arn, '*']]
+              - !GetAtt EnvironmentsBootstrapBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -254,6 +264,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   EnvTypeConfigsBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -263,11 +275,13 @@ Resources:
         Version: '2012-10-17'
         Id: PutObjectPolicy
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt EnvTypeConfigsBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt EnvTypeConfigsBucket.Arn, '*']]
+              - !GetAtt EnvTypeConfigsBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -402,6 +416,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   EgressStoreBucketPolicy:
     Condition: EnableEgressStore
@@ -412,11 +428,13 @@ Resources:
         Version: '2012-10-17'
         Id: PutObjectPolicy
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt EgressStoreBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt EgressStoreBucket.Arn, '*']]
+              - !GetAtt EgressStoreBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -428,6 +446,26 @@ Resources:
             Condition:
               StringNotEquals:
                 s3:signatureversion: 'AWS4-HMAC-SHA256'
+
+  EgressNotificationBucketPolicy:
+    Condition: EnableEgressStore
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref EgressNotificationBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: PutObjectPolicy
+        Statement:
+          - Sid: Deny requests that do not use HTTPS/TLS
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !Join ['/', [!GetAtt EgressNotificationBucket.Arn, '*']]
+              - !GetAtt EgressNotificationBucket.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   # =============================================================================================
   # IAM Roles

--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -25,6 +25,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   LoggingBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -32,11 +34,13 @@ Resources:
       Bucket: !Ref LoggingBucket
       PolicyDocument:
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt LoggingBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt LoggingBucket.Arn, '*']]
+              - !GetAtt LoggingBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -66,6 +70,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
 
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -81,11 +87,13 @@ Resources:
               AWS: !Join ['', ['arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ', !Ref 'CloudFrontOAI']]
             Resource:
               - !Join ['', ['arn:aws:s3:::', !Ref 'WebsiteBucket', '/*']]
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use HTTPS/TLS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt WebsiteBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt WebsiteBucket.Arn, '*']]
+              - !GetAtt WebsiteBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false


### PR DESCRIPTION
Issue #, if available: GALI-1202, GALI-1200

Description of changes: enable versioning on all buckets and add public policy statement to enforce https traffic only on all buckets and all items in buckets. Tested that versioning is enabled in the console of the buckets after but not before deployment with changes and that the bucket policy was updated to include protection for buckets after re-deployment.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.