### PR TITLE
[chore] Add conditionals for TRE permission boundaries

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -79,17 +79,21 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
-          - Effect: Deny
-            Action: '*'
-            Resource: '*'
-            Condition:
-              StringNotEquals:
-                aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
-                aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
-              BoolIfExists:
-                aws:ViaAWSService: "false"
-              'Null':
-                aws:ec2InstanceSourceVPC: "false"
+          - !If
+            - AppStreamEnabled
+            - Effect: Deny
+              Action: '*'
+              Resource: '*'
+              Condition:
+                StringNotEquals:
+                  aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
+                  aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
+                BoolIfExists:
+                  aws:ViaAWSService: "false"
+                'Null':
+                  aws:ec2InstanceSourceVPC: "false"
+            - !Ref 'AWS::NoValue'
+
 
   IAMRole:
     Type: 'AWS::IAM::Role'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -101,17 +101,20 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
-          - Effect: Deny
-            Action: '*'
-            Resource: '*'
-            Condition:
-              StringNotEquals:
-                aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
-                aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
-              BoolIfExists:
-                aws:ViaAWSService: "false"
-              'Null':
-                aws:ec2InstanceSourceVPC: "false"
+          - !If
+            - AppStreamEnabled
+            - Effect: Deny
+              Action: '*'
+              Resource: '*'
+              Condition:
+                StringNotEquals:
+                  aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
+                  aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
+                BoolIfExists:
+                  aws:ViaAWSService: "false"
+                'Null':
+                  aws:ec2InstanceSourceVPC: "false"
+            - !Ref 'AWS::NoValue'
   IAMRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -122,13 +122,16 @@ Resources:
               - sagemaker:DescribeNotebookInstance
               - sagemaker:StopNotebookInstance
             Resource: '*'
-          - Effect: Deny
-            Action: 's3:*'
-            Resource: '*'
-            Condition:
-              StringNotEquals:
-                aws:SourceVpce:
-                  Fn::ImportValue: !Sub '${SolutionNamespace}-S3VPCE'
+          - !If
+            - AppStreamEnabled
+            - Effect: Deny
+              Action: 's3:*'
+              Resource: '*'
+              Condition:
+                StringNotEquals:
+                  aws:SourceVpce:
+                    Fn::ImportValue: !Sub '${SolutionNamespace}-S3VPCE'
+            - !Ref 'AWS::NoValue'
 
 
   IAMRoleSageMakerURL:

--- a/main/end-to-end-tests/cypress.github.appstream-egress.json
+++ b/main/end-to-end-tests/cypress.github.appstream-egress.json
@@ -9,19 +9,19 @@
     "cognitoClientId": "3do9bsosfmol7r7hdnutbn5tup",
     "workspaces": {
       "sagemaker": {
-        "workspaceTypeName": "SageMaker Notebook-v6",
-        "configuration": "AppStream-SageMaker",
+        "workspaceTypeName": "SageMaker Notebook-v11",
+        "configuration": "SageMaker-v11",
         "projectId": "TRE-Project"
       },
       "ec2": {
         "linux": {
-          "workspaceTypeName": "EC2 Linux-v4",
-          "configuration": "AppStream-Linux",
+          "workspaceTypeName": "EC2 Linux-v9",
+          "configuration": "Linux-v9",
           "projectId": "TRE-Project"
         },
         "windows": {
-          "workspaceTypeName": "EC2 Windows-v4",
-          "configuration": "AppStream-Windows",
+          "workspaceTypeName": "EC2 Windows-v9",
+          "configuration": "Windows-v9",
           "projectId": "TRE-Project"
         }
       },

--- a/main/end-to-end-tests/cypress.github.json
+++ b/main/end-to-end-tests/cypress.github.json
@@ -9,19 +9,19 @@
     "cognitoClientId": "6dmj4qhbihtkigcbsjo346hjmi",
     "workspaces": {
       "sagemaker": {
-        "workspaceTypeName": "SageMaker Notebook-v9",
-        "configuration": "e2etest-config-with-autostop",
+        "workspaceTypeName": "SageMaker Notebook-v12",
+        "configuration": "SageMaker",
         "projectId": "e2eTestProject"
       },
       "ec2": {
         "windows": {
-          "workspaceTypeName": "EC2 Windows-v4",
-          "configuration": "ec2-windows-e2e",
+          "workspaceTypeName": "EC2 Windows-v9",
+          "configuration": "Windows",
           "projectId": "e2eTestProject"
         },
         "linux": {
-          "workspaceTypeName": "EC2 Linux-v3",
-          "configuration": "ec2-linux-e2e",
+          "workspaceTypeName": "EC2 Linux-v8",
+          "configuration": "Linux-v8",
           "projectId": "e2eTestProject"
         }
       },


### PR DESCRIPTION
Added check to cloudformation templates to only include boundary permission updates if AppStream is enabled.

Testing (in Linux, Windows, and SageMaker):
* Verified that credentials being used OUTSIDE of the AppStream environment could not access S3 data.
* Verified that credentials being used INSIDE of the AppStream environment could access studies.
