### PR TITLE
fix: cidr port range check

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
@@ -535,6 +535,48 @@ describe('EnvironmentScCidrService', () => {
       }
     });
 
+    it('should not call anything since request has invalid port numbers', async () => {
+      // BUILD
+      const requestContext = {};
+      let params = {
+        id: 'testId',
+        updateRequest: [
+          {
+            protocol: 'tcp',
+            fromPort: 65536,
+            toPort: 65536,
+            cidrBlocks: ['123.123.123.123/32'],
+          },
+        ],
+      };
+      // OPERATE
+      try {
+        await service.update(requestContext, params);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('The update request contains ports outside the allowed range 0-65535');
+      }
+
+      params = {
+        id: 'testId',
+        updateRequest: [
+          {
+            protocol: 'tcp',
+            fromPort: -10,
+            toPort: -10,
+            cidrBlocks: ['123.123.123.123/32'],
+          },
+        ],
+      };
+      // OPERATE
+      try {
+        await service.update(requestContext, params);
+        expect.hasAssertions();
+      } catch (err) {
+        expect(err.message).toEqual('The update request contains ports outside the allowed range 0-65535');
+      }
+    });
+
     it('should throw the exception as expected during internal errors for revoke', async () => {
       // BUILD
       const requestContext = {};

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-cidr-service.test.js
@@ -554,7 +554,7 @@ describe('EnvironmentScCidrService', () => {
         await service.update(requestContext, params);
         expect.hasAssertions();
       } catch (err) {
-        expect(err.message).toEqual('The update request contains ports outside the allowed range 0-65535');
+        expect(err.message).toEqual('Input has validation errors');
       }
 
       params = {
@@ -573,7 +573,7 @@ describe('EnvironmentScCidrService', () => {
         await service.update(requestContext, params);
         expect.hasAssertions();
       } catch (err) {
-        expect(err.message).toEqual('The update request contains ports outside the allowed range 0-65535');
+        expect(err.message).toEqual('Input has validation errors');
       }
     });
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
@@ -54,6 +54,14 @@ class EnvironmentScCidrService extends Service {
     const erroneousInputs = [];
     const ipv6Format = [];
     const protPortCombos = {};
+    if (
+      _.some(
+        updateRequest,
+        rule => rule.fromPort < 0 || rule.fromPort > 65535 || rule.toPort < 0 || rule.toPort > 65535,
+      )
+    ) {
+      throw this.boom.badRequest('The update request contains ports outside the allowed range 0-65535', true);
+    }
     _.map(updateRequest, rule => {
       _.forEach(rule.cidrBlocks, cidrBlock => {
         if (IsCidr(cidrBlock) === 0) erroneousInputs.push(cidrBlock);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-cidr-service.js
@@ -54,14 +54,6 @@ class EnvironmentScCidrService extends Service {
     const erroneousInputs = [];
     const ipv6Format = [];
     const protPortCombos = {};
-    if (
-      _.some(
-        updateRequest,
-        rule => rule.fromPort < 0 || rule.fromPort > 65535 || rule.toPort < 0 || rule.toPort > 65535,
-      )
-    ) {
-      throw this.boom.badRequest('The update request contains ports outside the allowed range 0-65535', true);
-    }
     _.map(updateRequest, rule => {
       _.forEach(rule.cidrBlocks, cidrBlock => {
         if (IsCidr(cidrBlock) === 0) erroneousInputs.push(cidrBlock);

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-environment-sc-cidr.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-environment-sc-cidr.json
@@ -6,10 +6,14 @@
       "type": "object",
       "properties": {
         "fromPort": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
         },
         "toPort": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
         },
         "protocol": {
           "type": "string"


### PR DESCRIPTION
Issue #, if available:
The "fromPort" and “toPort” parameters in the API for updating a workspace's CIDR does not throw errors when ports outside range 0-65535 are entered. Although the update request does not fail the changes do not persist.

Description of changes:
Explicitly throw errors when ports outside 0-65535 range are used for CIDR updates.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.