### PR TITLE
fix: avoid duplicate hosted zone when provided

### DIFF
--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -2,6 +2,12 @@ Conditions:
   IsDev: !Equals ['${self:custom.settings.envType}', 'dev']
   UseCustomDomain: !Not
     - !Equals ['${self:custom.settings.domainName}', '']
+  UseHostedZoneId: !Not
+    - !Equals ['${self:custom.settings.hostedZoneId}', '']
+  CustomDomainWithoutHostedZoneId: !And
+    - !Not
+      - !Equals ['${self:custom.settings.domainName}', '']
+    - !Equals ['${self:custom.settings.hostedZoneId}', '']
 
 Description: (SO0144) Service Workbench on AWS Solution
 
@@ -168,7 +174,7 @@ Resources:
 
   HostedZone:
     Type: AWS::Route53::HostedZone
-    Condition: UseCustomDomain
+    Condition: CustomDomainWithoutHostedZoneId
     DeletionPolicy: Retain
     Properties:
       Name: ${self:custom.settings.domainName}
@@ -177,7 +183,12 @@ Resources:
     Type: AWS::Route53::RecordSetGroup
     Condition: UseCustomDomain
     Properties:
-      HostedZoneId: !Ref HostedZone
+      # Blank hosted zone ID in stage file creates a new one
+      # This is to ensure backwards compatibility
+      HostedZoneId: !If
+        - UseHostedZoneId
+        - ${self:custom.settings.hostedZoneId}
+        - !Ref HostedZone
       RecordSets:
         - Name: ${self:custom.settings.domainName}
           Type: A
@@ -206,8 +217,9 @@ Outputs:
     Value: !Ref WebsiteCloudFront
 
   HostedZoneId:
+    Condition: UseCustomDomain
     Description: Id of the hosted zone created when a custom domain is used
     Value: !If
-      - UseCustomDomain
+      - CustomDomainWithoutHostedZoneId
       - !Ref HostedZone
-      - 'NotSetAsCustomDomainDisabled'
+      - ${self:custom.settings.hostedZoneId}


### PR DESCRIPTION
Issue #, if available:
New Hosted Zone is created even when one is provided in the main `stage.yml` file.

Description of changes:
Added backwards compatible logic to create one only when `hostedZoneId` is not provided by the config settings.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.