### PR TITLE
feat: add IMDSv2 support on AMI creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ docs/build
 
 # rStudio specific
 source/ServiceWorkbenchOnAWS/main/solution/machine-images/config/infra/files/rstudio/*
+
+# temp packer log files
+main/solution/machine-images/*_build.log

--- a/addons/addon-base-raas/packages/serverless-packer/index.js
+++ b/addons/addon-base-raas/packages/serverless-packer/index.js
@@ -123,7 +123,7 @@ class ServerlessPackerPlugin {
 
     // For each AMI, add IMDSv2 support
     return Promise.all(
-      _.forEach(amis, async ami => {
+      amis.map(async ami => {
         this.serverless.cli.log(`${ami}: Adding IMDSv2 support`);
         const args = _.concat(
           'ec2',

--- a/addons/addon-base-raas/packages/serverless-packer/lib/utils/command.js
+++ b/addons/addon-base-raas/packages/serverless-packer/lib/utils/command.js
@@ -21,8 +21,11 @@ const chalk = require('chalk');
 const spawn = require('cross-spawn');
 
 const runCommand = ({ command, args, successCodes = [0], cwd, stdout }) => {
-  const child = spawn(command, args, { stdio: 'pipe', cwd });
+  const options = { stdio: 'pipe', cwd };
+  if (stdout.fileStream) options.stdout = stdout.fileStream;
+  const child = spawn(command, args, options);
   stdout.log(`${chalk.bgGreen('>>')} ${command} ${args.join(' ')}`);
+  if (stdout.fileStream) child.stdout.pipe(stdout.fileStream);
   return new Promise((resolve, reject) => {
     // we are using _.once() because the error and exit events might be fired one after the other
     // see https://nodejs.org/api/child_process.html#child_process_event_error


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This adds IMDSv2 support to the AMIs created by running `pnpx sls build-image -s <STAGE>`. To apply these changes to your environment, rerun this command update the AMI IDs in the Workspace Type Configs with the newly created AMIs.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- For major releases please provide internal ticket id -->

AS review ticket id:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.