### PR TITLE
fix: more secure traffic policy

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -123,6 +123,24 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  LogBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LogBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: Deny requests that do not use TLS/HTTPS
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !Join ['/', [!GetAtt LogBucket.Arn, '*']]
+              - !GetAtt LogBucket.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+
   MasterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/main/solution/backend/config/infra/cloudformation.yml
+++ b/main/solution/backend/config/infra/cloudformation.yml
@@ -181,11 +181,13 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use TLS/HTTPS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt ExternalCfnTemplatesBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt ExternalCfnTemplatesBucket.Arn, '*']]
+              - !GetAtt ExternalCfnTemplatesBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -269,11 +271,13 @@ Resources:
         Version: '2012-10-17'
         Id: PutObjectPolicy
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use TLS/HTTPS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt EnvTypeConfigsBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt EnvTypeConfigsBucket.Arn, '*']]
+              - !GetAtt EnvTypeConfigsBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -420,11 +424,13 @@ Resources:
         Version: '2012-10-17'
         Id: PutObjectPolicy
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use TLS/HTTPS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt EgressStoreBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt EgressStoreBucket.Arn, '*']]
+              - !GetAtt EgressStoreBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -433,6 +439,34 @@ Resources:
             Principal: '*'
             Action: s3:*
             Resource: !Join ['/', [!GetAtt EgressStoreBucket.Arn, '*']]
+            Condition:
+              StringNotEquals:
+                s3:signatureversion: 'AWS4-HMAC-SHA256'
+
+  EgressNotificationBucketPolicy:
+    Condition: EnableEgressStore
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref EgressNotificationBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: PutObjectPolicy
+        Statement:
+          - Sid: Deny requests that do not use TLS/HTTPS
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource:
+              - !Join ['/', [!GetAtt EgressNotificationBucket.Arn, '*']]
+              - !GetAtt EgressNotificationBucket.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+          - Sid: Deny requests that do not use SigV4
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource: !Join ['/', [!GetAtt EgressNotificationBucket.Arn, '*']]
             Condition:
               StringNotEquals:
                 s3:signatureversion: 'AWS4-HMAC-SHA256'

--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -34,11 +34,13 @@ Resources:
       Bucket: !Ref LoggingBucket
       PolicyDocument:
         Statement:
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use TLS/HTTPS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt LoggingBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt LoggingBucket.Arn, '*']]
+              - !GetAtt LoggingBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -85,11 +87,13 @@ Resources:
               AWS: !Join ['', ['arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ', !Ref 'CloudFrontOAI']]
             Resource:
               - !Join ['', ['arn:aws:s3:::', !Ref 'WebsiteBucket', '/*']]
-          - Sid: Deny requests that do not use TLS
+          - Sid: Deny requests that do not use TLS/HTTPS
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: !Join ['/', [!GetAtt WebsiteBucket.Arn, '*']]
+            Resource:
+              - !Join ['/', [!GetAtt WebsiteBucket.Arn, '*']]
+              - !GetAtt WebsiteBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false


### PR DESCRIPTION
Issue #, if available: GALI-1200

Description of changes: In the cloudformation templates, add another resource to enforce HTTPS traffic to S3 buckets provisioned by SWB. This fix only applies to the buckets that are static i.e. not changed by the user programmatically through the SWB UI later on. Those buckets will be fixed in another PR.

Testing: Deployed to both a TRE and non-TRE env and was able to make a study, launch a workspace with that study mounted, access the workspace and the contents of the study bucket.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.