### PR TITLE
fix: Allow users to go back and fix configuration errors

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/data-sources/register/RegisterStudyWizard.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/data-sources/register/RegisterStudyWizard.js
@@ -117,6 +117,10 @@ const RegisterStudyWizard = types
       }
     },
 
+    goToInputStep: () => {
+      self.step = 'input';
+    },
+
     cleanup: () => {
       self.step = 'start';
       if (self.operations) self.operations.clear();

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/data-sources/register/SubmitStep.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/data-sources/register/SubmitStep.js
@@ -61,6 +61,10 @@ class SubmitStep extends React.Component {
     goto('/data-sources');
   };
 
+  handlePrevious = () => {
+    this.wizard.goToInputStep();
+  };
+
   handleRetry = () => {
     swallowError(this.wizard.retry());
   };
@@ -122,6 +126,9 @@ class SubmitStep extends React.Component {
         <Message.Header>Failures have occurred</Message.Header>
         <p>It seems that one or more steps have failed while registration. Please fix the errors and retry.</p>
         <p>
+          You can click the &#39;Previous&#39; button to go back fix the configuration error shown in the steps above.
+        </p>
+        <p>
           If you wish to proceed anyway with creating/updating the CloudFormation stack, resources corresponding to the
           failed steps might not be reflected in the CloudFormation template.
         </p>
@@ -177,6 +184,7 @@ class SubmitStep extends React.Component {
     const showNext = !allFailed && (failure || success);
     const showRetry = allFailed || failure;
     const showCancel = showRetry;
+    const showPrevious = failure;
 
     return (
       <div className="mt3">
@@ -209,6 +217,15 @@ class SubmitStep extends React.Component {
 
         {showCancel && (
           <Button floated="right" className="ml2" content="Cancel" disabled={disabled} onClick={this.handleCancel} />
+        )}
+        {showPrevious && (
+          <Button
+            floated="right"
+            className="ml2"
+            content="Previous"
+            disabled={disabled}
+            onClick={this.handlePrevious}
+          />
         )}
       </div>
     );


### PR DESCRIPTION
Issue #, if available:

Description of changes:
**Summary of issue**
When a user provide invalid input, they get an error, but there is no way for them to change their inputs. In this particular case the error stems from the user providing a study name that is not globally unique. When we detect that the study name is invalid, we need to let them know and let them change the study name.

**Solution**
We add a "Previous" button and instructions on how they can fix their input error. Screenshot attached 

![study-name-error](https://user-images.githubusercontent.com/3661906/155384325-7ce0f387-60b0-472f-83d5-aabd8d575ee4.png)




Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
