### PR TITLE
chore: integration test cleanup for dummy envs

### DIFF
--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
@@ -95,7 +95,6 @@ class TerminateLaunchDependency extends StepBase {
     // convert output array to object. Return {} if no outputs found
     const environmentOutputs = await this.cfnOutputsArrayToObject(_.get(environment, 'outputs', []));
     const connectionType = _.get(environmentOutputs, 'MetaConnection1Type', '');
-    let templateOutputs = {};
     // Clean up listener rule and Route53 record before deleting ALB and Workspace
     if (connectionType.toLowerCase() === 'rstudiov2') {
       const [environmentDnsService] = await this.mustFindServices(['environmentDnsService']);
@@ -177,10 +176,10 @@ class TerminateLaunchDependency extends StepBase {
           });
         }
       }
-      // Get Template outputs to check NeedsALB flag. Not reading template outputs from DB
-      // Because failed products will not have outputs stored
-      templateOutputs = await this.getTemplateOutputs(requestContext, environment.envTypeId);
     }
+    // Get Template outputs to check NeedsALB flag. Not reading template outputs from DB
+    // Because failed products will not have outputs stored
+    const templateOutputs = await this.getTemplateOutputs(requestContext, environment.envTypeId);
     const needsAlb = _.get(templateOutputs.NeedsALB, 'Value', false);
     if (!needsAlb) return null;
 

--- a/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
+++ b/addons/addon-environment-sc-api/packages/environment-sc-workflow-steps/lib/steps/terminate-launch-dependency/terminate-launch-dependency.js
@@ -95,6 +95,7 @@ class TerminateLaunchDependency extends StepBase {
     // convert output array to object. Return {} if no outputs found
     const environmentOutputs = await this.cfnOutputsArrayToObject(_.get(environment, 'outputs', []));
     const connectionType = _.get(environmentOutputs, 'MetaConnection1Type', '');
+    let templateOutputs = {};
     // Clean up listener rule and Route53 record before deleting ALB and Workspace
     if (connectionType.toLowerCase() === 'rstudiov2') {
       const [environmentDnsService] = await this.mustFindServices(['environmentDnsService']);
@@ -176,10 +177,10 @@ class TerminateLaunchDependency extends StepBase {
           });
         }
       }
+      // Get Template outputs to check NeedsALB flag. Not reading template outputs from DB
+      // Because failed products will not have outputs stored
+      templateOutputs = await this.getTemplateOutputs(requestContext, environment.envTypeId);
     }
-    // Get Template outputs to check NeedsALB flag. Not reading template outputs from DB
-    // Because failed products will not have outputs stored
-    const templateOutputs = await this.getTemplateOutputs(requestContext, environment.envTypeId);
     const needsAlb = _.get(templateOutputs.NeedsALB, 'Value', false);
     if (!needsAlb) return null;
 

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/cidr-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/cidr-workspace-service-catalog.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 const errorCode = require('../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Cidr workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Cidr workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -85,6 +93,8 @@ describe('Cidr workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -107,6 +117,8 @@ describe('Cidr workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/cidr-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/cidr-workspace-service-catalog.test.js
@@ -30,7 +30,7 @@ describe('Cidr workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/create-url-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/create-url-connection.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../../support/setup');
 const errorCode = require('../../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Create URL scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Create URL scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -68,6 +76,8 @@ describe('Create URL scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -95,6 +105,8 @@ describe('Create URL scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/create-url-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/create-url-connection.test.js
@@ -30,7 +30,7 @@ describe('Create URL scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/get-connections.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/get-connections.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../../support/setup');
 const errorCode = require('../../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Get connections scenario', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Get connections scenario', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -66,6 +74,8 @@ describe('Get connections scenario', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -91,6 +101,8 @@ describe('Get connections scenario', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/get-connections.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/get-connections.test.js
@@ -30,7 +30,7 @@ describe('Get connections scenario', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/send-ssh-public-key-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/send-ssh-public-key-connection.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../../support/setup');
 const errorCode = require('../../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Send SSH public key scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Send SSH public key scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -72,6 +80,8 @@ describe('Send SSH public key scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -103,6 +113,8 @@ describe('Send SSH public key scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/send-ssh-public-key-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/send-ssh-public-key-connection.test.js
@@ -30,7 +30,7 @@ describe('Send SSH public key scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/windows-rdp-info-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/windows-rdp-info-connection.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../../support/setup');
 const errorCode = require('../../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Get Windows password for RDP scenario', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Get Windows password for RDP scenario', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -68,6 +76,8 @@ describe('Get Windows password for RDP scenario', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -95,6 +105,8 @@ describe('Get Windows password for RDP scenario', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/windows-rdp-info-connection.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/connections/windows-rdp-info-connection.test.js
@@ -30,7 +30,7 @@ describe('Get Windows password for RDP scenario', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/create-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/create-workspace-service-catalog.test.js
@@ -32,7 +32,7 @@ describe('Create workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
   beforeAll(async () => {
     setup = await runSetup();
 

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/create-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/create-workspace-service-catalog.test.js
@@ -14,6 +14,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { sleep } = require('@aws-ee/base-services/lib/helpers/utils');
 const { runSetup } = require('../../../../support/setup');
 
@@ -24,12 +25,14 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 const errorCode = require('../../../../support/utils/error-code');
 
 describe('Create workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
   beforeAll(async () => {
     setup = await runSetup();
 
@@ -40,6 +43,11 @@ describe('Create workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -135,16 +143,18 @@ describe('Create workspace-service-catalog scenarios', () => {
         setup,
       );
 
-      await expect(
-        adminSession.resources.workspaceServiceCatalogs.create({
-          name: workspaceName,
-          envTypeId: workspaceTypeId,
-          envTypeConfigId: configurationId,
-        }),
-      ).resolves.toMatchObject({
+      const response = await adminSession.resources.workspaceServiceCatalogs.create({
+        name: workspaceName,
         envTypeId: workspaceTypeId,
         envTypeConfigId: configurationId,
       });
+
+      expect(response).toMatchObject({
+        envTypeId: workspaceTypeId,
+        envTypeConfigId: configurationId,
+      });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should create if user role is allowed', async () => {
@@ -157,16 +167,18 @@ describe('Create workspace-service-catalog scenarios', () => {
         ['researcher'],
       );
 
-      await expect(
-        researcherSession.resources.workspaceServiceCatalogs.create({
-          name: workspaceName,
-          envTypeId: workspaceTypeId,
-          envTypeConfigId: configurationId,
-        }),
-      ).resolves.toMatchObject({
+      const response = await researcherSession.resources.workspaceServiceCatalogs.create({
+        name: workspaceName,
         envTypeId: workspaceTypeId,
         envTypeConfigId: configurationId,
       });
+
+      await expect(response).toMatchObject({
+        envTypeId: workspaceTypeId,
+        envTypeConfigId: configurationId,
+      });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
   describe('Workspace SC env with studies', () => {

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
@@ -30,7 +30,7 @@ describe('Delete workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
@@ -71,6 +71,8 @@ describe('Delete workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -93,6 +95,8 @@ describe('Delete workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is not owner of workspace', async () => {
@@ -115,6 +119,8 @@ describe('Delete workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should delete if user is admin', async () => {
@@ -157,6 +163,8 @@ describe('Delete workspace-service-catalog scenarios', () => {
       await expect(
         researcherSession.resources.workspaceServiceCatalogs.workspaceServiceCatalog(response.id).delete(),
       ).resolves.toEqual({});
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/delete-workspace-service-catalog.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 
 const {
@@ -22,12 +23,14 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 const errorCode = require('../../../../support/utils/error-code');
 
 describe('Delete workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Delete workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -126,6 +134,8 @@ describe('Delete workspace-service-catalog scenarios', () => {
       await expect(
         adminSession.resources.workspaceServiceCatalogs.workspaceServiceCatalog(response.id).delete(),
       ).resolves.toEqual({});
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should delete if user is owner of workspace', async () => {

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalog.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 
 const {
@@ -22,12 +23,14 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 const errorCode = require('../../../../support/utils/error-code');
 
 describe('Get workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Get workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -63,6 +71,8 @@ describe('Get workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -85,6 +95,8 @@ describe('Get workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user role is not owner', async () => {
@@ -107,6 +119,8 @@ describe('Get workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should pass if user role is owner', async () => {
@@ -131,6 +145,8 @@ describe('Get workspace-service-catalog scenarios', () => {
         envTypeId: workspaceTypeId,
         envTypeConfigId: configurationId,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should pass if user is admin', async () => {
@@ -153,6 +169,8 @@ describe('Get workspace-service-catalog scenarios', () => {
         envTypeId: workspaceTypeId,
         envTypeConfigId: configurationId,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalog.test.js
@@ -30,7 +30,7 @@ describe('Get workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalogs.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalogs.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 const errorCode = require('../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Get workspace-service-catalogs scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Get workspace-service-catalogs scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -73,7 +81,7 @@ describe('Get workspace-service-catalogs scenarios', () => {
         ['researcher'],
       );
 
-      await researcherSession.resources.workspaceServiceCatalogs.create({
+      const response = await researcherSession.resources.workspaceServiceCatalogs.create({
         name: workspaceName,
         envTypeId: workspaceTypeId,
         envTypeConfigId: configurationId,
@@ -84,6 +92,8 @@ describe('Get workspace-service-catalogs scenarios', () => {
           expect.objectContaining({ envTypeId: workspaceTypeId, envTypeConfigId: configurationId }),
         ]),
       );
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalogs.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/get-workspace-service-catalogs.test.js
@@ -30,7 +30,7 @@ describe('Get workspace-service-catalogs scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/start-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/start-workspace-service-catalog.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 const errorCode = require('../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Start workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Start workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -62,6 +70,8 @@ describe('Start workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -84,6 +94,8 @@ describe('Start workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is not owner of workspace', async () => {
@@ -106,6 +118,8 @@ describe('Start workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/start-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/start-workspace-service-catalog.test.js
@@ -30,7 +30,7 @@ describe('Start workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/stop-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/stop-workspace-service-catalog.test.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+const _ = require('lodash');
 const { runSetup } = require('../../../../support/setup');
 const errorCode = require('../../../../support/utils/error-code');
 
@@ -23,11 +24,13 @@ const {
   createDefaultServiceCatalogProduct,
   deleteDefaultServiceCatalogProduct,
 } = require('../../../../support/complex/default-integration-test-product');
+const { deleteWorkspaceServiceCatalog } = require('../../../../support/complex/delete-workspace-service-catalog');
 
 describe('Stop workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
+  let dummyWorkspacesToDelete;
 
   beforeAll(async () => {
     setup = await runSetup();
@@ -37,6 +40,11 @@ describe('Stop workspace-service-catalog scenarios', () => {
 
   afterAll(async () => {
     await deleteDefaultServiceCatalogProduct(setup, productInfo);
+    await Promise.all(
+      _.map(dummyWorkspacesToDelete, async envId => {
+        await deleteWorkspaceServiceCatalog({ aws: setup.aws, id: envId });
+      }),
+    );
     await setup.cleanup();
   });
 
@@ -62,6 +70,8 @@ describe('Stop workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
 
     it('should fail if user is anonymous', async () => {
@@ -84,6 +94,8 @@ describe('Stop workspace-service-catalog scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.badImplementation,
       });
+
+      dummyWorkspacesToDelete.push(response.id);
     });
   });
 
@@ -107,5 +119,7 @@ describe('Stop workspace-service-catalog scenarios', () => {
     ).rejects.toMatchObject({
       code: errorCode.http.code.forbidden,
     });
+
+    dummyWorkspacesToDelete.push(response.id);
   });
 });

--- a/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/stop-workspace-service-catalog.test.js
+++ b/main/integration-tests/__test__/api-tests/common/workspace-service-catalogs/stop-workspace-service-catalog.test.js
@@ -30,7 +30,7 @@ describe('Stop workspace-service-catalog scenarios', () => {
   let setup;
   let adminSession;
   let productInfo;
-  let dummyWorkspacesToDelete;
+  const dummyWorkspacesToDelete = [];
 
   beforeAll(async () => {
     setup = await runSetup();

--- a/main/integration-tests/support/complex/delete-workspace-service-catalog.js
+++ b/main/integration-tests/support/complex/delete-workspace-service-catalog.js
@@ -41,7 +41,12 @@ async function deleteWorkspaceServiceCatalog({ aws, id = '' }) {
       return;
     }
 
-    if (item.status === 'FAILED' || item.status === 'TERMINATED' || tryCount === 10) {
+    if (
+      item.status === 'FAILED' ||
+      item.status === 'TERMINATED' ||
+      item.status === 'TERMINATING_FAILED' ||
+      tryCount === 10
+    ) {
       await db.tables.environmentsSc
         .deleter()
         .key({ id })


### PR DESCRIPTION
Issue #, if available:
GALI-1249

Description of changes:
Service Workbench integration tests upon completion attempt to terminate provisioned workspaces. Some of these test workspaces are based on a temporary workspace config, which do not terminate fully (unsuccessful termination of these workspaces is expected, and does not impact test outcome).

However these are stored in the database with the status `TERMINATING_FAILED` message, and since they were linked to a temporary config, they show up as errored environment cards on the SWB UI. This could cause confusion, and potentially other tests to fail which depend on no workspaces being in the `TERMINATING_FAILED` state.

In the `afterAll` block of tests creating such workspaces, add logic to remove their entries completely from DDB.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.