### PR TITLE
fix: root users should be created later

### DIFF
--- a/addons/addon-base-post-deployment/packages/base-post-deployment/lib/plugins/steps-plugin.js
+++ b/addons/addon-base-post-deployment/packages/base-post-deployment/lib/plugins/steps-plugin.js
@@ -29,9 +29,9 @@ const CreateJwtKeyService = require('../steps/create-jwt-key-service');
 async function getSteps(existingStepsMap, pluginRegistry) {
   const stepsMap = new Map([
     ...existingStepsMap,
-    ['createRootUser', new CreateRootUserService()],
     ['createJwtKeyService', new CreateJwtKeyService()],
     ['addAuthProviders', new AddAuthProviders()],
+    ['createRootUser', new CreateRootUserService()],
   ]);
 
   return stepsMap;


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Root user creation should occur after authN providers are added.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.