### PR TITLE
test: Add Cognito creds for Integration and E2E tests

### DIFF
--- a/main/end-to-end-tests/cypress.appstream-egress.json
+++ b/main/end-to-end-tests/cypress.appstream-egress.json
@@ -9,7 +9,8 @@
     "researcherPassword": "<RESEARCHER ACCOUNT PASSWORD>",
     "adminEmail": "<EMAIL ACCOUNT OF PREMADE ADMIN>",
     "adminPassword": "<ADMIN ACCOUNT PASSWORD>",
-    "isCognitoEnabled": false,
+    "cognitoUserPoolId": "<COGNITO USER POOL ID>",
+    "cognitoClientId": "<COGNITO CLIENT ID>",
     "workspaces": {
       "sagemaker": {
         "workspaceTypeName": "<NAME OF SAGEMAKER WORKSPACE TYPE>",

--- a/main/end-to-end-tests/cypress.github.appstream-egress.json
+++ b/main/end-to-end-tests/cypress.github.appstream-egress.json
@@ -5,7 +5,8 @@
   "video": false,
   "env": {
     "isAppStreamEnabled": true,
-    "isCognitoEnabled": true,
+    "cognitoUserPoolId": "us-east-1_26lGvVl08",
+    "cognitoClientId": "3do9bsosfmol7r7hdnutbn5tup",
     "workspaces": {
       "sagemaker": {
         "workspaceTypeName": "SageMaker Notebook-v5",

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -5,7 +5,8 @@
   "video": false,
   "env": {
     "isAppStreamEnabled": false,
-    "isCognitoEnabled": true,
+    "cognitoUserPoolId": "us-east-1_fGB4nQKqN",
+    "cognitoClientId": "6dmj4qhbihtkigcbsjo346hjmi",
     "workspaces": {
       "sagemaker": {
         "workspaceTypeName": "SageMaker Notebook-v4",


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Updated e2e tests creds that is stored in Github config files
* We still need to update S3 config file for Int Tests and Github Secrets. However, that cannot be done until we merge the feature branch to `develop`. If we update those configs now, the current tests will not run correctly. 


AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.