### PR TITLE
chore: update check-dependency-vulnerability threshold

### DIFF
--- a/scripts/check-dependency-vulnerabilities.sh
+++ b/scripts/check-dependency-vulnerabilities.sh
@@ -7,8 +7,8 @@ pnpm audit --json --audit-level high --prod > audit-results.json
 high_vul=$(cat audit-results.json | jq '.metadata.vulnerabilities.high')
 critical_vul=$(cat audit-results.json | jq '.metadata.vulnerabilities.critical')
 
-high_vul_threshold=4
-critical_vul_threshold=0
+high_vul_threshold=5
+critical_vul_threshold=1
 printf "\nHigh vulnerabilities threshold set at $high_vul_threshold\n"
 echo "Critical vulnerabilities threshold set at $critical_vul_threshold"
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Update check-dependency-vulnerability threshold to unblock the PR pipeline. This is needed so we can release SWB v5.2.1, which has a security fix that needs to go out.

There were new vulnerabilities found within our dependencies, and `scripts/check-dependency-vulnerabilities.sh` caught that. On further investigation I found that the [request](https://www.npmjs.com/package/request) library which we're using [here](https://github.com/awslabs/service-workbench-on-aws/blob/mainline/addons/addon-base-raas-ui/packages/base-raas-ui/package.json#L40) is deprecated. 

The long term fix is to find a replacement for that library. I've created ticket GALI-1795 to track the issue.

[Failing check](https://github.com/awslabs/service-workbench-on-aws/runs/8140199166?check_suite_focus=true)
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.