### PR TITLE
fix: create aws account exc

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/aws-accounts/aws-accounts-service.js
@@ -142,7 +142,17 @@ class AwsAccountsService extends Service {
         Version: '2012-10-17',
         Statement: [...securityStatements, listStatement, getStatement],
       });
-      return s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy }).promise();
+
+      let response;
+      try {
+        response = await s3Client.putBucketPolicy({ Bucket: s3BucketName, Policy }).promise();
+      } catch (err) {
+        throw this.boom.badRequest(
+          `Could not update bucket policy for bucket "${s3BucketName}". Error code: ${err.code}`,
+          true,
+        );
+      }
+      return response;
     });
   }
 


### PR DESCRIPTION
Issue #, if available:
V377389564

Description of changes:
Catch errors from S3 bucket policy update logic to only display error code instead of entire stack trace.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.