### PR TITLE
fix: wide cidr warning and env config dep

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/CreateInternalEnvForm.js
@@ -44,19 +44,17 @@ const getFields = ({ projectIdOptions, cidr }) => {
       placeholder: 'The configuration for the research workspace',
       rules: 'required',
     },
-  };
-
-  if (!_.isUndefined(cidr)) {
-    fields.cidr = {
+    cidr: {
       label: 'Restricted CIDR',
       extra: {
-        explain: `This research workspace will only be reachable from this CIDR. You can get your organization's CIDR range from your IT department. The provided default is the CIDR that restricts to your IP address.`,
+        explain: `This research workspace will only be reachable from this CIDR. You can get your organization's CIDR range from your IT department. The provided default is the CIDR that restricts to your IP address.
+          Note: An environment config with a hardcoded CIDR will overwrite this value.`,
       },
       placeholder: 'The CIDR range to restrict research workspace access to',
       rules: 'required|cidr',
-      value: cidr,
-    };
-  }
+      value: !_.isUndefined(cidr) ? cidr : '',
+    },
+  };
 
   return fields;
 };

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -16,7 +16,7 @@ import _ from 'lodash';
 import React from 'react';
 import { decorate, computed, runInAction, observable, action } from 'mobx';
 import { observer, inject } from 'mobx-react';
-import { Segment, Button, Header, Icon } from 'semantic-ui-react';
+import { Segment, Button, Header, Icon, Message } from 'semantic-ui-react';
 import { displayError } from '@aws-ee/base-ui/dist/helpers/notification';
 import Dropdown from '@aws-ee/base-ui/dist/parts/helpers/fields/DropDown';
 import Form from '@aws-ee/base-ui/dist/parts/helpers/fields/Form';
@@ -164,6 +164,7 @@ class CreateInternalEnvForm extends React.Component {
     const form = this.form;
     const askForCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
     const configurations = this.configurations;
+    const field = form.$('cidr');
 
     // we show the AppStream configuration warning when the feature is enabled,
     // and the user's projects are not linked to AppStream-configured accounts
@@ -175,10 +176,19 @@ class CreateInternalEnvForm extends React.Component {
     return (
       <Segment clearing className="p3 mb3">
         <Form form={form} onCancel={this.handlePrevious} onSuccess={this.handleNext}>
-          {({ processing, /* onSubmit, */ onCancel }) => (
+          {({ processing, onCancel }) => (
             <>
               <Input dataTestId="workspace-name" field={form.$('name')} />
-              {askForCidr && <Input field={form.$('cidr')} />}
+              {askForCidr && <Input field={field} />}
+              {askForCidr && !_.isEmpty(field.value) && field.value.split('/')[1] <= 16 && (
+                <Message
+                  className="mb4"
+                  icon="warning"
+                  header="Wide CIDR block detected"
+                  content="One or more CIDR blocks entered might be too wide and could allow workspace access to a vast number of IP ranges. 
+                  Please proceed only after you ensure this is intended."
+                />
+              )}
               <Dropdown dataTestId="project-id" field={form.$('projectId')} fluid selection />
               <SelectConfigurationCards configurations={configurations} formField={form.$('envTypeConfigId')} />
               <TextArea dataTestId="description-text-area" field={form.$('description')} />

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/SelectConfigurationCards.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/SelectConfigurationCards.js
@@ -102,6 +102,7 @@ class SelectConfigurationCards extends React.Component {
                 <Divider />
                 {this.renderEstimatedCostInfo(config)}
                 {this.renderInstanceType(config)}
+                {this.renderCidr(config)}
               </Card.Description>
             </Card.Content>
           </Card>
@@ -140,6 +141,25 @@ class SelectConfigurationCards extends React.Component {
     );
 
     return content;
+  }
+
+  renderCidr(config) {
+    let hardcodedCidr;
+    _.forEach(config.params, param => {
+      // eslint-disable-next-line no-template-curly-in-string
+      if (param.key === 'AccessFromCIDRBlock' && param.value !== '${cidr}') {
+        hardcodedCidr = param.value;
+      }
+    });
+
+    const content = (
+      <div className="flex p1">
+        <div className="bold flex-auto">Hardcoded CIDR</div>
+        <div className="pr1">{hardcodedCidr}</div>
+      </div>
+    );
+
+    return _.isUndefined(hardcodedCidr) ? <></> : content;
   }
 
   renderTableInfo(config) {


### PR DESCRIPTION
Issue #, if available:
GALI-865, V327130500

Description of changes:
- Add warning banner if a user enters a wide CIDR when provisioning a workspace (similar to "Edit CIDR" warning)
- Add hardcoded CIDR value in env config card details. Researcher should be aware of CIDR overwrite if hardcoded value present in environment config.
-----------
![Screen Shot 2022-02-24 at 2 01 08 PM](https://user-images.githubusercontent.com/20480854/155589882-a7ccbc58-dd61-4319-beed-746ed10f1787.png)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.