### PR TITLE
fix: cicd pipeline permissions

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -359,6 +359,10 @@ Resources:
               - cloudformation:GetTemplate
               - cloudformation:ListStackResources
               - cloudformation:DescribeStackEvents
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:CreateChangeSet
+              - cloudformation:DeleteChangeSet
             Resource:
               - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${self:custom.settings.namespace}-*'
               - !Sub 'arn:aws:cloudformation:us-east-1:${AWS::AccountId}:stack/${self:custom.settings.envName}-va-${self:custom.settings.solutionName}-*'
@@ -658,7 +662,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
+            Value: ${self:provider.deploymentBucket.name}
           - Name: ENV_NAME
             Value: ${self:custom.settings.stgEnvName}
       ServiceRole: !GetAtt AppDeployerRole.Arn
@@ -687,7 +691,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
+            Value: ${self:provider.deploymentBucket.name}
           - Name: ENV_NAME
             Value: ${self:custom.settings.envName}
       ServiceRole: !GetAtt AppDeployerRole.Arn
@@ -714,7 +718,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
+            Value: ${self:provider.deploymentBucket.name}
           - Name: ENV_NAME
             Value: ${self:custom.settings.stgEnvName}
       ServiceRole: !GetAtt AppDeployerRole.Arn
@@ -741,7 +745,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
+            Value: ${self:provider.deploymentBucket.name}
           - Name: ENV_NAME
             Value: ${self:custom.settings.envName}
       ServiceRole: !GetAtt AppDeployerRole.Arn
@@ -769,7 +773,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
-            Value: ${self:provider.deploymentBucket}
+            Value: ${self:provider.deploymentBucket.name}
           - Name: ENV_NAME
             Value: ${self:custom.settings.envName}
       ServiceRole: !GetAtt AppDeployerRole.Arn

--- a/main/cicd/cicd-pipeline/serverless.yml
+++ b/main/cicd/cicd-pipeline/serverless.yml
@@ -24,8 +24,8 @@ custom:
     Name: ${self:custom.settings.envName}-${self:service}
   hooks:
     'aws:deploy:finalize:cleanup':
-      - scripts/upload-env-config-if-not-versioned.sh ${self:provider.profile} ${self:provider.deploymentBucket} ${self:custom.settings.stgEnvName} ${self:custom.settings.envName}
-      - scripts/upload-test-config-if-not-versioned.sh ${self:provider.profile} ${self:provider.deploymentBucket} ${self:custom.settings.stgEnvName} ${self:custom.settings.envName}
+      - scripts/upload-env-config-if-not-versioned.sh ${self:provider.profile} ${self:provider.deploymentBucket.name} ${self:custom.settings.stgEnvName} ${self:custom.settings.envName}
+      - scripts/upload-test-config-if-not-versioned.sh ${self:provider.profile} ${self:provider.deploymentBucket.name} ${self:custom.settings.stgEnvName} ${self:custom.settings.envName}
 
 resources:
   - Description: Service-Workbench-on-AWS ${self:custom.settings.version} ${self:custom.settings.solutionName} ${self:custom.settings.envName} CICD-Pipeline


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixing the CICD pipeline to use Serverless V3 which requires additional CFN permissions and specifying `.name` on a `provider` value to compile correctly

Manually tested deploying the sls component and rerunning the pipeline

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.