### PR TITLE
feat: Add integration tests for users and user-roles controllers

### DIFF
--- a/main/integration-tests/__test__/api-tests/common/user-roles/get-user-roles.test.js
+++ b/main/integration-tests/__test__/api-tests/common/user-roles/get-user-roles.test.js
@@ -56,7 +56,6 @@ describe('Get user role scenarios', () => {
   };
 
   describe('Getting user roles', () => {
-
     it.each(['admin', 'researcher', 'guest', 'internal-guest'])('should fail for inactive %p', async role => {
       const currentSession = await setup.createUserSession({ userRole: role, projectId: [] });
       await adminSession.resources.users.deactivateUser(currentSession.user);

--- a/main/integration-tests/__test__/api-tests/common/user-roles/get-user-roles.test.js
+++ b/main/integration-tests/__test__/api-tests/common/user-roles/get-user-roles.test.js
@@ -56,42 +56,18 @@ describe('Get user role scenarios', () => {
   };
 
   describe('Getting user roles', () => {
-    it('should fail if user is inactive', async () => {
-      const researcherSession = await setup.createResearcherSession();
-      await adminSession.resources.users.deactivateUser(researcherSession.user);
 
-      await expect(researcherSession.resources.userRoles.get()).rejects.toMatchObject({
+    it.each(['admin', 'researcher', 'guest', 'internal-guest'])('should fail for inactive %p', async role => {
+      const currentSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await adminSession.resources.users.deactivateUser(currentSession.user);
+      await expect(currentSession.resources.userRoles.get()).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
     });
 
-    it('should pass if researcher attempts to get user roles', async () => {
-      const researcherSession = await setup.createResearcherSession();
-      await expect(researcherSession.resources.userRoles.get()).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining(adminRole),
-          expect.objectContaining(internalGuestRole),
-          expect.objectContaining(internalResearcherRole),
-          expect.objectContaining(externalGuestRole),
-        ]),
-      );
-    });
-
-    it('should pass if internal guest attempts to get user roles', async () => {
-      const guestSession = await setup.createUserSession({ userRole: 'internal-guest', projectId: [] });
-      await expect(guestSession.resources.userRoles.get()).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining(adminRole),
-          expect.objectContaining(internalGuestRole),
-          expect.objectContaining(internalResearcherRole),
-          expect.objectContaining(externalGuestRole),
-        ]),
-      );
-    });
-
-    it('should pass if external guest attempts to get user roles', async () => {
-      const guestSession = await setup.createUserSession({ userRole: 'guest', projectId: [] });
-      await expect(guestSession.resources.userRoles.get()).resolves.toEqual(
+    it.each(['admin', 'researcher', 'guest', 'internal-guest'])('should pass for %p', async role => {
+      const currentSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await expect(currentSession.resources.userRoles.get()).resolves.toEqual(
         expect.arrayContaining([
           expect.objectContaining(adminRole),
           expect.objectContaining(internalGuestRole),

--- a/main/integration-tests/__test__/api-tests/common/users/bulk-add-users.test.js
+++ b/main/integration-tests/__test__/api-tests/common/users/bulk-add-users.test.js
@@ -16,7 +16,7 @@
 const { runSetup } = require('../../../../support/setup');
 const errorCode = require('../../../../support/utils/error-code');
 
-describe('Create user scenarios', () => {
+describe('Bulk Create user scenarios', () => {
   let setup;
   let defaultUser;
   let username;
@@ -41,15 +41,30 @@ describe('Create user scenarios', () => {
       });
     });
 
-    it('should fail for inactive admin', async () => {
-      const admin1Session = await setup.createAdminSession();
-      await adminSession.resources.users.deactivateUser(admin1Session.user);
-      await expect(admin1Session.resources.users.bulkAddUsers([defaultUser])).rejects.toMatchObject({
+    it.each(['researcher', 'guest', 'internal-guest'])('should fail for inactive %p', async role => {
+      const nonAdminSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await adminSession.resources.users.deactivateUser(nonAdminSession.user);
+      await expect(nonAdminSession.resources.users.bulkAddUsers([defaultUser])).rejects.toMatchObject({
         code: errorCode.http.code.unauthorized,
       });
     });
 
-    it('should create users successfully', async () => {
+    it.each(['researcher', 'guest', 'internal-guest'])('should fail for %p', async role => {
+      const nonAdminSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await expect(nonAdminSession.resources.users.bulkAddUsers([defaultUser])).rejects.toMatchObject({
+        code: errorCode.http.code.forbidden,
+      });
+    });
+
+    it('should fail for inactive admin', async () => {
+      const testAdminSession = await setup.createAdminSession();
+      await adminSession.resources.users.deactivateUser(testAdminSession.user);
+      await expect(testAdminSession.resources.users.bulkAddUsers([defaultUser])).rejects.toMatchObject({
+        code: errorCode.http.code.unauthorized,
+      });
+    });
+
+    it('should create users successfully as admin', async () => {
       const admin1Session = await setup.createAdminSession();
       await expect(admin1Session.resources.users.bulkAddUsers([defaultUser])).resolves.toMatchObject({
         errorCount: 0,
@@ -57,7 +72,7 @@ describe('Create user scenarios', () => {
       });
     });
 
-    it('should fail with badRequest code for adding users that already exist', async () => {
+    it('should fail with badRequest code for adding users that already exist as admin', async () => {
       const admin1Session = await setup.createAdminSession();
       const newUser = admin1Session.resources.users.defaults();
       await expect(admin1Session.resources.users.bulkAddUsers([defaultUser, newUser])).rejects.toMatchObject({
@@ -65,7 +80,14 @@ describe('Create user scenarios', () => {
       });
     });
 
-    it('should fail with badRequest code for adding malformed users', async () => {
+    it('should fail for adding root user as admin', async () => {
+      const admin1Session = await setup.createAdminSession();
+      await expect(admin1Session.resources.users.bulkAddUsers([{ ...defaultUser, isAdmin: true, userRole: 'admin', userType: 'root' }])).rejects.toMatchObject({
+        code: errorCode.http.code.badRequest,
+      });
+    });
+
+    it('should fail with badRequest code for adding malformed users as admin', async () => {
       const admin1Session = await setup.createAdminSession();
       const badUser = {};
       const newUser = admin1Session.resources.users.defaults();

--- a/main/integration-tests/__test__/api-tests/common/users/bulk-add-users.test.js
+++ b/main/integration-tests/__test__/api-tests/common/users/bulk-add-users.test.js
@@ -82,7 +82,11 @@ describe('Bulk Create user scenarios', () => {
 
     it('should fail for adding root user as admin', async () => {
       const admin1Session = await setup.createAdminSession();
-      await expect(admin1Session.resources.users.bulkAddUsers([{ ...defaultUser, isAdmin: true, userRole: 'admin', userType: 'root' }])).rejects.toMatchObject({
+      await expect(
+        admin1Session.resources.users.bulkAddUsers([
+          { ...defaultUser, isAdmin: true, userRole: 'admin', userType: 'root' },
+        ]),
+      ).rejects.toMatchObject({
         code: errorCode.http.code.badRequest,
       });
     });

--- a/main/integration-tests/__test__/api-tests/common/users/create-user.test.js
+++ b/main/integration-tests/__test__/api-tests/common/users/create-user.test.js
@@ -41,6 +41,21 @@ describe('Create user scenarios', () => {
       });
     });
 
+    it.each(['researcher', 'guest', 'internal-guest'])('should fail for inactive %p', async role => {
+      const nonAdminSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await adminSession.resources.users.deactivateUser(nonAdminSession.user);
+      await expect(nonAdminSession.resources.users.create(defaultUser)).rejects.toMatchObject({
+        code: errorCode.http.code.unauthorized,
+      });
+    });
+
+    it.each(['researcher', 'guest', 'internal-guest'])('should fail for %p', async role => {
+      const nonAdminSession = await setup.createUserSession({ userRole: role, projectId: [] });
+      await expect(nonAdminSession.resources.users.create(defaultUser)).rejects.toMatchObject({
+        code: errorCode.http.code.forbidden,
+      });
+    });
+
     it('should fail for inactive admin', async () => {
       const admin1Session = await setup.createAdminSession();
       await adminSession.resources.users.deactivateUser(admin1Session.user);
@@ -49,21 +64,21 @@ describe('Create user scenarios', () => {
       );
     });
 
-    it('should fail for creating root user', async () => {
+    it('should fail for creating root user as admin', async () => {
       const admin1Session = await setup.createAdminSession();
       await expect(
         admin1Session.resources.users.create({ ...defaultUser, isAdmin: true, userRole: 'admin', userType: 'root' }),
       ).rejects.toEqual(expect.objectContaining({ code: errorCode.http.code.forbidden }));
     });
 
-    it('should create user successfully', async () => {
+    it('should create user successfully as admin', async () => {
       const admin1Session = await setup.createAdminSession();
       await expect(admin1Session.resources.users.create(defaultUser)).resolves.toMatchObject({
         username,
       });
     });
 
-    it('should fail for adding user that already exist', async () => {
+    it('should fail for adding user that already exist as admin´', async () => {
       const admin1Session = await setup.createAdminSession();
       const username1 = setup.gen.username();
       await admin1Session.resources.users.create({ ...defaultUser, username: username1, email: username1 });

--- a/main/integration-tests/__test__/api-tests/common/users/update-user.test.js
+++ b/main/integration-tests/__test__/api-tests/common/users/update-user.test.js
@@ -87,11 +87,6 @@ describe('Update user scenarios', () => {
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
-      // await expect(
-      //   nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, status: 'inactive' }),
-      // ).rejects.toMatchObject({
-      //   code: errorCode.http.code.forbidden,
-      // });
       await expect(
         nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, isExternalUser: a !== 'guest' }),
       ).rejects.toMatchObject({

--- a/main/integration-tests/__test__/api-tests/common/users/update-user.test.js
+++ b/main/integration-tests/__test__/api-tests/common/users/update-user.test.js
@@ -88,7 +88,9 @@ describe('Update user scenarios', () => {
         code: errorCode.http.code.forbidden,
       });
       await expect(
-        nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, isExternalUser: a !== 'guest' }),
+        nonAdminSession.resources.users
+          .user(nonAdminSession.user.uid)
+          .update({ rev: 1, isExternalUser: a !== 'guest' }),
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
@@ -98,21 +100,26 @@ describe('Update user scenarios', () => {
         code: errorCode.http.code.forbidden,
       });
       await expect(
-        nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, identityProviderName: 'Cognito Native Pool 2' }),
+        nonAdminSession.resources.users
+          .user(nonAdminSession.user.uid)
+          .update({ rev: 1, identityProviderName: 'Cognito Native Pool 2' }),
       ).rejects.toMatchObject({
         code: errorCode.http.code.badRequest,
       });
       await expect(
-        nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, authenticationProviderId: 'forbbiden change' }),
+        nonAdminSession.resources.users
+          .user(nonAdminSession.user.uid)
+          .update({ rev: 1, authenticationProviderId: 'forbbiden change' }),
       ).rejects.toMatchObject({
         code: errorCode.http.code.badRequest,
       });
       await expect(
-        nonAdminSession.resources.users.user(nonAdminSession.user.uid).update({ rev: 1, isSamlAuthenticatedUser: true }),
+        nonAdminSession.resources.users
+          .user(nonAdminSession.user.uid)
+          .update({ rev: 1, isSamlAuthenticatedUser: true }),
       ).rejects.toMatchObject({
         code: errorCode.http.code.forbidden,
       });
-
     });
 
     it.each(['researcher', 'guest', 'internal-guest'])('should fail if %p updates other user', async a => {


### PR DESCRIPTION
Issue #, if available:
GALI-1888
Description of changes:
Add integration tests for users and user-roles controllers
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [x ] Have you written new tests for your core changes, as applicable?
- [x ] Have you successfully tested with your changes locally?
- [x ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.