### PR TITLE
fix: Test error because window open events are not stubbed for E2E tests

### DIFF
--- a/main/end-to-end-tests/cypress/support/commands.js
+++ b/main/end-to-end-tests/cypress/support/commands.js
@@ -93,6 +93,11 @@ Cypress.Commands.add('login', role => {
     });
   });
   cy.wrap(authResult);
-  cy.visit('/dashboard');
+  cy.visit('/dashboard', {
+    onBeforeLoad(window) {
+      // Allows us to check for window open event
+      cy.stub(window, 'open');
+    },
+  });
   cy.get("div[data-testid='page-title'] div").contains('Dashboard');
 });


### PR DESCRIPTION
Issue #, if available:

Description of changes:
test: Stub window open events for E2E tests


This fix this bug
```
  1) Launch new workspaces
       should launch Sagemaker, Linux, Windows, and RStudio workspaces successfully:
     TypeError: Timed out retrying: [Function: open] is not a spy or a call to a spy!
      at assertCanWorkWith (***/__cypress/runner/cypress_runner.js:1354:19)
      at Proxy.<anonymous> (***/__cypress/runner/cypress_runner.js:1405:13)
      at Proxy.methodWrapper (***/__cypress/runner/cypress_runner.js:80018:25)
      at applyChainer (***/__cypress/runner/cypress_runner.js:153811:32)
      at ***/__cypress/runner/cypress_runner.js:153853:16
      at arrayReduce (***/__cypress/runner/cypress_runner.js:25407:21)
      at Function.reduce (***/__cypress/runner/cypress_runner.js:34431:14)
      at applyChainers (***/__cypress/runner/cypress_runner.js:153842:22)
      at tryCatcher (***/__cypress/runner/cypress_runner.js:9956:23)
      at Function.Promise.attempt.Promise.try (***/__cypress/runner/cypress_runner.js:7230:29)
      at Context.shouldFn (***/__cypress/runner/cypress_runner.js:153859:26)
      at Context.should (***/__cypress/runner/cypress_runner.js:153877:23)
      at ***/__cypress/runner/cypress_runner.js:149652:39
      at assertions (***/__cypress/runner/cypress_runner.js:149913:14)
      at tryCatcher (***/__cypress/runner/cypress_runner.js:9956:23)
      at Object.gotValue (***/__cypress/runner/cypress_runner.js:9100:18)
```
https://github.com/awslabs/service-workbench-on-aws/runs/5147184129?check_suite_focus=true
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.