### PR TITLE
@babel/plugin-proposal-class-properties loose should be false

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/.babelrc
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/.babelrc
@@ -1,14 +1,8 @@
 {
   "plugins": [
-    [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ]
+    "@babel/plugin-proposal-class-properties"
   ],
   "presets": [
-    "@babel/preset-react",
-    "@babel/preset-env"
+    "@babel/preset-react", "@babel/preset-env"
   ]
 }

--- a/addons/addon-base-ui/packages/base-ui/.babelrc
+++ b/addons/addon-base-ui/packages/base-ui/.babelrc
@@ -1,14 +1,8 @@
 {
   "plugins": [
-    [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ]
+    "@babel/plugin-proposal-class-properties"
   ],
   "presets": [
-    "@babel/preset-react",
-    "@babel/preset-env"
+    "@babel/preset-react", "@babel/preset-env"
   ]
 }

--- a/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/.babelrc
+++ b/addons/addon-environment-sc-ui/packages/environment-type-mgmt-ui/.babelrc
@@ -1,11 +1,8 @@
 {
   "plugins": [
-    [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ]
+    "@babel/plugin-proposal-class-properties"
   ],
-  "presets": ["@babel/preset-react", "@babel/preset-env"]
+  "presets": [
+    "@babel/preset-react", "@babel/preset-env"
+  ]
 }


### PR DESCRIPTION
Issue #1237

Description of changes:
This change removes the loose="true" setting on @babel/plugin-proposal-class-properties which was not being applied anyway and caused thousands of warning lines in the logs

Checklist:

- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?
- [x] Is this change also required on the AWS Solution version?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.