### PR TITLE
fix: EMR launch failure because of bucket policy

### DIFF
--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -362,6 +362,7 @@ Resources:
                   - s3:PutBucketVersioning
                   - s3:PutBucketPolicy
                   - s3:GetBucketPolicy
+                  - s3:DeleteBucketPolicy
                 Resource: 'arn:aws:s3:::sc-*-logbucket-*'
               - Effect: Allow
                 Action:

--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -359,6 +359,9 @@ Resources:
                   - s3:PutBucketPublicAccessBlock
                   - s3:PutBucketTagging
                   - s3:PutEncryptionConfiguration
+                  - s3:PutBucketVersioning
+                  - s3:PutBucketPolicy
+                  - s3:GetBucketPolicy
                 Resource: 'arn:aws:s3:::sc-*-logbucket-*'
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Launching EMR workspaces was failing because of this error
```
The following resource(s) failed to create: [MasterSecurityGroup, ServiceRole, LogBucket, InstanceRolePermissionBoundary]. Rollback requested by user.}, {LogicalResourceId : MasterSecurityGroup, ResourceType : AWS::EC2::SecurityGroup, StatusReason : Resource creation cancelled}, {LogicalResourceId : ServiceRole, ResourceType : AWS::IAM::Role, StatusReason : Resource creation cancelled}, {LogicalResourceId : InstanceRolePermissionBoundary, ResourceType : AWS::IAM::ManagedPolicy, StatusReason : Resource creation cancelled}, {LogicalResourceId : LogBucket, ResourceType : AWS::S3::Bucket, StatusReason : API: s3:PutBucketVersioning Access Denied},
```

Root cause is the `LaunchConstraint` role didn't have access to update S3 bucket policy. This PR fixes that.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.