### PR TITLE
fix: Allow CICD pipeline to have cognito permission for creating root user

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -413,6 +413,14 @@ Resources:
                 - !Sub 'arn:aws:catalog:${AWS::Region}:${AWS::AccountId}:product/*'
                 - !Sub arn:${AWS::Partition}:catalog:${AWS::Region}:${AWS::AccountId}:*
             - !Ref AWS::NoValue
+          - !If
+            - RunTestsAgainstTargetEnv
+            - Effect: 'Allow'
+              Action:
+                - cognito-idp:AdminInitiateAuth
+              Resource:
+                - !Sub 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*'
+            - !Ref AWS::NoValue
 
   AppDeployerRole:
     Type: AWS::IAM::Role

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -418,6 +418,8 @@ Resources:
             - Effect: 'Allow'
               Action:
                 - cognito-idp:AdminInitiateAuth
+                - cognito-idp:AdminDeleteUser
+                - cognito-idp:SignUp
               Resource:
                 - !Sub 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*'
             - !Ref AWS::NoValue


### PR DESCRIPTION


Issue #, if available:

Description of changesfix: 

Allow CICD pipeline to have cognito permission for creating root user

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.