### PR TITLE
fix: tre egress store data updated S3 return

### DIFF
--- a/main/integration-tests/__test__/api-tests/appstream-egress-enabled/data-egress/get-data-egress.test.js
+++ b/main/integration-tests/__test__/api-tests/appstream-egress-enabled/data-egress/get-data-egress.test.js
@@ -70,6 +70,7 @@ describe('Create URL scenarios', () => {
             StorageClass: 'STANDARD',
             projectId: 'TRE-Project',
             workspaceId: 'ea8e5286-45ca-402a-8c98-7d4495f646e2',
+            ChecksumAlgorithm: [], // new attribute introduced in Feb 2022 https://aws.amazon.com/blogs/aws/new-additional-checksum-algorithms-for-amazon-s3/
           },
         ],
         isAbleToSubmitEgressRequest: false,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
S3 introduced a new attribute in their `listObjectsV2` method that contains the checksum algorithm for S3 objects in Feb 2022. The test did not expect the attribute. The attribute is empty as we are not specifying a checksum algorithm during `put` calls.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.