### PR TITLE
fix: hsts header

### DIFF
--- a/addons/addon-base-rest-api/packages/api-handler-factory/lib/handler.js
+++ b/addons/addon-base-rest-api/packages/api-handler-factory/lib/handler.js
@@ -54,6 +54,16 @@ function handlerFactory({ registerServices, registerRoutes }) {
     // register routes
     await registerRoutes(appContext, apiRouter);
 
+    // Implement HSTS before any other controller (https://www.maxivanov.io/http-strict-transport-security/)
+    // max-age = 63072000 which is 1 year
+    // includeSubDomains to protect subdomains of the site with HSTS as well (recommended)
+    app.use((req, res, next) => {
+      if (req.secure) {
+        res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      }
+      next();
+    });
+
     // setup CORS, compression and body parser
     const isDev = settingsService.get('envType') === 'dev';
     let allowList = settingsService.optionalObject('corsAllowList', []);


### PR DESCRIPTION
Issue #, if available: GALI-1190

Description of changes: Added a strict-transport-security header to enforce HSTS traffic for extra security.

Tested manually and was able to see the proper header in the response in both the UI and through Postman. Ran the entire collection of integration tests and end-to-end tests and all passed. Manually tested in both non-TRE and TRE environments.

Header in response:
<img width="841" alt="Screen Shot 2021-11-04 at 4 06 20 PM" src="https://user-images.githubusercontent.com/43092418/140948200-d346e285-5557-43df-96ee-fe28ab2cc45f.png">

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.