### PR TITLE
Add an S3 Endpoint for Non-TRE deployments

### DIFF
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -882,6 +882,41 @@ Resources:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
       VpcId: !Ref VPC
 
+  S3NonAppStreamEndpoint:
+    Type: 'AWS::EC2::VPCEndpoint'
+    Condition: isNotAppStream
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action:
+              - 's3:GetObject'
+              - 's3:GetObjectTagging'
+              - 's3:GetObjectTorrent'
+              - 's3:GetObjectVersion'
+              - 's3:GetObjectVersionTagging'
+              - 's3:GetObjectVersionTorrent'
+              - 's3:AbortMultipartUpload'
+              - 's3:ListMultipartUploadParts'
+              - 's3:PutObject'
+              - 's3:PutObjectAcl'
+              - 's3:PutObjectTagging'
+              - 's3:PutObjectVersionTagging'
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectTagging'
+              - 's3:DeleteObjectVersion'
+              - 's3:DeleteObjectVersionTagging'
+              - 's3:ListBucket' # Required in get_bootstrap.sh when running `aws s3 sync`
+            Resource:
+              - '*'
+      RouteTableIds:
+        - !Ref PublicRouteTable
+      VpcEndpointType: Gateway
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
+      VpcId: !Ref VPC
+
   KMSEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
@@ -1157,6 +1192,13 @@ Outputs:
     Description: The public route table assigned to the workspace VPC
     Value: !Ref PublicRouteTable
 
+  S3NonAppStreamVPCE:
+    Description: S3 interface endpoint
+    Condition: isNotAppStream
+    Value: !Ref S3NonAppStreamEndpoint
+    Export:
+      Name: !Join [ '', [ Ref: Namespace, '-S3NonAppStreamVPCE' ] ]
+
   #------------AppStream Output Below-------
   PrivateAppStreamSubnet:
     Description: AppStream subnet
@@ -1228,9 +1270,9 @@ Outputs:
     Condition: isAppStreamAndCustomDomain
     Value: !Ref Route53HostedZone
 
-  S3VPCE:
+  S3AppStreamVPCE:
     Description: S3 interface endpoint
     Condition: isAppStream
     Value: !Ref S3Endpoint
     Export:
-      Name: !Join [ '', [ Ref: Namespace, '-S3VPCE' ] ]
+      Name: !Join [ '', [ Ref: Namespace, '-S3AppStreamVPCE' ] ]

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-linux-instance.cfn.yml
@@ -79,20 +79,16 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
-          - !If
-            - AppStreamEnabled
-            - Effect: Deny
-              Action: '*'
-              Resource: '*'
-              Condition:
-                StringNotEquals:
-                  aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
-                  aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
-                BoolIfExists:
-                  aws:ViaAWSService: "false"
-                'Null':
-                  aws:ec2InstanceSourceVPC: "false"
-            - !Ref 'AWS::NoValue'
+          - Effect: Deny
+            Action: 's3:*'
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce:
+                  - !If
+                    - AppStreamEnabled
+                    - Fn::ImportValue: !Sub "${SolutionNamespace}-S3AppStreamVPCE"
+                    - Fn::ImportValue: !Sub "${SolutionNamespace}-S3NonAppStreamVPCE"
 
 
   IAMRole:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/ec2-windows-instance.cfn.yml
@@ -101,20 +101,16 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
-          - !If
-            - AppStreamEnabled
-            - Effect: Deny
-              Action: '*'
-              Resource: '*'
-              Condition:
-                StringNotEquals:
-                  aws:Ec2InstanceSourceVPC: "${aws:SourceVpc}"
-                  aws:ec2InstanceSourcePrivateIPv4: "${aws:VpcSourceIp}"
-                BoolIfExists:
-                  aws:ViaAWSService: "false"
-                'Null':
-                  aws:ec2InstanceSourceVPC: "false"
-            - !Ref 'AWS::NoValue'
+          - Effect: Deny
+            Action: 's3:*'
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce:
+                  - !If
+                    - AppStreamEnabled
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3AppStreamVPCE'
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
   IAMRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -181,6 +181,16 @@ Resources:
             Action:
               - 'sts:AssumeRole'
             Resource: 'arn:aws:iam::*:role/swb-*'
+          - Effect: Deny
+            Action: 's3:*'
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce:
+                  - !If
+                    - AppStreamEnabled
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3AppStreamVPCE'
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
 
   Ec2Role:
     Type: 'AWS::IAM::Role'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/emr-cluster.cfn.yml
@@ -187,10 +187,7 @@ Resources:
             Condition:
               StringNotEquals:
                 aws:SourceVpce:
-                  - !If
-                    - AppStreamEnabled
-                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3AppStreamVPCE'
-                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
+                  - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
 
   Ec2Role:
     Type: 'AWS::IAM::Role'

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -122,6 +122,11 @@ Resources:
               - sagemaker:DescribeNotebookInstance
               - sagemaker:StopNotebookInstance
             Resource: '*'
+          - Effect: 'Allow'
+            Action:
+              - 'ec2:DescribePrefixLists'
+              - 'ec2:DescribeManagedPrefixLists'
+            Resource: '*'
           - Effect: Deny
             Action: 's3:*'
             Resource: '*'
@@ -132,8 +137,6 @@ Resources:
                     - AppStreamEnabled
                     - Fn::ImportValue: !Sub '${SolutionNamespace}-S3AppStreamVPCE'
                     - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
-
-
 
   IAMRoleSageMakerURL:
     Type: 'AWS::IAM::Role'
@@ -210,6 +213,11 @@ Resources:
                     s3:prefix: !Sub
                       - '${S3Prefix}/*'
                       - S3Prefix: !Select [3, !Split ['/', !Ref EnvironmentInstanceFiles]]
+              - Effect: 'Allow'
+                Action:
+                  - 'ec2:DescribePrefixLists'
+                  - 'ec2:DescribeManagedPrefixLists'
+                Resource: '*'
         - PolicyName: cw-logs
           PolicyDocument:
             Statement:
@@ -269,6 +277,21 @@ Resources:
         - Content:
             Fn::Base64: !Sub |
               #!/usr/bin/env bash
+              set -e
+              TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+              REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+              PREFIX_LIST_ID=$(aws --region $REGION ec2 describe-managed-prefix-lists --filters Name=owner-id,Values=AWS Name=prefix-list-name,Values=com.amazonaws.$REGION.s3 --query PrefixLists[0].PrefixListId --output text)
+              PREFIXES=$(aws --region $REGION ec2 describe-prefix-lists --prefix-list-id $PREFIX_LIST_ID --query PrefixLists[0].Cidrs --output text)
+            
+              IFACE=$(ip link show eth2 | grep ether | awk '{ print $2 }')
+              VPC_CIDR=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/network/interfaces/macs/$IFACE/vpc-ipv4-cidr-block)
+              GATEWAY=$(ip route show | grep $VPC_CIDR | awk '{ print $3 }')
+            
+              set -x
+              for PREFIX in $PREFIXES; do
+                sudo ip route add $PREFIX via $GATEWAY dev eth2
+              done
+              
               # Download and execute bootstrap script
               aws s3 cp "${EnvironmentInstanceFiles}/get_bootstrap.sh" "/tmp"
               chmod 500 "/tmp/get_bootstrap.sh"

--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/service-catalog/sagemaker-notebook-instance.cfn.yml
@@ -122,16 +122,17 @@ Resources:
               - sagemaker:DescribeNotebookInstance
               - sagemaker:StopNotebookInstance
             Resource: '*'
-          - !If
-            - AppStreamEnabled
-            - Effect: Deny
-              Action: 's3:*'
-              Resource: '*'
-              Condition:
-                StringNotEquals:
-                  aws:SourceVpce:
-                    Fn::ImportValue: !Sub '${SolutionNamespace}-S3VPCE'
-            - !Ref 'AWS::NoValue'
+          - Effect: Deny
+            Action: 's3:*'
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce:
+                  - !If
+                    - AppStreamEnabled
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3AppStreamVPCE'
+                    - Fn::ImportValue: !Sub '${SolutionNamespace}-S3NonAppStreamVPCE'
+
 
 
   IAMRoleSageMakerURL:

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-config-vars-service.js
@@ -296,8 +296,7 @@ class EnvironmentConfigVarsService extends Service {
       iamPolicyDocument: JSON.stringify(iamPolicyDocument),
       environmentInstanceFiles: this.settings.get(settingKeys.environmentInstanceFiles),
       isAppStreamEnabled,
-      solutionNamespace:
-        isAppStreamEnabled === 'true' ? await this.getSolutionNamespace(requestContext, awsAccountId) : '',
+      solutionNamespace: await this.getSolutionNamespace(requestContext, awsAccountId),
       // s3Prefixes // This variable is no longer relevant it is being removed, the assumption is that
       // this variable has not been used in any of the product templates.
       uid: user.uid,

--- a/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-config-service.js
+++ b/addons/addon-environment-sc-api/packages/environment-type-mgmt-services/lib/environment-type/env-type-config-service.js
@@ -264,7 +264,7 @@ class EnvTypeConfigService extends Service {
       params = [
         ...params,
         { key: 'EgressStoreIamPolicyDocument', value: '{}' },
-        { key: 'SolutionNamespace', value: '' },
+        { key: 'SolutionNamespace', value: '${solutionNamespace}' },
       ];
     }
     updatedConfig.params = params;


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Adding an S3 VPC Endpoint to Non-TRE deployments that will be explicitly used by the resources spun up in the environments that get created in the Hosting account. 
* Reroute all S3 calls through the custom VPC we attach to SageMaker to ensure it points to the new S3 VPC Endpoint

Testing:
* Verified that environment credentials from TRE (AppStream Linux, AppStream Windows, AppStream SageMaker) and Non-TRE (Linux, Windows, SageMaker, EMR) environments could not access S3 data outside of their VPC.