### PR TITLE
[feat] Use S3VPCE to prevent S3 access outside of VPC

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -1228,7 +1228,9 @@ Outputs:
     Condition: isAppStreamAndCustomDomain
     Value: !Ref Route53HostedZone
 
-  S3VpcEndpoint:
+  S3VPCE:
     Description: S3 interface endpoint
     Condition: isAppStream
     Value: !Ref S3Endpoint
+    Export:
+      Name: !Join [ '', [ Ref: Namespace, '-S3VPCE' ] ]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -122,6 +122,14 @@ Resources:
               - sagemaker:DescribeNotebookInstance
               - sagemaker:StopNotebookInstance
             Resource: '*'
+          - Effect: Deny
+            Action: 's3:*'
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce:
+                  Fn::ImportValue: !Sub '${SolutionNamespace}-S3VPCE'
+
 
   IAMRoleSageMakerURL:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Added `aws:SourceVpce` check onto SageMaker cloud formation template's permission boundary.
