### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Service Workbench documentation can be accessed in the PDF format or by visiting
 ### Implementation Guide
 For information on installing Service Workbench on AWS, please visit the [AWS Solutions Implementation Guide](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/solution-overview.html).
 
+- [Service Workbench Solution Overview](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/solution-overview.html)
+- [Service Workbench  Architecture Overview](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/architecture-overview.html)
+- [Service Workbench Plan Your Deployment](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/plan-your-deployment.html)
+- [Service Workbench Deploy The Solution](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/deploy-the-solution.html)
+- [Service Workbench Update The Solution](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/update-the-solution.html)
+- [Service Workbench Uninstall The Solution](https://docs.aws.amazon.com/solutions/latest/service-workbench-on-aws/uninstall-the-solution.html)
+
 ### Documentation PDFs
 
 You can view the online documentation if you do not have Service Workbench locally installed on your machine. Click the following links to access the documentation:

--- a/docs/docs/installation_guide/installation/cloud9install.md
+++ b/docs/docs/installation_guide/installation/cloud9install.md
@@ -26,6 +26,8 @@ You can install Service Workbench by using AWS Cloud9. This section provides inf
 4. Choose **Next step**.
 5. For **Instance type**, choose **m5.large (8 GiB + 2 vCPU)**.
 6. For **Platform**, choose **Amazon Linux 2**.
+7. For **Network settings**, choose the VPC and a Public Subnet to deploy Cloud9. **Note** if you plan to use a private subnet you will not
+be able to use [AWS Managed Temporary Credentials](https://docs.aws.amazon.com/cloud9/latest/user-guide/security-iam.html#auth-and-access-control-temporary-managed-credentials) at this time and can impact installation. 
 7. Choose **Next step**.
 8. Review all the changes and choose **Create environment**.
 


### PR DESCRIPTION

Issue #, if available: 1135

Description of changes:
Minor documentation updates to reconcile differences between AWS website and Repository. Additionally included step for the Cloud9 installation instructions to specify a public subnet for VPC installation. If you do not you cannot use AWS Managed Temporary Credentials and will break the install of Cloud9 without a very verbose error message.

Checklist:
Documentation updates. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.