### PR TITLE
fix: username should be in email format

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-user.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/create-user.json
@@ -7,13 +7,13 @@
       "type": "string",
       "minLength": 3,
       "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "format": "email",
+      "pattern": "^([^.%+!$&*=^|~#%{}]+)[a-zA-Z0-9\\._%+!$&*=^|~#%{}/\\-]+([^.!]+)@([^-.!](([a-zA-Z0-9\\-]+\\.){1,}([a-zA-Z]{2,3})))"
     },
     "usernameInIdp": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "maxLength": 300
     },
     "password": {
       "type": "string"
@@ -26,7 +26,7 @@
     },
     "email": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "pattern": "^([^.%+!$&*=^|~#%{}]+)[a-zA-Z0-9\\._%+!$&*=^|~#%{}/\\-]+([^.!]+)@([^-.!](([a-zA-Z0-9\\-]+\\.){1,}([a-zA-Z]{2,3})))"
     },
     "firstName": {
       "type": "string",

--- a/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-user.json
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/schema/update-user.json
@@ -8,13 +8,12 @@
     },
     "email": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "pattern": "^([^.%+!$&*=^|~#%{}]+)[a-zA-Z0-9\\._%+!$&*=^|~#%{}/\\-]+([^.!]+)@([^-.!](([a-zA-Z0-9\\-]+\\.){1,}([a-zA-Z]{2,3})))"
     },
     "usernameInIdp": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "maxLength": 300
     },
     "firstName": {
       "type": "string",

--- a/addons/addon-base/packages/services/lib/schema/create-user.json
+++ b/addons/addon-base/packages/services/lib/schema/create-user.json
@@ -7,13 +7,13 @@
       "type": "string",
       "minLength": 3,
       "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "format": "email",
+      "pattern": "^([^.%+!$&*=^|~#%{}]+)[a-zA-Z0-9\\._%+!$&*=^|~#%{}/\\-]+([^.!]+)@([^-.!](([a-zA-Z0-9\\-]+\\.){1,}([a-zA-Z]{2,3})))"
     },
     "usernameInIdp": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "maxLength": 300
     },
     "password": {
       "type": "string"

--- a/addons/addon-base/packages/services/lib/schema/update-user.json
+++ b/addons/addon-base/packages/services/lib/schema/update-user.json
@@ -9,12 +9,11 @@
     "usernameInIdp": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 300,
-      "pattern": "^[A-Za-z0-9-_.]+$|^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "maxLength": 300
     },
     "email": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$"
+      "pattern": "^([^.%+!$&*=^|~#%{}]+)[a-zA-Z0-9\\._%+!$&*=^|~#%{}/\\-]+([^.!]+)@([^-.!](([a-zA-Z0-9\\-]+\\.){1,}([a-zA-Z]{2,3})))"
     },
     "firstName": {
       "type": "string",

--- a/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
@@ -88,7 +88,7 @@ describe('UserService', () => {
     it('should fail because password cannot be provided with federated users', async () => {
       // BUILD
       const newUser = {
-        username: 'tlannister',
+        username: 'dragonsrkool@example.com',
         email: 'dragonsrkool@example.com',
         firstName: 'Tirion',
         lastName: 'Lannister',
@@ -109,7 +109,7 @@ describe('UserService', () => {
     it('should fail because user already exists', async () => {
       // BUILD
       const newUser = {
-        username: 'jsnow',
+        username: 'nightwatch@example.com',
         email: 'nightwatch@example.com',
         firstName: 'Jon',
         lastName: 'Snow',
@@ -129,7 +129,7 @@ describe('UserService', () => {
     it('should not save user password to the DB', async () => {
       // BUILD
       const newUser = {
-        username: 'hpie',
+        username: 'sourcherries@example.com',
         email: 'sourcherries@example.com',
         firstName: 'Hot',
         lastName: 'Pie',
@@ -150,7 +150,7 @@ describe('UserService', () => {
     it('should try to create a user', async () => {
       // BUILD
       const newUser = {
-        username: 'nstark',
+        username: 'headlesshorseman@example.com',
         email: 'headlesshorseman@example.com',
         firstName: 'Ned',
         lastName: 'Stark',
@@ -185,7 +185,7 @@ describe('UserService', () => {
     it.each(validEmails)('should pass when creating users with valid email: %p', async email => {
       // BUILD
       const newUser = {
-        username: 'nstark',
+        username: email,
         email,
         firstName: 'Ned',
         lastName: 'Stark',
@@ -223,7 +223,7 @@ describe('UserService', () => {
     it.each(invalidEmails)('should fail when creating users with invalid email: %p', async email => {
       // BUILD
       const newUser = {
-        username: 'nstark',
+        username: email,
         email,
         firstName: 'Ned',
         lastName: 'Stark',
@@ -246,7 +246,7 @@ describe('UserService', () => {
     const uid = 'u-testUpdateUserId';
     const newUser = {
       uid,
-      username: 'dtargaryen',
+      username: 'dragonseverywhere@example.com',
       email: 'dragonseverywhere@example.com',
       firstName: 'Daenerys',
       lastName: 'Targaryen',
@@ -254,7 +254,7 @@ describe('UserService', () => {
     it('should fail because no value of rev was provided', async () => {
       // BUILD
       const toUpdate = {
-        username: 'dtargaryen',
+        username: 'dragonseverywhere@example.com',
       };
 
       service.findUser = jest.fn().mockResolvedValue(newUser);
@@ -334,7 +334,7 @@ describe('UserService', () => {
     const uid = 'u-testDeleteUserId';
     const curUser = {
       uid,
-      username: 'astark',
+      username: 'ilovemasks@example.com',
       email: 'ilovemasks@example.com',
       firstName: 'Arya',
       lastName: 'Stark',
@@ -348,7 +348,7 @@ describe('UserService', () => {
 
       // OPERATE
       try {
-        await service.deleteUser({}, { username: 'lskywalker' });
+        await service.deleteUser({}, { username: 'ilovemasks@example.com' });
         expect.hasAssertions();
       } catch (err) {
         // CHECK


### PR DESCRIPTION
Issue #, if available:
V377389529

Description of changes:
Username validation should be enforced on server-side.
`usernameInIdp` could be in non-email format for external IdPs, so removing regex pattern from it (it was anyways unenforced, just like `username`)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.