### PR TITLE
chore: rerun mainline protection check on PR edit

### DIFF
--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -18,7 +18,7 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v5.1
       - name: mainline protection
-        if: steps.branch-name.outputs.base_ref_branch == 'mainline' || steps.branch-name.outputs.base_ref_branch == 'smart-mainline'
+        if: steps.branch-name.outputs.base_ref_branch == 'mainline'
         run: |
           echo "PR has target branch ${{ steps.branch-name.outputs.base_ref_branch }}. Failing workflow..."
           exit 1

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -6,13 +6,19 @@
 name: Mainline Protection
 on:
   pull_request:
-    branches:
-      - mainline
+    types: [opened, synchronize, edited, reopened]
 # The purpose of this workflow is to create a failing Status check on pull request against mainline. This will prevent
 # PR from being merged into mainline.
 jobs:
   mainline-protection:
-    name: Only create PR against develop branch, not mainline branch
+    name: Only create PR against develop branches, not mainline branches
     runs-on: ubuntu-18.04
     steps:
-      - run: failing-command # An invalid bash command to trigger failure of this workflow
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: mainline protection
+        if: steps.branch-name.outputs.base_ref_branch == 'mainline' || steps.branch-name.outputs.base_ref_branch == 'smart-mainline'
+        run: |
+          echo "PR has target branch ${{ steps.branch-name.outputs.base_ref_branch }}. Failing workflow..."
+          exit 1

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -11,7 +11,7 @@ on:
 # PR from being merged into mainline.
 jobs:
   mainline-protection:
-    name: Only create PR against develop branches, not mainline branches
+    name: Only create PR against develop branch, not mainline branch
     runs-on: ubuntu-18.04
     steps:
       - name: Get branch name


### PR DESCRIPTION
Now we can simply change the branch to `develop` to rerun the mainline protection check instead of having to push an empty commit.

Same as https://github.com/awslabs/fhir-works-on-aws-deployment/pull/537

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.