### PR TITLE
fix: notify api returns internal error on malformed id

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -75,7 +75,7 @@ class DataEgressService extends Service {
     }
 
     if (!egressStoreResult) {
-      return null;
+      throw this.boom.notFound(`Error: unable to find Egress Store in environment ${environmentId}.`);
     }
     return egressStoreResult;
   }

--- a/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/data-egress/data-egress-service.js
@@ -75,7 +75,7 @@ class DataEgressService extends Service {
     }
 
     if (!egressStoreResult) {
-      throw this.boom.notFound(`Error: unable to find Egress Store in environment ${environmentId}.`);
+      return null;
     }
     return egressStoreResult;
   }
@@ -312,6 +312,9 @@ class DataEgressService extends Service {
     }
 
     const egressStoreInfo = await this.getEgressStoreInfo(environmentId);
+    if (!egressStoreInfo) {
+      throw this.boom.notFound(`Error: egress store info not found for environment ${environmentId}!`, true);
+    }
     const isEgressStoreOwner = egressStoreInfo.createdBy === curUser;
     if (!isAdmin(requestContext) && !isEgressStoreOwner) {
       throw this.boom.forbidden(


### PR DESCRIPTION
Issue #, if available: (AppSec) V444731886

Description of changes:
Looks like the `getEgressStore` method can return a null value that is immediately accessed in `data-egress-service.js` (lines 314-315).

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [X] Have you successfully deployed to an AWS account with your changes?
- [X] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.