### PR TITLE
fix: upgrade code build image for target env deploy project

### DIFF
--- a/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
+++ b/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
@@ -5,7 +5,7 @@ phases:
     # See supported runtimes at https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
     runtime-versions:
       nodejs: 12
-      golang: 1.13
+      golang: 1.18
 
   pre_build:
     commands:

--- a/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
+++ b/main/cicd/cicd-pipeline/config/buildspec/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     # See supported runtimes at https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
     runtime-versions:
-      nodejs: 12
+      nodejs: 16
       golang: 1.18
 
   pre_build:

--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -9,12 +9,10 @@ Conditions:
   UseCodeCommit: !Not
     - !Equals ['${self:custom.settings.sourceAccountId}', '']
   CreateStagingEnv: !Equals ['${self:custom.settings.createStagingEnv}', true]
-  RunTestsAgainstTargetEnv:
-    !Equals ['${self:custom.settings.runTestsAgainstTargetEnv}', true]
+  RunTestsAgainstTargetEnv: !Equals ['${self:custom.settings.runTestsAgainstTargetEnv}', true]
   DeleteTargetEnv: !Equals ['${self:custom.settings.deleteAfterInstall}', true]
   PreventCollision: !Equals ['${self:custom.settings.preventCollision}', true]
-  AddManualApproval:
-    !Equals ['${self:custom.settings.requireManualApproval}', true]
+  AddManualApproval: !Equals ['${self:custom.settings.requireManualApproval}', true]
   SubscribeNotificationEmail: !Not
     - !Equals ['${self:custom.settings.emailForNotifications}', '']
 
@@ -844,7 +842,7 @@ Resources:
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: DEPLOYMENT_BUCKET
             Value: ${self:provider.deploymentBucket.name}
@@ -1047,8 +1045,5 @@ Outputs:
   AppArtifactBucketArn: { Value: !GetAtt AppArtifactBucket.Arn }
   ArtifactBucketKeyArn: { Value: !GetAtt ArtifactBucketKey.Arn }
   AppPipelineName: { Value: !Ref AppPipeline }
-  AppPipelineArn:
-    {
-      Value: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${AppPipeline}',
-    }
+  AppPipelineArn: { Value: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${AppPipeline}' }
   PipelineNotificationsTopic: { Value: !Ref PipelineNotificationsTopic }


### PR DESCRIPTION
Issue #, if available: GALI-2438

Description of changes: 
Upgrade CodeBuild image for TargetEnvDeployProject to aws/codebuild/amazonlinux2-x86_64-standard:4.0, which allows Golang 1.18. 

I had to upgrade NodeJS version 16 because 12 is not on the new image. This should be fine since we did [earlier work](https://github.com/awslabs/service-workbench-on-aws/pull/1047) to ensure 16 works as runtime version to deploy SWB.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.