### PR TITLE
fix: cicd pipeline S3 config check fail 

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -26,7 +26,7 @@ if [ -e "${CONFIG_TARGET_PATH}" ]; then
   echo "Already present; not overwriting!"
 else
   echo "Not present; checking if present in S3"
-  aws s3api head-object --bucket $DEPLOYMENT_BUCKET --key "integration-test/$ENV_NAME.yml" || TEST_CONFIG_EXISTS=false
+  aws s3api head-object --bucket $DEPLOYMENT_BUCKET --key "integration-test/$ENV_NAME.yml" --no-cli-pager || TEST_CONFIG_EXISTS=false
 
   if [ "$TEST_CONFIG_EXISTS" == true ]; then
     echo "Test config found! Downloading from ${CONFIG_S3_PATH}"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Tested from CLI for both cases, verified `TEST_CONFIG_EXISTS` remains true when object exists and flipped to false when object does not exist


<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.