### PR TITLE
fix: Return badRequest if trying to terminate an environment that has already been terminated

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -1449,6 +1449,36 @@ Quisque egestas, eros nec feugiat venenatis, lorem turpis placerat tortor, ullam
       }
     });
 
+    it('should fail because the environment is in termination failed status', async () => {
+      // BUILD
+      const requestContext = {
+        principal: {
+          isExternalUser: false,
+        },
+      };
+      const existingEnv = {
+        id: 'abc',
+        name: 'exampleName',
+        envTypeId: 'exampleETI',
+        envTypeConfigId: 'exampleETCI',
+        status: environmentScStatus.TERMINATING_FAILED,
+      };
+
+      service.mustFind = jest.fn().mockResolvedValueOnce(existingEnv);
+
+      // OPERATE
+      try {
+        await service.delete(requestContext, { id: existingEnv.id });
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'badRequest')).toBe(true);
+        expect(err.message).toContain(
+          `Workspace '${existingEnv.id}' can not be terminated while in ${environmentScStatus.TERMINATING_FAILED} status`,
+        );
+      }
+    });
+
     it('should fail because the workflow failed to trigger', async () => {
       // BUILD
       const requestContext = {

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/__tests__/environment-sc-service.test.js
@@ -35,6 +35,7 @@ const SettingsServiceMock = require('@aws-ee/base-services/lib/settings/env-sett
 
 jest.mock('@aws-ee/base-services/lib/audit/audit-writer-service');
 const AuditServiceMock = require('@aws-ee/base-services/lib/audit/audit-writer-service');
+const environmentScStatus = require('../environent-sc-status-enum');
 
 jest.mock('../../environment-authz-service.js');
 const EnvironmentAuthZServiceMock = require('../../environment-authz-service.js');
@@ -1389,6 +1390,62 @@ Quisque egestas, eros nec feugiat venenatis, lorem turpis placerat tortor, ullam
       } catch (err) {
         expect(service.boom.is(err, 'forbidden')).toBe(true);
         expect(err.message).toContain('not authorized');
+      }
+    });
+
+    it('should fail because the environment is already terminated', async () => {
+      // BUILD
+      const requestContext = {
+        principal: {
+          isExternalUser: false,
+        },
+      };
+      const existingEnv = {
+        id: 'abc',
+        name: 'exampleName',
+        envTypeId: 'exampleETI',
+        envTypeConfigId: 'exampleETCI',
+        status: environmentScStatus.TERMINATED,
+      };
+
+      service.mustFind = jest.fn().mockResolvedValueOnce(existingEnv);
+
+      // OPERATE
+      try {
+        await service.delete(requestContext, { id: existingEnv.id });
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'badRequest')).toBe(true);
+        expect(err.message).toContain(`Workspace '${existingEnv.id}' has already been terminated`);
+      }
+    });
+
+    it('should fail because the environment is being terminated', async () => {
+      // BUILD
+      const requestContext = {
+        principal: {
+          isExternalUser: false,
+        },
+      };
+      const existingEnv = {
+        id: 'abc',
+        name: 'exampleName',
+        envTypeId: 'exampleETI',
+        envTypeConfigId: 'exampleETCI',
+        status: environmentScStatus.TERMINATING,
+      };
+
+      service.mustFind = jest.fn().mockResolvedValueOnce(existingEnv);
+
+      // OPERATE
+      try {
+        await service.delete(requestContext, { id: existingEnv.id });
+        expect.hasAssertions();
+      } catch (err) {
+        // CHECK
+        expect(service.boom.is(err, 'badRequest')).toBe(true);
+        expect(err.message).toContain(`Workspace '${existingEnv.id}' is already being terminated`);
       }
     });
 

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -987,6 +987,13 @@ class EnvironmentScService extends Service {
       throw this.boom.badRequest(`Workspace '${id}' is already being terminated`, true);
     }
 
+    if (existingEnvironment.status === environmentScStatus.TERMINATING_FAILED) {
+      throw this.boom.badRequest(
+        `Workspace '${id}' can not be terminated while in ${environmentScStatus.TERMINATING_FAILED} status`,
+        true,
+      );
+    }
+
     await this.update(requestContext, {
       id,
       rev: existingEnvironment.rev,

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -979,6 +979,14 @@ class EnvironmentScService extends Service {
       existingEnvironment,
     );
 
+    if (existingEnvironment.status === environmentScStatus.TERMINATED) {
+      throw this.boom.badRequest(`Workspace '${id}' has already been terminated`, true);
+    }
+
+    if (existingEnvironment.status === environmentScStatus.TERMINATING) {
+      throw this.boom.badRequest(`Workspace '${id}' is already being terminated`, true);
+    }
+
     await this.update(requestContext, {
       id,
       rev: existingEnvironment.rev,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
If an environment is in the `TERMINATED`, `TERMINATING`, or `TERMINATING_FAILED` status and a request is made to terminate the environment, return an HTTP Status Code 400 error.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.