### PR TITLE
Mount s3 bucket without option --region

### DIFF
--- a/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
+++ b/main/solution/post-deployment/config/environment-files/bin/mount_s3.sh
@@ -77,6 +77,7 @@ do
         if [ "$s3_role_arn" == "null" ]
         then
             printf 'Mounting internal study "%s" at "%s"\n' "$study_id" "$study_dir"
+            goofys --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir" || \
             goofys --region $region --acl "bucket-owner-full-control" "${s3_bucket}:${s3_prefix}" "$study_dir"
         else
             bucket_region="$(printf "%s" "$mounts" | jq -r ".[$study_idx].region" -)"
@@ -93,11 +94,15 @@ do
             then
                 printf 'Mounting external study "%s" at "%s" using role "%s" and region "%s" \n' "$study_id" "$study_dir" \
                 "$s3_role_arn" "$bucket_region"
+                goofys --profile $study_id --acl "bucket-owner-full-control" \
+                "${s3_bucket}:${s3_prefix}" "$study_dir" || \
                 goofys --region $bucket_region --profile $study_id --acl "bucket-owner-full-control" \
                 "${s3_bucket}:${s3_prefix}" "$study_dir"
             else
                 printf 'Mounting external study "%s" at "%s" using role "%s", kms arn "%s" and region "%s" \n' "$study_id" "$study_dir" \
                 "$s3_role_arn" "$kms_arn" "$bucket_region"
+                goofys --profile $study_id --sse-kms $kms_arn --acl "bucket-owner-full-control" \
+                "${s3_bucket}:${s3_prefix}" "$study_dir" || \
                 goofys --region $bucket_region --profile $study_id --sse-kms $kms_arn --acl "bucket-owner-full-control" \
                 "${s3_bucket}:${s3_prefix}" "$study_dir"
             fi


### PR DESCRIPTION
#1004

Description of changes:

Since `goofys` will fail to mount s3 bucket if the wrong `--region` is specified, and will usually be able to detect `--region` automatically, this patch calls `goofys` without option `--region` and calls `goofys` again with option `--region` if it fails.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you successfully deployed to an AWS account with your changes?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully tested with your changes locally?
- [ ] If new dependencies have been added, have they been pinned to specific versions?
- [ ] Is this change also required on the AWS Solution version?
- [ ] Have you updated openapi.yaml if you made updates to API definition (including add, delete or update parameter and request data schema)?
- [ ] If you had to run manual tests, have you considered automating those tests by adding them to [end-to-end tests](../main/end-to-end-tests/README.md)?
- [ ] If you are updating the changelog and vending out a new release, have you updated versionNumber and versionDate in [.defaults.yml](../main/config/settings/.defaults.yml)

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.