### PR TITLE
fix: Reduce scope of list users API for non admin users

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/__tests__/user-service.test.js
@@ -37,6 +37,7 @@ jest.mock('@aws-ee/base-services/lib/settings/env-settings-service');
 const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-settings-service');
 
 jest.mock('../../user-roles/user-roles-service');
+const _ = require('lodash');
 const UserRolesServiceMock = require('../../user-roles/user-roles-service');
 
 const UserService = require('../user-service');
@@ -337,11 +338,21 @@ describe('UserService', () => {
       identityProviderId: 'ned2',
     };
 
-    it('should list all users', async () => {
+    it('admin: should list all users with all fields', async () => {
       // OPERATE
       dbService.table.scan.mockResolvedValueOnce([user1, user2]);
       const result = await service.listUsers({ principal: { isAdmin: true } }, {});
       expect(result).toEqual([user1, user2]);
+    });
+
+    it('researcher: should list all users with subset of fields', async () => {
+      // OPERATE
+      dbService.table.scan.mockResolvedValueOnce([user1, user2]);
+      const result = await service.listUsers({ principal: { isAdmin: false } }, {});
+      const expectedUser1 = _.pick(user1, ['firstName', 'lastName', 'email', 'uid', 'username']);
+      const expectedUser2 = _.pick(user2, ['firstName', 'lastName', 'email', 'uid', 'username']);
+
+      expect(result).toEqual([expectedUser1, expectedUser2]);
     });
   });
 });

--- a/addons/addon-base-raas/packages/base-raas-services/lib/user/user-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/user/user-service.js
@@ -161,8 +161,12 @@ class UserService extends BaseUserService {
 
     const isAdmin = _.get(requestContext, 'principal.isAdmin', false);
 
-    const fieldsToOmit = isAdmin ? ['encryptedCreds'] : ['encryptedCreds', 'userRole'];
-    const sanitizedUsers = users.map(user => _.omit(user, fieldsToOmit));
+    let sanitizedUsers = [];
+    if (isAdmin) {
+      sanitizedUsers = users.map(user => _.omit(user, ['encryptedCreds']));
+    } else {
+      sanitizedUsers = users.map(user => _.pick(user, ['firstName', 'lastName', 'email', 'uid', 'username']));
+    }
     return sanitizedUsers;
   }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Reduce the number of fields that is returned by the list users API when the requester is a `researcher`. We will only return these fields `['firstName', 'lastName', 'email', 'uid', 'username']`.

**Testing:**  
* Checked that researchers can still edit the user permissions in `Org studies`
* Checked the researchers can still navigate to `Workspace` page and launch workspaces

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.