### PR TITLE
fix: upgrade goland in buildspec

### DIFF
--- a/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
+++ b/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
@@ -5,7 +5,7 @@ phases:
     # See supported runtimes at https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
     runtime-versions:
       nodejs: 12
-      golang: 1.13
+      golang: 1.18
 
   pre_build:
     commands:


### PR DESCRIPTION
Issue #, if available: GALI-2438

Description of changes: upgrade buildspec for CodeBuild as part of `int` pipeline to unblock GH actions pipeline

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.