### PR TITLE
fix: select cidr field only in non-TRE env

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -164,7 +164,7 @@ class CreateInternalEnvForm extends React.Component {
     const form = this.form;
     const askForCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
     const configurations = this.configurations;
-    const field = form.$('cidr');
+    const field = !this.isAppStreamEnabled ? form.$('cidr') : undefined;
 
     // we show the AppStream configuration warning when the feature is enabled,
     // and the user's projects are not linked to AppStream-configured accounts

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -162,9 +162,9 @@ class CreateInternalEnvForm extends React.Component {
 
   renderForm() {
     const form = this.form;
-    const askForCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
+    const shouldAskforCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
     const configurations = this.configurations;
-    const cidrField = !this.isAppStreamEnabled ? form.$('cidr') : undefined;
+    const cidrField = shouldAskforCidr ? form.$('cidr') : undefined;
 
     // we show the AppStream configuration warning when the feature is enabled,
     // and the user's projects are not linked to AppStream-configured accounts
@@ -179,8 +179,8 @@ class CreateInternalEnvForm extends React.Component {
           {({ processing, onCancel }) => (
             <>
               <Input dataTestId="workspace-name" field={form.$('name')} />
-              {askForCidr && <Input field={cidrField} />}
-              {askForCidr && !_.isEmpty(cidrField.value) && cidrField.value.split('/')[1] <= 16 && (
+              {shouldAskforCidr && <Input field={cidrField} />}
+              {shouldAskforCidr && !_.isEmpty(cidrField.value) && cidrField.value.split('/')[1] <= 16 && (
                 <Message
                   className="mb4"
                   icon="warning"

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/setup/CreateInternalEnvForm.js
@@ -164,7 +164,7 @@ class CreateInternalEnvForm extends React.Component {
     const form = this.form;
     const askForCidr = !_.isUndefined(this.props.defaultCidr) && !this.isAppStreamEnabled;
     const configurations = this.configurations;
-    const field = !this.isAppStreamEnabled ? form.$('cidr') : undefined;
+    const cidrField = !this.isAppStreamEnabled ? form.$('cidr') : undefined;
 
     // we show the AppStream configuration warning when the feature is enabled,
     // and the user's projects are not linked to AppStream-configured accounts
@@ -179,8 +179,8 @@ class CreateInternalEnvForm extends React.Component {
           {({ processing, onCancel }) => (
             <>
               <Input dataTestId="workspace-name" field={form.$('name')} />
-              {askForCidr && <Input field={field} />}
-              {askForCidr && !_.isEmpty(field.value) && field.value.split('/')[1] <= 16 && (
+              {askForCidr && <Input field={cidrField} />}
+              {askForCidr && !_.isEmpty(cidrField.value) && cidrField.value.split('/')[1] <= 16 && (
                 <Message
                   className="mb4"
                   icon="warning"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Compute UI errors for CIDR only in non-TRE environments.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.