### PR TITLE
fix: allow Guest users to log in

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
@@ -33,7 +33,12 @@ const UsersStore = BaseStore.named('UsersStore')
 
     return {
       async doLoad() {
-        const users = (await getUsers()) || [];
+        let users = [];
+        try {
+          users = await getUsers();
+        } catch (e) {
+          console.error('Could not get users', e);
+        }
         self.runInAction(() => {
           users.forEach(user => {
             const userModel = User.create(user);

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UsersStore.js
@@ -37,7 +37,10 @@ const UsersStore = BaseStore.named('UsersStore')
         try {
           users = await getUsers();
         } catch (e) {
-          console.error('Could not get users', e);
+          console.error(
+            'Could not get users. This is expected if you have a Guest role, but is not expected behavior for any other roles',
+            e,
+          );
         }
         self.runInAction(() => {
           users.forEach(user => {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
By default when a user logs in, the UI call the GET `/users` API. Since we're now restricting Guest roles for calling the GET `/users` API, the UI returns an error. When the `userStore` can't get the users list it is supposed to set the user list to be an empty array. The code didn't properly handle that use case, and this PR fixes that. 

**Testing**
* Guest can log in and create SSH key (only functionality that Guest can actually do)
* Researcher can log in and view/edit study permissions
* Admin can log in and edit studies. Can view and edit users

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
-  [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.