### PR TITLE
Fix SageMaker launch permissions

### DIFF
--- a/main/solution/post-deployment/config/infra/cloudformation.yml
+++ b/main/solution/post-deployment/config/infra/cloudformation.yml
@@ -424,7 +424,7 @@ Resources:
                 Action:
                   - sagemaker:DescribeNotebookInstance
                   - sagemaker:CreateNotebookInstance
-                  - sagemaker:StopNotebookInstance
+                  - sagemaker:AddTags
                   - sagemaker:StopNotebookInstance
                   - sagemaker:DeleteNotebookInstance
                 Resource: 'arn:aws:sagemaker:*:*:notebook-instance/basicnotebookinstance-*'


### PR DESCRIPTION
Removes a duplicate SageMaker permission, and adds a missing permission for tagging.
Closes #1018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.