### PR TITLE
chore: add e2etest for sagemaker auto-stop

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -269,7 +269,7 @@ Resources:
                 chmod a+x /usr/local/bin/autostop.py
                 IDLE_TIME=`expr ${AutoStopIdleTimeInMinutes} \* 60`
                 echo "Starting the SageMaker autostop script in cron"
-                (crontab -l 2>/dev/null; echo "*/1 * * * * /usr/bin/python /usr/local/bin/autostop.py --time $IDLE_TIME --ignore-connections >> /var/log/autostop.log") | crontab -
+                (crontab -l 2>/dev/null; echo "*/1 * * * * /bin/bash -c '/usr/bin/python3 /usr/local/bin/autostop.py --time $IDLE_TIME | tee -a /var/log/autostop.log'") | crontab -
               fi
 
 Outputs:

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -9,7 +9,7 @@
     "cognitoClientId": "6dmj4qhbihtkigcbsjo346hjmi",
     "workspaces": {
       "sagemaker": {
-        "workspaceTypeName": "SageMaker Notebook-v4",
+        "workspaceTypeName": "SageMaker Notebook-v6",
         "configuration": "sagemaker-e2e",
         "projectId": "e2eTestProject"
       },

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -9,7 +9,7 @@
     "cognitoClientId": "6dmj4qhbihtkigcbsjo346hjmi",
     "workspaces": {
       "sagemaker": {
-        "workspaceTypeName": "SageMaker Notebook-v6",
+        "workspaceTypeName": "SageMaker Notebook-v8",
         "configuration": "sagemaker-e2e",
         "projectId": "e2eTestProject"
       },

--- a/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
@@ -19,22 +19,16 @@ import {
   navigateToWorkspaces,
   checkDetailsTable,
   checkWorkspaceAvailable,
+  checkWorkspaceAutoStop
 } from '../../support/workspace-util';
 
 describe('Launch a workspace', () => {
-  const workspaceNames = [];
   before(() => {
     cy.login('researcher');
     navigateToWorkspaces();
     terminateWorkspaces();
   });
   after(() => {
-    // Wait until all new workspaces are available and then terminate them
-    _.forEach(workspaceNames, workspaceName => {
-      checkWorkspaceAvailable(workspaceName);
-    });
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(3000);
     terminateWorkspaces();
   });
 
@@ -44,39 +38,42 @@ describe('Launch a workspace', () => {
     const workspaces = Cypress.env('workspaces');
     const rstudioServer = workspaces.rstudioServer;
     const workspaceName = launchWorkspace(rstudioServer, 'RStudio-Server');
-    workspaceNames.push(workspaceName);
     checkDetailsTable(workspaceName);
+    checkWorkspaceAvailable(workspaceName);
   });
 
-  it('should launch a new sagemaker workspace correctly', () => {
+  it('should launch a new sagemaker workspace and auto-stops correctly', () => {
     const workspaces = Cypress.env('workspaces');
     const sagemaker = workspaces.sagemaker;
     const workspaceName = launchWorkspace(sagemaker, 'Sagemaker');
-    workspaceNames.push(workspaceName);
     checkDetailsTable(workspaceName);
+    checkWorkspaceAvailable(workspaceName);
+
+    // Sagemaker workspace type config has been updated to auto-stop instances after 3 minutes
+    checkWorkspaceAutoStop(workspaceName);
   });
 
   it('should launch a new ec2 Linux workspace correctly', () => {
     const workspaces = Cypress.env('workspaces');
     const ec2 = workspaces.ec2;
     const workspaceName = launchWorkspace(ec2.linux, 'Linux');
-    workspaceNames.push(workspaceName);
     checkDetailsTable(workspaceName);
+    checkWorkspaceAvailable(workspaceName);
   });
 
   it('should launch a new ec2 Windows workspace correctly', () => {
     const workspaces = Cypress.env('workspaces');
     const ec2 = workspaces.ec2;
     const workspaceName = launchWorkspace(ec2.windows, 'Windows');
-    workspaceNames.push(workspaceName);
     checkDetailsTable(workspaceName);
+    checkWorkspaceAvailable(workspaceName);
   });
 
   it('should launch a new emr workspace correctly', () => {
     const workspaces = Cypress.env('workspaces');
     const emr = workspaces.emr;
     const workspaceName = launchWorkspace(emr, 'EMR');
-    workspaceNames.push(workspaceName);
     checkDetailsTable(workspaceName);
+    checkWorkspaceAvailable(workspaceName);
   });
 });

--- a/main/end-to-end-tests/cypress/support/workspace-util.js
+++ b/main/end-to-end-tests/cypress/support/workspace-util.js
@@ -125,6 +125,12 @@ function checkWorkspaceAvailable(workspaceName) {
     .contains('AVAILABLE', { timeout: 1000000 });
 }
 
+function checkWorkspaceAutoStop(workspaceName) {
+  cy.contains(workspaceName)
+    .parent()
+    .contains('STOPPED', { timeout: 300000 });
+}
+
 module.exports = {
   terminateWorkspaces,
   launchWorkspace,
@@ -132,4 +138,5 @@ module.exports = {
   checkDetailsTable,
   checkWorkspaceAvailableAndClickConnectionsButton,
   checkWorkspaceAvailable,
+  checkWorkspaceAutoStop
 };

--- a/main/end-to-end-tests/cypress/support/workspace-util.js
+++ b/main/end-to-end-tests/cypress/support/workspace-util.js
@@ -128,7 +128,7 @@ function checkWorkspaceAvailable(workspaceName) {
 function checkWorkspaceAutoStop(workspaceName) {
   cy.contains(workspaceName)
     .parent()
-    .contains('STOPPED', { timeout: 300000 });
+    .contains('STOPPED', { timeout: 1000000 });
 }
 
 module.exports = {


### PR DESCRIPTION
Issue #, if available:
GALI-2167

Description of changes:
Add e2e test for SageMaker auto-stop check.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.