### PR TITLE
chore: Migrate api integ tests

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/migration/__tests__/migration-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/migration/__tests__/migration-service.test.js
@@ -191,7 +191,7 @@ describe('migrationService', () => {
     it('should output a message when migration is not needed', async () => {
       // BUILD
       const requestContext = createAdminContext();
-      const expectedResult = 'No My Studies are owned my internal users. No migration needed.';
+      const expectedResult = [];
       dbService.table.query = jest.fn().mockResolvedValueOnce([{ id: 'my-study-1' }, { id: 'my-study-2' }]);
       studyService.getStudyPermissions = jest
         .fn()

--- a/addons/addon-base-raas/packages/base-raas-services/lib/migration/migration-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/migration/migration-service.js
@@ -87,7 +87,7 @@ class MigrationService extends Service {
       .limit(1000)
       .query();
 
-    let helpfulResult = await Promise.all(
+    const helpfulResult = await Promise.all(
       await result.map(async study => {
         const currentStudyPermissions = await studyService.getStudyPermissions(requestContext, study.id);
         const currentOwner = currentStudyPermissions.permissions.adminUsers[0];

--- a/addons/addon-base-raas/packages/base-raas-services/lib/migration/migration-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/migration/migration-service.js
@@ -107,9 +107,7 @@ class MigrationService extends Service {
       }),
     );
 
-    helpfulResult = helpfulResult.filter(study => study.authProvider === 'internal');
-
-    return helpfulResult.length > 0 ? helpfulResult : 'No My Studies are owned my internal users. No migration needed.';
+    return helpfulResult.filter(study => study.authProvider === 'internal');
   }
 }
 

--- a/docs/docs/installation_guide/upgrading/authentication.md
+++ b/docs/docs/installation_guide/upgrading/authentication.md
@@ -187,7 +187,7 @@ We will be using API calls to migrate My Study resources.<a name="migrating"></a
 1. If you do not know which My Study resources you need to migrate, first use the `{{baseUrl}}/api/migrate/my-studies GET` API. When using Postman, make sure you have a valid token in your environment variable. For more information on how to get this token, see [Getting authentication token](#token).     
    + In the Collections or APIs section, navigate to the `service-workbench-on-aws/api/migrate/my-studies` API.    
    + Choose **GET list My Study(s)** in environment.     
-   +  Choose **Send**. Either the response will contain a list of My Study Ids and current owner user IDs or it will say `"No My Studies are owned my internal users. No migration needed."` In the latter case, nothing more is needed to be done in this section.   
+   +  Choose **Send**. The response will either be an empty list or a list of My Study Ids and current owner user IDs. In the former case, nothing more is needed to be done in this section as no migration of My Study resources is needed.   
    + For command line, make sure you have a valid token. For more information on how to get this token, see [Getting authentication token](#token). In your terminal paste and substitute the following:
            ```
            curl --location --request GET 'https://{{baseUrl}}/api/migrate/my-studies' \

--- a/main/integration-tests/__test__/api-tests/common/migration/my-study-migration.test.js
+++ b/main/integration-tests/__test__/api-tests/common/migration/my-study-migration.test.js
@@ -65,7 +65,7 @@ describe('Migration for My Studies scenarios', () => {
       await researcherSession.resources.studies.create({ id: studyId, name: studyId, category: 'My Studies' });
       await researcherSession.resources.studies.study(studyId);
 
-      const body = [{ studyId: studyId, uid: defaultUser.uid }];
+      const body = [{ studyId, uid: defaultUser.uid }];
       await expect(researcherSession.resources.migration.migrateMyStudyOwnership(body)).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
@@ -77,7 +77,7 @@ describe('Migration for My Studies scenarios', () => {
       await adminSession.resources.studies.create({ id: studyId, name: studyId, category: 'My Studies' });
       await adminSession.resources.studies.study(studyId);
 
-      const body = [{ studyId: studyId, uid: defaultUser.uid }];
+      const body = [{ studyId, uid: defaultUser.uid }];
       const expectedContents = {
         category: 'My Studies',
         id: studyId,

--- a/main/integration-tests/__test__/api-tests/common/migration/my-study-migration.test.js
+++ b/main/integration-tests/__test__/api-tests/common/migration/my-study-migration.test.js
@@ -1,0 +1,95 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const { runSetup } = require('../../../../support/setup');
+const errorCode = require('../../../../support/utils/error-code');
+
+describe('Migration for My Studies scenarios', () => {
+  let setup;
+  let adminSession;
+  let defaultUser;
+  let defaultUserSession;
+
+  beforeAll(async () => {
+    setup = await runSetup();
+    adminSession = await setup.defaultAdminSession();
+    // Create cognito user to migrate ownership to
+    // Proper way that currently doesn't work:
+    // const username = setup.gen.username();
+    // defaultUser = adminSession.resources.users.defaults({ username });
+    // defaultUser = await await adminSession.resources.users.create(defaultUser);
+    // await adminSession.resources.users.user(defaultUser.uid);
+    // Workaround:
+    defaultUserSession = await setup.createResearcherSession();
+    defaultUser = defaultUserSession.user;
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  describe('Getting My Studies', () => {
+    it('should fail if request not by admin', async () => {
+      const researcherSession = await setup.createResearcherSession();
+      await expect(researcherSession.resources.migration.listInternaAuthUserMyStudies()).rejects.toMatchObject({
+        code: errorCode.http.code.forbidden,
+      });
+    });
+
+    it('should return message that there is nothing to migrate', async () => {
+      await expect(adminSession.resources.migration.listInternaAuthUserMyStudies()).resolves.toStrictEqual(
+        'No My Studies are owned my internal users. No migration needed.',
+      );
+    });
+  });
+
+  describe('Migrating My Studies', () => {
+    let studyId;
+
+    it('should fail if request not by admin', async () => {
+      const researcherSession = await setup.createResearcherSession();
+      // Create My Study
+      studyId = setup.gen.string({ prefix: `create-my-study-test` });
+      await researcherSession.resources.studies.create({ id: studyId, name: studyId, category: 'My Studies' });
+      await researcherSession.resources.studies.study(studyId);
+
+      const body = [{ studyId: studyId, uid: defaultUser.uid }];
+      await expect(researcherSession.resources.migration.migrateMyStudyOwnership(body)).rejects.toMatchObject({
+        code: errorCode.http.code.forbidden,
+      });
+    });
+
+    it('should succeed if end user is non internal and fail on reattempt after success', async () => {
+      // Create My Study
+      studyId = setup.gen.string({ prefix: `create-my-study-test` });
+      await adminSession.resources.studies.create({ id: studyId, name: studyId, category: 'My Studies' });
+      await adminSession.resources.studies.study(studyId);
+
+      const body = [{ studyId: studyId, uid: defaultUser.uid }];
+      const expectedContents = {
+        category: 'My Studies',
+        id: studyId,
+        name: studyId,
+      };
+
+      await expect(adminSession.resources.migration.migrateMyStudyOwnership(body)).resolves.toMatchObject([
+        expect.objectContaining(expectedContents),
+      ]);
+      await expect(adminSession.resources.migration.migrateMyStudyOwnership(body)).rejects.toMatchObject({
+        code: errorCode.http.code.badRequest,
+      });
+    });
+  });
+});

--- a/main/integration-tests/support/resources.js
+++ b/main/integration-tests/support/resources.js
@@ -36,6 +36,7 @@ const Budgets = require('./resources/budgets/budgets');
 const WorkspaceServiceCatalogs = require('./resources/workspace-service-catalogs/workspace-service-catalogs');
 const Workflows = require('./resources/workflows/workflows');
 const DataEgresses = require('./resources/data-egress/data-egresses');
+const Migration = require('./resources/migration/migration');
 
 // Returns the top level resource operations helpers. You should not use this directly in your tests.
 // These top level resource operation helpers are available via client sessions.
@@ -64,6 +65,7 @@ async function getResources({ clientSession }) {
     workspaceServiceCatalogs: new WorkspaceServiceCatalogs({ clientSession }),
     workflows: new Workflows({ clientSession }),
     dataEgresses: new DataEgresses({ clientSession }),
+    migration: new Migration({ clientSession }),
   };
 
   return resources;

--- a/main/integration-tests/support/resources/migration/migration.js
+++ b/main/integration-tests/support/resources/migration/migration.js
@@ -1,0 +1,41 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+const _ = require('lodash');
+
+const Resource = require('../base/resource');
+
+class Migration extends Resource {
+  constructor({ clientSession }) {
+    super({ clientSession, type: 'migration' });
+
+    this.api = 'api/migrate';
+  }
+
+  // ************************ Helpers methods ************************
+  listInternaAuthUserMyStudies() {
+    const api = `${this.api}/my-studies`;
+
+    return this.doCall(async () => this.axiosClient.get(api));
+  }
+
+  migrateMyStudyOwnership(body) {
+    const api = `${this.api}/my-studies`;
+
+    return this.doCall(async () => this.axiosClient.put(api, body));
+  }
+}
+
+module.exports = Migration;

--- a/main/integration-tests/support/resources/migration/migration.js
+++ b/main/integration-tests/support/resources/migration/migration.js
@@ -13,8 +13,6 @@
  *  permissions and limitations under the License.
  */
 
-const _ = require('lodash');
-
 const Resource = require('../base/resource');
 
 class Migration extends Resource {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2150,7 +2150,7 @@ paths:
       operationId: listMyStudies
       responses:
         '200':
-          description: 'Return My Study(s) for environment'
+          description: 'Return My Study(s) owned by internal auth users that need migration. Empty list means nothing to migrate.'
   
 components:
   securitySchemes:


### PR DESCRIPTION
Issue #, if available: GALI-1375

Description of changes: add integration tests to test api/migrate/my-studies GET and PUT. Test cases:
Call list my studies (GET)
    Should fail if request not by admin
    Should return message that there is nothing to migrate if admin
Migrate my study to non internal user (PUT)
    Should fail if request not by admin
    Should succeed if end user is not internal and should fail if attempting to transfer to same non internal user


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you written new tests for your core changes, as applicable?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.