### PR TITLE
fix: allow RStudio EC2 to initialize

### DIFF
--- a/main/integration-tests/__test__/api-tests/common/advanced-tests/rstudio/launch-rstudio-workspace.test.js
+++ b/main/integration-tests/__test__/api-tests/common/advanced-tests/rstudio/launch-rstudio-workspace.test.js
@@ -60,6 +60,9 @@ describe('Launch and terminate RStudio instance', () => {
       await checkCIDR(envId);
     }
 
+    // Allow 90 seconds for EC2 to initialize and create SSM parameters
+    await sleep(90 * 1000);
+
     const rstudioServerUrlResponse = await checkConnectionUrlCanBeCreated(envId);
     await checkConnectionUrlNetworkConnectivity(rstudioServerUrlResponse);
     await checkWorkspaceCanBeTerminatedCorrectly(envId);


### PR DESCRIPTION
Issue #, if available:
SSM params are created after RStudio EC2 is fully initialized (takes 60-90 seconds).

Description of changes:
Adding a wait time of 60-90 seconds in RStudio integration test.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.