### PR TITLE
fix: fix input validation and escape html on popups

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/files/FileDropZone.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/files/FileDropZone.js
@@ -17,10 +17,10 @@ import React from 'react';
 import { decorate, observable, runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import PropTypes from 'prop-types';
-import toastr from 'toastr';
 
 import { Segment, Header, Divider, Button, Icon } from 'semantic-ui-react';
 import uuidv4 from 'uuid/v4';
+import { displayWarning } from '@amzn/base-ui/dist/helpers/notification';
 
 /**
  * A reusable file input component.
@@ -61,7 +61,7 @@ class FileDropZone extends React.Component {
     if (this.props.onSelectFiles) {
       const fileList = event.currentTarget.files || [];
       if (fileList.length > this.props.maximumUploadFilesLimit) {
-        toastr.warning(
+        displayWarning(
           `There are currently ${fileList.length} files selected. Please select less than ${this.props.maximumUploadFilesLimit} files.`,
         );
       } else {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/files/FileUpload.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/files/FileUpload.js
@@ -22,7 +22,6 @@ import { Button, Grid, Header, Segment } from 'semantic-ui-react';
 
 import { displayError, displaySuccess, displayWarning } from '@amzn/base-ui/dist/helpers/notification';
 
-import toastr from 'toastr';
 import StudyFileDropZone from './FileDropZone';
 import FileUploadTable from './FileUploadTable';
 
@@ -69,7 +68,7 @@ const FileUpload = observer(
                       color="blue"
                       onClick={() => {
                         if (files.length > maximumUploadFilesLimit) {
-                          toastr.warning(
+                          displayWarning(
                             `There are currently ${files.length} files selected. Please select less than ${maximumUploadFilesLimit} files.`,
                           );
                         } else {

--- a/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
@@ -50,11 +50,11 @@ function displayFormErrors(form) {
 
 function toMessage(msg, error) {
   if (_.isError(msg)) {
-    return `${msg.message || msg.friendly} <br/>&nbsp;`;
+    return `${msg.message || msg.friendly} \n;`;
   }
 
   if (_.isError(error)) {
-    return `${msg} - ${error.message} <br/>&nbsp;`;
+    return `${msg} - ${error.message} \n;`;
   }
 
   if (_.isArray(msg)) {
@@ -62,25 +62,22 @@ function toMessage(msg, error) {
     const size = _.size(messages);
 
     if (size === 0) {
-      return 'Unknown error <br/>&nbsp;';
+      return 'Unknown error \n;';
     }
     if (size === 1) {
-      return `${messages[0]}<br/>&nbsp;`;
+      return `${messages[0]}\n;`;
     }
     const result = [];
-    result.push('<br/>');
-    result.push('<ul>');
     _.forEach(messages, message => {
-      result.push(`<li style="margin-left: -20px;">${message}</li>`);
+      result.push(`${message}\n`);
     });
-    result.push('</ul><br/>&nbsp;');
 
     return result.join('');
   }
 
-  if (_.isEmpty(msg)) return 'Unknown error <br/>&nbsp;';
+  if (_.isEmpty(msg)) return 'Unknown error \n;';
 
-  return `${msg} <br/>&nbsp;`;
+  return `${msg} \n;`;
 }
 
 // For details of options, see https://github.com/CodeSeven/toastr

--- a/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/notification.js
@@ -17,18 +17,21 @@ import _ from 'lodash';
 import toastr from 'toastr';
 
 function displayError(msg, error, timeOut = '20000') {
+  toastr.options.escapeHtml = true;
   toastr.error(toMessage(msg, error), 'We have a problem!', { ...toasterErrorOptions, timeOut });
   if (error) console.error(msg, error);
   if (_.isError(msg)) console.error(msg);
 }
 
 function displayWarning(msg, error, timeOut = '20000') {
+  toastr.options.escapeHtml = true;
   toastr.warning(toMessage(msg, error), 'Warning!', { ...toasterWarningOptions, timeOut });
   if (error) console.error(msg, error);
   if (_.isError(msg)) console.error(msg);
 }
 
 function displaySuccess(msg, title = 'Submitted!') {
+  toastr.options.escapeHtml = true;
   toastr.success(toMessage(msg), title, toasterSuccessOptions);
 }
 

--- a/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/__tests__/key-pair-service.test.js
+++ b/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/__tests__/key-pair-service.test.js
@@ -1,0 +1,106 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+const ServicesContainer = require('@amzn/base-services-container/lib/services-container');
+const JsonSchemaValidationService = require('@amzn/base-services/lib/json-schema-validation-service');
+
+jest.mock('@amzn/base-services/lib/db-service');
+const DbServiceMock = require('@amzn/base-services/lib/db-service');
+
+jest.mock('@amzn/base-services/lib/audit/audit-writer-service');
+const AuditServiceMock = require('@amzn/base-services/lib/audit/audit-writer-service');
+
+jest.mock('@amzn/base-services/lib/authorization/authorization-service');
+const AuthServiceMock = require('@amzn/base-services/lib/authorization/authorization-service');
+
+const KeyPairService = require('../key-pair-service');
+
+describe('keyPairService', () => {
+  let service = null;
+  beforeEach(async () => {
+    // initialize services container and register dependencies
+    const container = new ServicesContainer();
+    container.register('jsonSchemaValidationService', new JsonSchemaValidationService());
+    container.register('dbService', new DbServiceMock());
+    container.register('authorizationService', new AuthServiceMock());
+    container.register('auditWriterService', new AuditServiceMock());
+    container.register('keyPairService', new KeyPairService());
+    await container.initServices();
+
+    // Get instance of the service we are testing
+    service = await container.find('keyPairService');
+
+    // skip authorization
+    service.assertAuthorized = jest.fn();
+    service.isAuthorized = jest.fn();
+  });
+  describe('create', () => {
+    const requestContext = {
+      principalIdentifier: {
+        uid: 'UID',
+      },
+    };
+
+    describe('if the name is invalid', () => {
+      const keyPair = {
+        name: '<script>console.log("**hacker voice** I\'m in")</script>',
+      };
+
+      it('should fail', async () => {
+        // OPERATE and CHECK
+        await expect(service.create(requestContext, keyPair)).rejects.toThrow(
+          expect.objectContaining({
+            boom: true,
+            code: 'badRequest',
+            safe: true,
+            message: 'Input has validation errors',
+          }),
+        );
+      });
+    });
+  });
+
+  //   it('should fail name incorrect', async () => {
+  //     // BUILD
+  //     const envType = {
+  //       id: 'theverybest',
+  //       rev: 1,
+  //       name: '<stuff>',
+  //       desc: 'stuff',
+  //       status: 'approved',
+  //     };
+
+  //     service.audit = jest.fn();
+
+  //     // This function mainly just wraps some aws functions on a ServiceCatalogClient instance
+  //     service.getProvisioningArtifactParams = jest.fn();
+
+  //     const requestContext = {
+  //       principalIdentifier: {
+  //         id: 'aheartsotrue',
+  //         ns: 'ourcouragewillpullusthrough',
+  //       },
+  //     };
+
+  //     // OPERATE and CHECK
+  //     await expect(service.update(requestContext, envType)).rejects.toThrow(
+  //       expect.objectContaining({
+  //         boom: true,
+  //         code: 'badRequest',
+  //         safe: true,
+  //         message: 'Input has validation errors',
+  //       }),
+  //     );
+  //   });
+});

--- a/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/schema/create-key-pair.js
+++ b/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/schema/create-key-pair.js
@@ -22,7 +22,7 @@ const schema = {
       type: 'string',
       maxLength: 100,
       minLength: 2,
-      pattern: '^[a-zA-Z0-9_\\-]*',
+      pattern: '^[A-Za-z0-9-_ ]+$',
     },
     // Description for this key-pair
     desc: {

--- a/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/schema/update-key-pair.js
+++ b/addons/addon-key-pair-mgmt-api/packages/key-pair-mgmt-services/lib/key-pair/schema/update-key-pair.js
@@ -31,7 +31,7 @@ const schema = {
       type: 'string',
       maxLength: 100,
       minLength: 2,
-      pattern: '^[a-zA-Z0-9_\\-]*',
+      pattern: '^[A-Za-z0-9-_ ]+$',
     },
     // Description for this key-pair
     desc: {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2469,6 +2469,9 @@ components:
       properties:
         name:
           type: string
+          maxLength: 100
+          minLength: 2
+          pattern: '^[A-Za-z0-9-_ ]+$'
         desc:
           type: string
       example: {"name": "foo2-key", "desc": "Example key being created"}
@@ -2479,6 +2482,9 @@ components:
           type: number
         name:
           type: string
+          maxLength: 100
+          minLength: 2
+          pattern: '^[A-Za-z0-9-_ ]+$'
         desc:
           type: string
       example: { "rev": 0, "name": "foo2-key", "desc": "Example key being created" }


### PR DESCRIPTION
Issue #, if available:

Description of changes: 
Validate input from the SSH Key API POST and PUT to not accept html syntax for name value
Escape HTML on rendering of popups in the UI via [toastr](https://github.com/CodeSeven/toastr).
Add unit tests to cover service changes.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.