### PR TITLE
fix: add OwnershipControls for LoggingBucket

### DIFF
--- a/main/solution/infrastructure/config/infra/cloudformation.yml
+++ b/main/solution/infrastructure/config/infra/cloudformation.yml
@@ -86,6 +86,9 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
 
   LoggingBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
Issue #, if available: V892857827/GALI-2234

Description of changes:
Upgrades `ObjectOwnership` on the logging bucket to explicitly be set to `ObjectWriter` so canned ACL `LogDeliveryWrite` can be used by other S3 buckets within the solution. This allows existing and new installations of SWB to be deployed to.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.