### PR TITLE
chore: end to end tests rstudio feature

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
@@ -267,6 +267,7 @@ class ScEnvironmentHttpConnections extends React.Component {
                   disabled={isDisabled(item.id)}
                   loading={isLoading(item.id)}
                   onClick={this.handleConnect(item.id)}
+                  data-testid="connect-to-workspace-button"
                 >
                   Connect
                 </Button>

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeCandidatesList.js
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/src/parts/environment-types/EnvTypeCandidatesList.js
@@ -121,7 +121,11 @@ class EnvTypeCandidatesList extends Component {
             onClick={() => this.handleShowAllVersionsToggle()}
             label={this.showAllVersions ? 'All Versions' : 'Latest Versions'}
           />
-          {this.portfolioId && <div className="portfolio-id">Portfolio Id: {this.portfolioId}</div>}
+          {this.portfolioId && (
+            <div data-testid="portfolio-id" className="portfolio-id">
+              Portfolio Id: {this.portfolioId}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/main/end-to-end-tests/README.md
+++ b/main/end-to-end-tests/README.md
@@ -11,13 +11,15 @@ To run the E2E tests, you will need the following items:
 - A Service Workbench environment setup with Service Catalog
 - Username and password of an admin for the Service Workbench environment
 - Username and password of a researcher for the Service Workbench environment
-- A project set up for that researcher that can launch EC2 workspaces and Sagemaker workspaces
+- A project set up for that researcher that can launch workspaces
 	- Within that project, a study where the researcher is admin
 	- Within that project, a study where the researcher is not an admin
 - A configured EC2 Linux workspace
 - A configured Sagemaker workspace
 - A configured EC2 Windows workspace
 - A configured EMR workspace
+- A configured RStudio Server workspace
+- An SSH Key pair created *by the researcher user*
 
 Once you've confirmed that you have the items above setup, you can create a `cypress.dev.json` and a `cypress.local.json` file with the configurations needed for your tests. You can use `cypress.json` as a template for your new configuration files. An example file is included as `cypress.local.example.json`
 

--- a/main/end-to-end-tests/cypress.appstream-egress.json
+++ b/main/end-to-end-tests/cypress.appstream-egress.json
@@ -27,6 +27,11 @@
           "configuration": "<EC2 WINDOWS WORKSPACE CONFIGURATION>",
           "projectId": "<PROJECT TO LAUNCH EC2 WORKSPACE IN>"
         }
+      },
+      "rstudioServer": {
+        "workspaceTypeName": "<NAME OF RSTUDIO SERVER WORKSPACE TYPE>",
+        "configuration": "<RSTUDIO SERVER WORKSPACE CONFIGURATION>",
+        "projectId": "<PROJECT TO LAUNCH RSTUDIO SERVER WORKSPACE IN>"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress.github.appstream-egress.json
+++ b/main/end-to-end-tests/cypress.github.appstream-egress.json
@@ -23,6 +23,11 @@
           "configuration": "AppStream-Windows",
           "projectId": "TRE-Project"
         }
+      },
+      "rstudioServer": {
+        "workspaceTypeName": "RStudio-Server-ALB-v1",
+        "configuration": "RStudio-Server-ALB-TRE",
+        "projectId": "TRE-Project"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -28,6 +28,11 @@
         "workspaceTypeName": "EMR-v7",
         "configuration": "emr-e2e",
         "projectId": "e2eTestProject"
+      },
+      "rstudioServer": {
+        "workspaceTypeName": "RStudio-Server-ALB-v2",
+        "configuration": "RStudio-Server-ALB-v2",
+        "projectId": "e2eTestProject"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress.json
+++ b/main/end-to-end-tests/cypress.json
@@ -16,9 +16,6 @@
         "projectId": "<PROJECT TO LAUNCH SAGEMAKER WORKSPACE IN>"
       },
       "ec2": {
-        "workspaceTypeName": "<NAME OF EC2 WORKSPACE TYPE>",
-        "configuration": "<EC2 WORKSPACE CONFIGURATION>",
-        "projectId": "<PROJECT TO LAUNCH EC2 WORKSPACE IN>",
         "windows": {
           "workspaceTypeName": "<NAME OF EC2 WINDOWS WORKSPACE TYPE>",
           "configuration": "<EC2 WINDOWS WORKSPACE CONFIGURATION>",
@@ -34,6 +31,11 @@
         "workspaceTypeName": "<NAME OF EMR WORKSPACE TYPE>",
         "configuration": "<EMR WORKSPACE CONFIGURATION>",
         "projectId": "<PROJECT TO LAUNCH EMR WORKSPACE IN>"
+      },
+      "rstudioServer": {
+        "workspaceTypeName": "<NAME OF RSTUDIO SERVER WORKSPACE TYPE>",
+        "configuration": "<RSTUDIO SERVER WORKSPACE CONFIGURATION>",
+        "projectId": "<PROJECT TO LAUNCH RSTUDIO SERVER WORKSPACE IN>"
       }
     },
     "studies": {

--- a/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
@@ -17,6 +17,7 @@ import {
   launchWorkspace,
   navigateToWorkspaces,
   checkDetailsTable,
+  checkWorkspaceAvailableAndClickConnectionsButton,
 } from '../../support/workspace-util';
 
 describe('Launch a workspace', () => {
@@ -24,6 +25,14 @@ describe('Launch a workspace', () => {
     cy.login('researcher');
     navigateToWorkspaces();
     terminateWorkspaces();
+  });
+
+  // Do RStudio create first as we need to test when this becomes available as well
+  it('should launch a new RStudio Server workspace correctly', () => {
+    const workspaces = Cypress.env('workspaces');
+    const rstudioServer = workspaces.rstudioServer;
+    const workspaceName = launchWorkspace(rstudioServer, 'RStudio-Server');
+    checkDetailsTable(workspaceName);
   });
 
   it('should launch a new sagemaker workspace correctly', () => {
@@ -52,5 +61,28 @@ describe('Launch a workspace', () => {
     const emr = workspaces.emr;
     const workspaceName = launchWorkspace(emr, 'EMR');
     checkDetailsTable(workspaceName);
+  });
+
+  it('should have opened a new tab for the RStudio Server when you click Connect', () => {
+    // Need to login at the beginning so the stub is initialized directly before we use to monitor the new tab opening
+    cy.login('researcher');
+    navigateToWorkspaces();
+    // Check that the RStudio Server workspace is in available status
+    checkWorkspaceAvailableAndClickConnectionsButton('CypressTestRStudio-ServerWorkspace-');
+    // Click connect
+    cy.contains('CypressTestRStudio-ServerWorkspace-')
+      .parent()
+      .find('[data-testid=connect-to-workspace-button]')
+      .click();
+    // Each time we click the "Connect" button on a workspace, it should open a new browser window connected to the RStudio server instance.
+    // Let's check the expected number of new browser windows are opened
+    cy.window()
+      .its('open')
+      .should('be.called');
+    // Click connect
+    cy.contains('CypressTestRStudio-ServerWorkspace-')
+      .parent()
+      .find('[data-testid=connect-to-workspace-button]')
+      .click();
   });
 });

--- a/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
@@ -17,7 +17,6 @@ import {
   launchWorkspace,
   navigateToWorkspaces,
   checkDetailsTable,
-  checkWorkspaceAvailableAndClickConnectionsButton,
 } from '../../support/workspace-util';
 
 describe('Launch a workspace', () => {
@@ -61,28 +60,5 @@ describe('Launch a workspace', () => {
     const emr = workspaces.emr;
     const workspaceName = launchWorkspace(emr, 'EMR');
     checkDetailsTable(workspaceName);
-  });
-
-  it('should have opened a new tab for the RStudio Server when you click Connect', () => {
-    // Need to login at the beginning so the stub is initialized directly before we use to monitor the new tab opening
-    cy.login('researcher');
-    navigateToWorkspaces();
-    // Check that the RStudio Server workspace is in available status
-    checkWorkspaceAvailableAndClickConnectionsButton('CypressTestRStudio-ServerWorkspace-');
-    // Click connect
-    cy.contains('CypressTestRStudio-ServerWorkspace-')
-      .parent()
-      .find('[data-testid=connect-to-workspace-button]')
-      .click();
-    // Each time we click the "Connect" button on a workspace, it should open a new browser window connected to the RStudio server instance.
-    // Let's check the expected number of new browser windows are opened
-    cy.window()
-      .its('open')
-      .should('be.called');
-    // Click connect
-    cy.contains('CypressTestRStudio-ServerWorkspace-')
-      .parent()
-      .find('[data-testid=connect-to-workspace-button]')
-      .click();
   });
 });

--- a/main/end-to-end-tests/cypress/integration/appstream-egress-enabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-enabled/workspaces.spec.js
@@ -18,6 +18,7 @@ import {
   launchWorkspace,
   navigateToWorkspaces,
   checkDetailsTable,
+  checkWorkspaceAvailableAndClickConnectionsButton,
 } from '../../support/workspace-util';
 
 describe('Launch new workspaces', () => {
@@ -32,15 +33,17 @@ describe('Launch new workspaces', () => {
 
   let expectedNumberOfNewlyOpenBrowserWindows = 0;
 
-  it('should launch Sagemaker, Linux, and Windows successfully', () => {
+  it('should launch Sagemaker, Linux, Windows, adn RStudio workspaces successfully', () => {
     const workspaces = Cypress.env('workspaces');
     const sagemakerWorkspaceName = launchWorkspace(workspaces.sagemaker, 'Sagemaker');
     const linuxWorkspaceName = launchWorkspace(workspaces.ec2.linux, 'Linux');
     const windowsWorkspaceName = launchWorkspace(workspaces.ec2.windows, 'Windows');
+    const rstudioWorkspaceName = launchWorkspace(workspaces.rstudioServer, 'RStudio-Server');
 
     checkSagemaker(sagemakerWorkspaceName);
     checkLinux(linuxWorkspaceName);
     checkWindows(windowsWorkspaceName);
+    checkRstudio(rstudioWorkspaceName);
 
     // Each time we click the "Connect" button on a workspace, it should open a new browser window connected to an AppStream instance.
     // Let's check the expected number of new browser windows are opened
@@ -119,14 +122,29 @@ describe('Launch new workspaces', () => {
     expectedNumberOfNewlyOpenBrowserWindows += 1;
   }
 
-  function checkWorkspaceAvailableAndClickConnectionsButton(workspaceName) {
+  function checkRstudio(workspaceName) {
+    checkDetailsTable(workspaceName);
+    checkWorkspaceAvailableAndClickConnectionsButton(workspaceName);
     cy.contains(workspaceName)
       .parent()
-      .contains('AVAILABLE', { timeout: 900000 });
-    cy.contains(workspaceName)
-      .parent()
-      .find('[data-testid=sc-environment-connection-button]')
+      .find('[data-testid=sc-environment-generate-url-button]', { timeout: 60000 })
       .click();
+
+    // Check we can not access Rstudio server url from the internet. Note rstudio server url is different from AppStream Url.
+    // To access Rstudio server we would do it through the AppStream Url
+    cy.get('[data-testid=destination-url]')
+      .invoke('text')
+      .then(url => {
+        cy.request({ url, failOnStatusCode: false }).then(response => {
+          expect(response.status).to.equal(403);
+        });
+      });
+
+    cy.contains(workspaceName)
+      .parent()
+      .find('[data-testid=connect-to-workspace-button]')
+      .click();
+    expectedNumberOfNewlyOpenBrowserWindows += 1;
   }
 
   /**

--- a/main/end-to-end-tests/cypress/integration/common/workspace-types.spec.js
+++ b/main/end-to-end-tests/cypress/integration/common/workspace-types.spec.js
@@ -26,6 +26,10 @@ describe('Check that variables prepopulate when making a new configuration', () 
       .click();
   };
 
+  it('should display a portfolio id', () => {
+    cy.get('[data-testid=portfolio-id]').contains('Portfolio Id: ');
+  });
+
   it('should have the proper variables prepopulated-EMR', () => {
     const isAppStreamEnabled = Cypress.env('isAppStreamEnabled');
     // AppStream enabled env does not support EMR (10/7/21)
@@ -52,6 +56,12 @@ describe('Check that variables prepopulate when making a new configuration', () 
     const workspaces = Cypress.env('workspaces');
     const ec2windows = workspaces.ec2.windows;
     checkPrepopVariables(ec2windows, 'EC2 Windows');
+  });
+
+  it('should have the proper variables prepopulated-Rstudio Server', () => {
+    const workspaces = Cypress.env('workspaces');
+    const rstudioServer = workspaces.rstudioServer;
+    checkPrepopVariables(rstudioServer, 'RStudio Server');
   });
 
   const checkPrepopVariables = (workspaceParam, workspaceType) => {
@@ -96,7 +106,7 @@ describe('Check that variables prepopulate when making a new configuration', () 
       .click();
 
     // Make sure the correct variables have the correct default values for the current workspace type
-    if (workspaceType === 'EMR' || workspaceType === 'EC2 Windows') {
+    if (workspaceType === 'EMR' || workspaceType === 'EC2 Windows' || workspaceType === 'RStudio Server') {
       cy.get('[data-testid=KeyName]').contains('${adminKeyPairName}');
     }
     cy.get('[data-testid=EncryptionKeyArn]').contains('${encryptionKeyArn}');

--- a/main/end-to-end-tests/cypress/support/workspace-util.js
+++ b/main/end-to-end-tests/cypress/support/workspace-util.js
@@ -18,7 +18,7 @@ function terminateWorkspaces() {
   //  If there are workspaces, the cards will contain the word "Workspace" in the details table ("Workspace Type" in full)
   //  If there are not any workspaces, the displayed message is "No research workspaces"
   //  Both cases will be caught with this contains as it is case insensitive and doesn't match whole words
-  cy.get('[data-testid=workspaces]').contains('CypressTest', { matchCase: false });
+  cy.get('[data-testid=workspaces]').contains('workspace', { matchCase: false });
   cy.get('#root').then($body => {
     if ($body.find('[data-testid=sc-env-terminate]').length > 0) {
       cy.get('#root')
@@ -106,9 +106,21 @@ function checkDetailsTable(workspaceName) {
     .get('[data-testid=environment-card-details-table]')
     .contains('Instance Type');
 }
+
+function checkWorkspaceAvailableAndClickConnectionsButton(workspaceName) {
+  cy.contains(workspaceName)
+    .parent()
+    .contains('AVAILABLE', { timeout: 900000 });
+  cy.contains(workspaceName)
+    .parent()
+    .find('[data-testid=sc-environment-connection-button]')
+    .click();
+}
+
 module.exports = {
   terminateWorkspaces,
   launchWorkspace,
   navigateToWorkspaces,
   checkDetailsTable,
+  checkWorkspaceAvailableAndClickConnectionsButton,
 };


### PR DESCRIPTION
Issue #, if available: GALI-1175

Description of changes: added workspace tests for both TRE and non TRE env, added test to check prepopulated configuration, added test to check presence of portfolio id, updated templates and readme, and updated github pipeline files. Tested workspace test on my environments and the environments used in the pipeline.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [x] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.