### PR TITLE
fix: reorder pre dep checks

### DIFF
--- a/addons/addon-internal-auth-dep-check/packages/internal-auth-dep-check/lib/steps/internal-auth-dep-check-service.js
+++ b/addons/addon-internal-auth-dep-check/packages/internal-auth-dep-check/lib/steps/internal-auth-dep-check-service.js
@@ -51,8 +51,6 @@ class InternalAuthDepCheckService extends Service {
       internalUserProjectBlockers,
     } = await this._listInternalUsers();
 
-    // Verify all internal users (including root) are deactivated
-    blockers.activeUsers = activeUserBlockers;
     // Verify internal users are not linked to projects
     blockers.projects = internalUserProjectBlockers;
 
@@ -70,6 +68,9 @@ class InternalAuthDepCheckService extends Service {
     // Verify internal users are not linked to Org Studies
     const orgStudiesBlockers = await this.verifyNoInternalUserOrgStudies(listOfInternalUsers, listOfInternalUsernames);
     blockers.orgStudies = orgStudiesBlockers;
+
+    // LASTLY, verify all internal users (including root) are deactivated
+    blockers.activeUsers = activeUserBlockers;
 
     if (Object.keys(blockers).length > 0) {
       const compositeError = this.createBlockerReport(blockers);


### PR DESCRIPTION
Issue #, if available:

Description of changes: Reorder pre deployment checks so deactivating internal users is listed last to avoid confusion since users should be deactivated last after other resources are resolved.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.