### PR TITLE
fix: better internal auth error messages

### DIFF
--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/authentication-provider-config-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/authentication-provider-config-service.js
@@ -47,6 +47,12 @@ class AuthenticationProviderConfigService extends Service {
   }
 
   async getAuthenticationProviderConfig(providerId, fields = []) {
+    if (providerId === 'internal') {
+      throw this.boom.badRequest(
+        'Internal users cannot log in. Please use an external IdP or native Cognito user pool user.',
+        true,
+      );
+    }
     const dbService = await this.service('dbService');
     const table = this.settings.get(settingKeys.tableName);
     const dbResult = await dbService.helper

--- a/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
+++ b/addons/addon-base/packages/services/lib/user/__tests__/user-service.test.js
@@ -224,6 +224,31 @@ describe('UserService', () => {
         expect(err.message).toEqual('Input has validation errors');
       }
     });
+
+    it('should fail when creating internal auth users', async () => {
+      // BUILD
+      const email = 'test@example.com';
+      const newUser = {
+        username: email,
+        email,
+        firstName: 'Ned',
+        lastName: 'Stark',
+        authenticationProviderId: 'internal',
+      };
+      service.getUserByPrincipal = jest.fn();
+      service.audit = jest.fn();
+
+      // OPERATE
+      try {
+        await service.createUser({}, newUser);
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(err.message).toEqual(
+          'Internal users cannot be created. Please use an external IdP or the native Cognito user pool',
+        );
+      }
+    });
   });
 
   describe('updateUser', () => {

--- a/addons/addon-base/packages/services/lib/user/user-service.js
+++ b/addons/addon-base/packages/services/lib/user/user-service.js
@@ -60,11 +60,12 @@ class UserService extends Service {
     delete user.password;
 
     // ensure that an internal user is not created in this request
-    if (_.isUndefined(user.authenticationProviderId))
+    if (_.isUndefined(user.authenticationProviderId) || user.authenticationProviderId === 'internal') {
       throw this.boom.badRequest(
         'Internal users cannot be created. Please use an external IdP or the native Cognito user pool',
         true,
       );
+    }
 
     const authenticationProviderId = user.authenticationProviderId;
     if (password && authenticationProviderId !== 'internal') {


### PR DESCRIPTION
Issue #, if available: GALI-1388

Description of changes: Add better messaging and error catching for log in attempt or create user attempt for internal auth user

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.