### PR TITLE
chore: Use correct colour for pending workspace display (#968)

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironment.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/ScEnvironment.js
@@ -35,7 +35,7 @@ const states = [
   {
     key: 'PENDING',
     display: 'PENDING',
-    color: 'orange',
+    color: 'yellow',
     tip: 'The workspace is being prepared, this could take sometime.',
     spinner: true,
     canTerminate: false,


### PR DESCRIPTION
Closes #968 

Description of changes:
- Sets colour for pending workspaces to the same colour used for the filter button at the top of the page (see https://github.com/awslabs/service-workbench-on-aws/blob/mainline/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentsFilterButtons.js#L27)

Checklist:

- [ ] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

   **NOTE**: Testing was only done locally in the browser console, to confirm that the class applied successfully and looked as expected:
![image](https://user-images.githubusercontent.com/900469/163309494-4f0386ea-741f-45a1-b948-2199c198b81d.png)
![image](https://user-images.githubusercontent.com/900469/163309467-952de117-e37c-4c41-b260-bd1c1a9ce51c.png)

- [ ] Is this change also required on the AWS Solution version?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.