### PR TITLE
test: extend emr e2e test timeout to 20 min

### DIFF
--- a/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
@@ -18,7 +18,7 @@ import {
   navigateToWorkspaces,
   checkDetailsTable,
   checkWorkspaceAvailable,
-  checkWorkspaceAutoStop,
+  checkWorkspaceAutoStop
 } from '../../support/workspace-util';
 
 describe('Launch a workspace', () => {

--- a/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
+++ b/main/end-to-end-tests/cypress/integration/appstream-egress-disabled/workspaces.spec.js
@@ -12,14 +12,13 @@
  *  express or implied. See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-import _ from 'lodash';
 import {
   terminateWorkspaces,
   launchWorkspace,
   navigateToWorkspaces,
   checkDetailsTable,
   checkWorkspaceAvailable,
-  checkWorkspaceAutoStop
+  checkWorkspaceAutoStop,
 } from '../../support/workspace-util';
 
 describe('Launch a workspace', () => {
@@ -74,6 +73,6 @@ describe('Launch a workspace', () => {
     const emr = workspaces.emr;
     const workspaceName = launchWorkspace(emr, 'EMR');
     checkDetailsTable(workspaceName);
-    checkWorkspaceAvailable(workspaceName);
+    checkWorkspaceAvailable(workspaceName, 2000000);
   });
 });

--- a/main/end-to-end-tests/cypress/support/workspace-util.js
+++ b/main/end-to-end-tests/cypress/support/workspace-util.js
@@ -119,10 +119,10 @@ function checkWorkspaceAvailableAndClickConnectionsButton(workspaceName) {
     .click();
 }
 
-function checkWorkspaceAvailable(workspaceName) {
+function checkWorkspaceAvailable(workspaceName, timeout = 1000000) {
   cy.contains(workspaceName)
     .parent()
-    .contains('AVAILABLE', { timeout: 1000000 });
+    .contains('AVAILABLE', { timeout });
 }
 
 function checkWorkspaceAutoStop(workspaceName) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Extend the EMR E2E test timeout to 20 minutes to account for longer range of spin up time

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.