### PR TITLE
fix the sed expression replacing version info

### DIFF
--- a/scripts/get-release-info.sh
+++ b/scripts/get-release-info.sh
@@ -38,8 +38,8 @@ then
         if ([ "$oldVersionNumber" != "$versionNumber" ]) || ([ "$oldVersionDate" != "$versionDate" ])
         then
             # Yes-->Replace new with old
-            sed -i -e "s/versionNumber: '$oldVersionNumber/versionNumber: '$versionNumber/" "$FILE"
-            sed -i -e "s/versionDate: '$oldVersionDate/versionDate: '$versionDate/" $FILE
+            sed -i -e "/^versionNumber: /s/.*/versionNumber: '$versionNumber'/" "$FILE"
+            sed -i -e "/^versionDate: /s/.*/versionDate: '$versionDate'/" $FILE
         fi
     else
         # No-->Append new


### PR DESCRIPTION
Issue #, if available:

the sed expression in scripts/get-release-info.sh was broken giving the rather cryptic

```bash
sed: -e expression #1, char 26: unterminated `s' command
```

when rerunning scripts/environment-deploy.sh

Checklist:

- [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.